### PR TITLE
Add JDK to CI test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,4 +21,10 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Set up JDK 22
+        uses: actions/setup-java@v2
+        with:
+          java-version: '22'
+          distribution: 'adopt'
+
       - run: make test


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/test.yml` file. The change adds a new job for setting up JDK 22 using the `actions/setup-java@v2` action, with the Java version set to '22' and the distribution set to 'adopt'. This job is added before the `make test` command is run.This commit updates the test workflow to include setting up JDK 22 using the `actions/setup-java@v2` action. The Java version is set to 22 and the distribution is set to 'adopt'. This change ensures that the correct Java version is used during the testing process.