### PR TITLE
Add test for unterminated string

### DIFF
--- a/internal/stage12.go
+++ b/internal/stage12.go
@@ -14,7 +14,7 @@ func testStrings(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	logger := stageHarness.Logger
 
-	string1 := randomSelection(2, Strings, " ")
+	string1 := randomSelection(1, Strings, "") + " " + "\"unterminated"
 	string2 := `"foo 	bar 123 // hello world!"`
 	shuffledString2 := (randomSelection(2, Strings, "+")) + `"perseverance" && "Success" != "Failure"`
 

--- a/internal/test_helpers/fixtures/pass_all
+++ b/internal/test_helpers/fixtures/pass_all
@@ -280,13 +280,14 @@ Debug = true
 [33m[stage-12] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-12] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-12] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-12] [test-2] [0m[94m[test.lox] "hello" "foo"[0m
+[33m[stage-12] [test-2] [0m[94m[test.lox] "hello" "unterminated[0m
 [33m[stage-12] [test-2] [0m[94m$ ./your_program.sh tokenize test.lox[0m
+[33m[your_program] [0m[line 1] Error: Unterminated string.
 [33m[your_program] [0mSTRING "hello" hello
-[33m[your_program] [0mSTRING "foo" foo
 [33m[your_program] [0mEOF  null
-[33m[stage-12] [test-2] [0m[92m✓ 3 line(s) match on stdout[0m
-[33m[stage-12] [test-2] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-12] [test-2] [0m[92m✓ 1 line(s) match on stderr[0m
+[33m[stage-12] [test-2] [0m[92m✓ 2 line(s) match on stdout[0m
+[33m[stage-12] [test-2] [0m[92m✓ Received exit code 65.[0m
 [33m[stage-12] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-12] [test-3] [0m[94mWriting contents to ./test.lox:[0m
 [33m[stage-12] [test-3] [0m[94m[test.lox] "foo <|TAB|>bar 123 // hello world!"[0m
@@ -297,13 +298,13 @@ Debug = true
 [33m[stage-12] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-12] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-12] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-12] [test-4] [0m[94m[test.lox] "world"+"baz""perseverance" && "Success" != "Failure"[0m
+[33m[stage-12] [test-4] [0m[94m[test.lox] "foo"+"world""perseverance" && "Success" != "Failure"[0m
 [33m[stage-12] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0m[line 1] Error: Unexpected character: &
 [33m[your_program] [0m[line 1] Error: Unexpected character: &
-[33m[your_program] [0mSTRING "world" world
+[33m[your_program] [0mSTRING "foo" foo
 [33m[your_program] [0mPLUS + null
-[33m[your_program] [0mSTRING "baz" baz
+[33m[your_program] [0mSTRING "world" world
 [33m[your_program] [0mSTRING "perseverance" perseverance
 [33m[your_program] [0mSTRING "Success" Success
 [33m[your_program] [0mBANG_EQUAL != null
@@ -328,7 +329,7 @@ Debug = true
 [33m[stage-11] [test-1] [0m[92m✓ Received exit code 65.[0m
 [33m[stage-11] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-11] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-11] [test-2] [0m[94m[test.lox]  %<|TAB|>[0m
+[33m[stage-11] [test-2] [0m[94m[test.lox]   %[0m
 [33m[stage-11] [test-2] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0m[line 1] Error: Unexpected character: %
 [33m[your_program] [0mEOF  null
@@ -365,12 +366,13 @@ Debug = true
 [33m[stage-11] [test-3] [0m[92m✓ Received exit code 65.[0m
 [33m[stage-11] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-11] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-11] [test-4] [0m[94m[test.lox] ({;<|TAB|>%})[0m
+[33m[stage-11] [test-4] [0m[94m[test.lox] ({+[0m
+[33m[stage-11] [test-4] [0m[94m[test.lox] #})[0m
 [33m[stage-11] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0m[line 1] Error: Unexpected character: %
+[33m[your_program] [0m[line 2] Error: Unexpected character: #
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mLEFT_BRACE { null
-[33m[your_program] [0mSEMICOLON ; null
+[33m[your_program] [0mPLUS + null
 [33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mEOF  null
@@ -400,7 +402,8 @@ Debug = true
 [33m[stage-10] [test-3] [0m[94m[test.lox] {[0m
 [33m[stage-10] [test-3] [0m[94m[test.lox] [0m
 [33m[stage-10] [test-3] [0m[94m[test.lox] }[0m
-[33m[stage-10] [test-3] [0m[94m[test.lox] ((- *<|TAB|>*))[0m
+[33m[stage-10] [test-3] [0m[94m[test.lox] (([0m
+[33m[stage-10] [test-3] [0m[94m[test.lox] - *<|TAB|>))[0m
 [33m[stage-10] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0mLEFT_BRACE { null
 [33m[your_program] [0mRIGHT_BRACE } null
@@ -408,26 +411,26 @@ Debug = true
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mMINUS - null
 [33m[your_program] [0mSTAR * null
-[33m[your_program] [0mSTAR * null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mEOF  null
-[33m[stage-10] [test-3] [0m[92m✓ 10 line(s) match on stdout[0m
+[33m[stage-10] [test-3] [0m[92m✓ 9 line(s) match on stdout[0m
 [33m[stage-10] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-10] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-10] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-10] [test-4] [0m[94m[test.lox] {<|SPACE|>[0m
-[33m[stage-10] [test-4] [0m[94m[test.lox] <|TAB|> }[0m
-[33m[stage-10] [test-4] [0m[94m[test.lox] ((; <=[0m
-[33m[stage-10] [test-4] [0m[94m[test.lox] >))[0m
+[33m[stage-10] [test-4] [0m[94m[test.lox] {[0m
+[33m[stage-10] [test-4] [0m[94m[test.lox] <|SPACE|>[0m
+[33m[stage-10] [test-4] [0m[94m[test.lox] <|TAB|>}[0m
+[33m[stage-10] [test-4] [0m[94m[test.lox] ((;; <=[0m
+[33m[stage-10] [test-4] [0m[94m[test.lox] ))[0m
 [33m[stage-10] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0mLEFT_BRACE { null
 [33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mSEMICOLON ; null
+[33m[your_program] [0mSEMICOLON ; null
 [33m[your_program] [0mLESS_EQUAL <= null
-[33m[your_program] [0mGREATER > null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mEOF  null
@@ -461,9 +464,9 @@ Debug = true
 [33m[stage-9] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-9] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-9] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-9] [test-4] [0m[94m[test.lox] ({(+;@)})//Comment[0m
+[33m[stage-9] [test-4] [0m[94m[test.lox] ({(%+;)})//Comment[0m
 [33m[stage-9] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0m[line 1] Error: Unexpected character: @
+[33m[your_program] [0m[line 1] Error: Unexpected character: %
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mLEFT_BRACE { null
 [33m[your_program] [0mLEFT_PAREN ( null
@@ -502,30 +505,31 @@ Debug = true
 [33m[stage-8] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-8] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-8] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-8] [test-3] [0m[94m[test.lox] <=>>=<<[0m
+[33m[stage-8] [test-3] [0m[94m[test.lox] <=<=>>=<[0m
 [33m[stage-8] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
+[33m[your_program] [0mLESS_EQUAL <= null
 [33m[your_program] [0mLESS_EQUAL <= null
 [33m[your_program] [0mGREATER > null
 [33m[your_program] [0mGREATER_EQUAL >= null
-[33m[your_program] [0mLESS < null
 [33m[your_program] [0mLESS < null
 [33m[your_program] [0mEOF  null
 [33m[stage-8] [test-3] [0m[92m✓ 6 line(s) match on stdout[0m
 [33m[stage-8] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-8] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-8] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-8] [test-4] [0m[94m[test.lox] (){=><=}[0m
+[33m[stage-8] [test-4] [0m[94m[test.lox] (){@=>}[0m
 [33m[stage-8] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
+[33m[your_program] [0m[line 1] Error: Unexpected character: @
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mLEFT_BRACE { null
 [33m[your_program] [0mEQUAL = null
 [33m[your_program] [0mGREATER > null
-[33m[your_program] [0mLESS_EQUAL <= null
 [33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mEOF  null
-[33m[stage-8] [test-4] [0m[92m✓ 8 line(s) match on stdout[0m
-[33m[stage-8] [test-4] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-8] [test-4] [0m[92m✓ 1 line(s) match on stderr[0m
+[33m[stage-8] [test-4] [0m[92m✓ 7 line(s) match on stdout[0m
+[33m[stage-8] [test-4] [0m[92m✓ Received exit code 65.[0m
 [33m[stage-8] [0m[92mTest passed.[0m
 
 [33m[stage-7] [0m[94mRunning tests for Stage #7: bu3[0m
@@ -565,20 +569,20 @@ Debug = true
 [33m[stage-7] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-7] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-7] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-7] [test-4] [0m[94m[test.lox] {(###==%)}[0m
+[33m[stage-7] [test-4] [0m[94m[test.lox] {(!###==)}[0m
 [33m[stage-7] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0m[line 1] Error: Unexpected character: #
 [33m[your_program] [0m[line 1] Error: Unexpected character: #
 [33m[your_program] [0m[line 1] Error: Unexpected character: #
-[33m[your_program] [0m[line 1] Error: Unexpected character: %
 [33m[your_program] [0mLEFT_BRACE { null
 [33m[your_program] [0mLEFT_PAREN ( null
+[33m[your_program] [0mBANG ! null
 [33m[your_program] [0mEQUAL_EQUAL == null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mEOF  null
-[33m[stage-7] [test-4] [0m[92m✓ 4 line(s) match on stderr[0m
-[33m[stage-7] [test-4] [0m[92m✓ 6 line(s) match on stdout[0m
+[33m[stage-7] [test-4] [0m[92m✓ 3 line(s) match on stderr[0m
+[33m[stage-7] [test-4] [0m[92m✓ 7 line(s) match on stdout[0m
 [33m[stage-7] [test-4] [0m[92m✓ Received exit code 65.[0m
 [33m[stage-7] [0m[92mTest passed.[0m
 
@@ -619,11 +623,11 @@ Debug = true
 [33m[stage-6] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-6] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-6] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-6] [test-4] [0m[94m[test.lox] ((#%==#))[0m
+[33m[stage-6] [test-4] [0m[94m[test.lox] ((%#%==))[0m
 [33m[stage-6] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0m[line 1] Error: Unexpected character: #
 [33m[your_program] [0m[line 1] Error: Unexpected character: %
 [33m[your_program] [0m[line 1] Error: Unexpected character: #
+[33m[your_program] [0m[line 1] Error: Unexpected character: %
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mEQUAL_EQUAL == null
@@ -660,28 +664,28 @@ Debug = true
 [33m[stage-5] [test-2] [0m[92m✓ Received exit code 65.[0m
 [33m[stage-5] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-5] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-5] [test-3] [0m[94m[test.lox] $@$%$[0m
+[33m[stage-5] [test-3] [0m[94m[test.lox] #$@$%[0m
 [33m[stage-5] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
+[33m[your_program] [0m[line 1] Error: Unexpected character: #
 [33m[your_program] [0m[line 1] Error: Unexpected character: $
 [33m[your_program] [0m[line 1] Error: Unexpected character: @
 [33m[your_program] [0m[line 1] Error: Unexpected character: $
 [33m[your_program] [0m[line 1] Error: Unexpected character: %
-[33m[your_program] [0m[line 1] Error: Unexpected character: $
 [33m[your_program] [0mEOF  null
 [33m[stage-5] [test-3] [0m[92m✓ 5 line(s) match on stderr[0m
 [33m[stage-5] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-5] [test-3] [0m[92m✓ Received exit code 65.[0m
 [33m[stage-5] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-5] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-5] [test-4] [0m[94m[test.lox] {(;-**+)}[0m
+[33m[stage-5] [test-4] [0m[94m[test.lox] {(-;-**)}[0m
 [33m[stage-5] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0mLEFT_BRACE { null
 [33m[your_program] [0mLEFT_PAREN ( null
+[33m[your_program] [0mMINUS - null
 [33m[your_program] [0mSEMICOLON ; null
 [33m[your_program] [0mMINUS - null
 [33m[your_program] [0mSTAR * null
 [33m[your_program] [0mSTAR * null
-[33m[your_program] [0mPLUS + null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mEOF  null
@@ -720,29 +724,29 @@ Debug = true
 [33m[stage-4] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-4] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-4] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-4] [test-3] [0m[94m[test.lox] +*---*-[0m
+[33m[stage-4] [test-3] [0m[94m[test.lox] *+*---*[0m
 [33m[stage-4] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
+[33m[your_program] [0mSTAR * null
 [33m[your_program] [0mPLUS + null
 [33m[your_program] [0mSTAR * null
 [33m[your_program] [0mMINUS - null
 [33m[your_program] [0mMINUS - null
 [33m[your_program] [0mMINUS - null
 [33m[your_program] [0mSTAR * null
-[33m[your_program] [0mMINUS - null
 [33m[your_program] [0mEOF  null
 [33m[stage-4] [test-3] [0m[92m✓ 8 line(s) match on stdout[0m
 [33m[stage-4] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-4] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-4] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-4] [test-4] [0m[94m[test.lox] ({-+.-,})[0m
+[33m[stage-4] [test-4] [0m[94m[test.lox] ({--+.-})[0m
 [33m[stage-4] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mLEFT_BRACE { null
 [33m[your_program] [0mMINUS - null
+[33m[your_program] [0mMINUS - null
 [33m[your_program] [0mPLUS + null
 [33m[your_program] [0mDOT . null
 [33m[your_program] [0mMINUS - null
-[33m[your_program] [0mCOMMA , null
 [33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mEOF  null
@@ -772,27 +776,27 @@ Debug = true
 [33m[stage-3] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-3] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-3] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-3] [test-3] [0m[94m[test.lox] {}{}{[0m
+[33m[stage-3] [test-3] [0m[94m[test.lox] {{}{}[0m
 [33m[stage-3] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0mLEFT_BRACE { null
-[33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mLEFT_BRACE { null
 [33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mLEFT_BRACE { null
+[33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mEOF  null
 [33m[stage-3] [test-3] [0m[92m✓ 6 line(s) match on stdout[0m
 [33m[stage-3] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-3] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-3] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-3] [test-4] [0m[94m[test.lox] {)){(){[0m
+[33m[stage-3] [test-4] [0m[94m[test.lox] {{)){()[0m
 [33m[stage-3] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
+[33m[your_program] [0mLEFT_BRACE { null
 [33m[your_program] [0mLEFT_BRACE { null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mLEFT_BRACE { null
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mLEFT_BRACE { null
 [33m[your_program] [0mEOF  null
 [33m[stage-3] [test-4] [0m[92m✓ 8 line(s) match on stdout[0m
 [33m[stage-3] [test-4] [0m[92m✓ Received exit code 0.[0m
@@ -818,23 +822,23 @@ Debug = true
 [33m[stage-2] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-2] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-2] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-2] [test-3] [0m[94m[test.lox] )(())[0m
+[33m[stage-2] [test-3] [0m[94m[test.lox] ()(()[0m
 [33m[stage-2] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
+[33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mEOF  null
 [33m[stage-2] [test-3] [0m[92m✓ 6 line(s) match on stdout[0m
 [33m[stage-2] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-2] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-2] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-2] [test-4] [0m[94m[test.lox] (()))))[0m
+[33m[stage-2] [test-4] [0m[94m[test.lox] )(())))[0m
 [33m[stage-2] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mRIGHT_PAREN ) null
+[33m[your_program] [0mLEFT_PAREN ( null
+[33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mRIGHT_PAREN ) null


### PR DESCRIPTION
This pull request includes a change in the `testStrings` function in the `internal/stage12.go` file. The change modifies how `string1` is generated by reducing the number of elements randomly selected from `Strings`, removing the space as the separator, and appending an unterminated string. This change seems to be testing the handling of unterminated strings in the code. 

* `internal/stage12.go` : Modified `string1` assignment in `testStrings` function to include an unterminated string for testing.