### PR TITLE
Update Go version to 1.22.x in publish.yml workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.17.x
+          go-version: 1.22.x
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v1


### PR DESCRIPTION
This pull request updates the Go version in the publish.yml workflow from 1.17.x to 1.22.x. This ensures that the latest version of Go is used for the workflow.