### PR TITLE
Extension: Evaluating Expressions tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ test_and_watch:
 
 copy_course_file:
 	hub api \
-		repos/codecrafters-io/build-your-own-interpreter/contents/course-definition.yml \
+		repos/codecrafters-io/build-your-own-interpreter/course-definition.yml \
 		| jq -r .content \
 		| base64 -d \
 		> internal/test_helpers/course_definition.yml
@@ -93,7 +93,16 @@ test_evaluation_w_jlox: build
 		{\"slug\":\"iz6\",\"tester_log_prefix\":\"stage_301\",\"title\":\"Stage #301: Evaluation: Literals: Booleans & Nil\"}, \
 		{\"slug\":\"lv1\",\"tester_log_prefix\":\"stage_302\",\"title\":\"Stage #302: Evaluation: Literals: Strings & Numbers\"}, \
 		{\"slug\":\"oq9\",\"tester_log_prefix\":\"stage_303\",\"title\":\"Stage #303: Evaluation: Parentheses\"}, \
-		{\"slug\":\"dc1\",\"tester_log_prefix\":\"stage_304\",\"title\":\"Stage #304: Evaluation: Unary operators\"} \
+		{\"slug\":\"dc1\",\"tester_log_prefix\":\"stage_304\",\"title\":\"Stage #304: Evaluation: Unary operators\"}, \
+		{\"slug\":\"bp3\",\"tester_log_prefix\":\"stage_305\",\"title\":\"Stage #305: Evaluation: Multiplicative operators\"}, \
+		{\"slug\":\"jy2\",\"tester_log_prefix\":\"stage_306\",\"title\":\"Stage #306: Evaluation: Additive operators\"}, \
+		{\"slug\":\"jx8\",\"tester_log_prefix\":\"stage_307\",\"title\":\"Stage #307: Evaluation: Concatenation operator\"}, \
+		{\"slug\":\"et4\",\"tester_log_prefix\":\"stage_308\",\"title\":\"Stage #308: Evaluation: Relational operators\"}, \
+		{\"slug\":\"hw7\",\"tester_log_prefix\":\"stage_309\",\"title\":\"Stage #309: Evaluation: Equality operators\"}, \
+		{\"slug\":\"gj9\",\"tester_log_prefix\":\"stage_310\",\"title\":\"Stage #310: Evaluation: Runtime errors: Unary\"}, \
+		{\"slug\":\"yu6\",\"tester_log_prefix\":\"stage_311\",\"title\":\"Stage #311: Evaluation: Runtime errors: Multiplication\"}, \
+		{\"slug\":\"cq1\",\"tester_log_prefix\":\"stage_312\",\"title\":\"Stage #312: Evaluation: Runtime errors: Addition\"}, \
+		{\"slug\":\"ib5\",\"tester_log_prefix\":\"stage_313\",\"title\":\"Stage #313: Evaluation: Runtime errors: Comparisons\"} \
 	]" \
 	$(shell pwd)/dist/main.out
 

--- a/internal/lox/parse_error.go
+++ b/internal/lox/parse_error.go
@@ -20,7 +20,7 @@ func LogParseError(err error) {
 	HadParseError = true
 }
 
-// MakeParseError renders an parsing error as a string
+// MakeParseError renders a parsing error as a string
 func MakeParseError(tok Token, message string) error {
 	if tok.Type == EOF {
 		return fmt.Errorf("[line %v] Error at end: %s", tok.Line, message)

--- a/internal/lox/runtimeerror.go
+++ b/internal/lox/runtimeerror.go
@@ -5,7 +5,7 @@ import (
 	"os"
 )
 
-// Print reports a runtime error
+// PrintRuntimeError reports a runtime error
 func PrintRuntimeError(message string) {
 	fmt.Fprintf(os.Stderr, "%v\n", message)
 	HadRuntimeError = true

--- a/internal/stage_e10.go
+++ b/internal/stage_e10.go
@@ -1,0 +1,26 @@
+package internal
+
+import (
+	"fmt"
+
+	"github.com/codecrafters-io/interpreter-tester/internal/interpreter_executable"
+	testcases "github.com/codecrafters-io/interpreter-tester/internal/test_cases"
+
+	"github.com/codecrafters-io/tester-utils/test_case_harness"
+)
+
+func testEvaluateUnaryErrors(stageHarness *test_case_harness.TestCaseHarness) error {
+	b := interpreter_executable.NewInterpreterExecutable(stageHarness)
+
+	logger := stageHarness.Logger
+
+	error1 := fmt.Sprintf("-\"%s\"", getRandString())
+	error2 := "-true"
+	error3 := "-false"
+	error4 := fmt.Sprintf("-(\"%s\" + \"%s\")", getRandString(), getRandString())
+
+	evaluateTestCases := testcases.MultiEvaluateTestCase{
+		FileContents: []string{error1, error2, error3, error4},
+	}
+	return evaluateTestCases.RunAll(b, logger)
+}

--- a/internal/stage_e11.go
+++ b/internal/stage_e11.go
@@ -1,0 +1,26 @@
+package internal
+
+import (
+	"fmt"
+
+	"github.com/codecrafters-io/interpreter-tester/internal/interpreter_executable"
+	testcases "github.com/codecrafters-io/interpreter-tester/internal/test_cases"
+
+	"github.com/codecrafters-io/tester-utils/test_case_harness"
+)
+
+func testEvaluateMultErrors(stageHarness *test_case_harness.TestCaseHarness) error {
+	b := interpreter_executable.NewInterpreterExecutable(stageHarness)
+
+	logger := stageHarness.Logger
+
+	error1 := fmt.Sprintf("%d * \"%s\"", getRandInt(), getRandString())
+	error2 := fmt.Sprintf("\"%s\" / %d", getRandString(), getRandInt())
+	error3 := fmt.Sprintf("%s / %s", getRandBoolean(), getRandBoolean())
+	error4 := fmt.Sprintf("(\"%s\" + \"%s\") * (\"%s\" + \"%s\")", getRandString(), getRandString(), getRandString(), getRandString())
+
+	evaluateTestCases := testcases.MultiEvaluateTestCase{
+		FileContents: []string{error1, error2, error3, error4},
+	}
+	return evaluateTestCases.RunAll(b, logger)
+}

--- a/internal/stage_e12.go
+++ b/internal/stage_e12.go
@@ -1,0 +1,26 @@
+package internal
+
+import (
+	"fmt"
+
+	"github.com/codecrafters-io/interpreter-tester/internal/interpreter_executable"
+	testcases "github.com/codecrafters-io/interpreter-tester/internal/test_cases"
+
+	"github.com/codecrafters-io/tester-utils/test_case_harness"
+)
+
+func testEvaluateAddErrors(stageHarness *test_case_harness.TestCaseHarness) error {
+	b := interpreter_executable.NewInterpreterExecutable(stageHarness)
+
+	logger := stageHarness.Logger
+
+	error1 := fmt.Sprintf("\"%s\" + %s", getRandString(), getRandBoolean())
+	error2 := fmt.Sprintf("%d + \"%s\" + %d", getRandInt(), getRandString(), getRandInt())
+	error3 := fmt.Sprintf("%d - %s", getRandInt(), getRandBoolean())
+	error4 := fmt.Sprintf("%s - (\"%s\" + \"%s\")", getRandBoolean(), getRandString(), getRandString())
+
+	evaluateTestCases := testcases.MultiEvaluateTestCase{
+		FileContents: []string{error1, error2, error3, error4},
+	}
+	return evaluateTestCases.RunAll(b, logger)
+}

--- a/internal/stage_e13.go
+++ b/internal/stage_e13.go
@@ -1,0 +1,26 @@
+package internal
+
+import (
+	"fmt"
+
+	"github.com/codecrafters-io/interpreter-tester/internal/interpreter_executable"
+	testcases "github.com/codecrafters-io/interpreter-tester/internal/test_cases"
+
+	"github.com/codecrafters-io/tester-utils/test_case_harness"
+)
+
+func testEvaluateCompErrors(stageHarness *test_case_harness.TestCaseHarness) error {
+	b := interpreter_executable.NewInterpreterExecutable(stageHarness)
+
+	logger := stageHarness.Logger
+
+	error1 := fmt.Sprintf("\"%s\" < %s", getRandString(), getRandBoolean())
+	error2 := fmt.Sprintf("%s <= (%d + %d)", getRandBoolean(), getRandInt(), getRandInt())
+	error3 := fmt.Sprintf("%d > (\"%s\" + \"%s\")", getRandInt(), getRandString(), getRandString())
+	error4 := fmt.Sprintf("%s >= %s", getRandBoolean(), getRandBoolean())
+
+	evaluateTestCases := testcases.MultiEvaluateTestCase{
+		FileContents: []string{error1, error2, error3, error4},
+	}
+	return evaluateTestCases.RunAll(b, logger)
+}

--- a/internal/stage_e3.go
+++ b/internal/stage_e3.go
@@ -19,7 +19,7 @@ func testEvaluateParens(stageHarness *test_case_harness.TestCaseHarness) error {
 	parens1 := "(true)"
 	parens2 := fmt.Sprintf("(%d)", getRandInt())
 	parens3 := fmt.Sprintf("(\"%s\")", strings.Join(random.RandomElementsFromArray(STRINGS, 2), " "))
-	parens4 := fmt.Sprintf("((%s))", random.RandomElementFromArray(BOOLEANS))
+	parens4 := fmt.Sprintf("((%s))", getRandBoolean())
 
 	evaluateTestCases := testcases.MultiEvaluateTestCase{
 		FileContents: []string{parens1, parens2, parens3, parens4},

--- a/internal/stage_e4.go
+++ b/internal/stage_e4.go
@@ -6,7 +6,6 @@ import (
 	"github.com/codecrafters-io/interpreter-tester/internal/interpreter_executable"
 	testcases "github.com/codecrafters-io/interpreter-tester/internal/test_cases"
 
-	"github.com/codecrafters-io/tester-utils/random"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
@@ -16,7 +15,7 @@ func testEvaluateUnary(stageHarness *test_case_harness.TestCaseHarness) error {
 	logger := stageHarness.Logger
 
 	unary1 := fmt.Sprintf("-%d", getRandInt())
-	unary2 := fmt.Sprintf("!%s", random.RandomElementFromArray(BOOLEANS))
+	unary2 := fmt.Sprintf("!%s", getRandBoolean())
 	unary3 := "!nil"
 	unary4 := fmt.Sprintf("(!!%d)", getRandInt())
 

--- a/internal/stage_e5.go
+++ b/internal/stage_e5.go
@@ -1,9 +1,12 @@
 package internal
 
 import (
+	"fmt"
+
 	"github.com/codecrafters-io/interpreter-tester/internal/interpreter_executable"
 	testcases "github.com/codecrafters-io/interpreter-tester/internal/test_cases"
 
+	"github.com/codecrafters-io/tester-utils/random"
 	"github.com/codecrafters-io/tester-utils/test_case_harness"
 )
 
@@ -12,10 +15,11 @@ func testEvaluateFactor(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	logger := stageHarness.Logger
 
-	factor1 := "12 * 2"
-	factor2 := "66 / 11"
-	factor3 := "14 * 4 / 7 / 2"
-	factor4 := "(18 * -2 / (3 * 6))"
+	n1 := random.RandomInt(2, 5)
+	factor1 := fmt.Sprintf("%d * %d", getRandInt(), getRandInt())
+	factor2 := fmt.Sprintf("%d / 5", getRandInt())
+	factor3 := fmt.Sprintf("7 * %d / 7 / 1", n1)
+	factor4 := fmt.Sprintf("(18 * %d / (3 * 6))", n1)
 
 	evaluateTestCases := testcases.MultiEvaluateTestCase{
 		FileContents: []string{factor1, factor2, factor3, factor4},

--- a/internal/stage_e5.go
+++ b/internal/stage_e5.go
@@ -1,0 +1,24 @@
+package internal
+
+import (
+	"github.com/codecrafters-io/interpreter-tester/internal/interpreter_executable"
+	testcases "github.com/codecrafters-io/interpreter-tester/internal/test_cases"
+
+	"github.com/codecrafters-io/tester-utils/test_case_harness"
+)
+
+func testEvaluateFactor(stageHarness *test_case_harness.TestCaseHarness) error {
+	b := interpreter_executable.NewInterpreterExecutable(stageHarness)
+
+	logger := stageHarness.Logger
+
+	factor1 := "12 * 2"
+	factor2 := "66 / 11"
+	factor3 := "14 * 4 / 7 / 2"
+	factor4 := "(18 * -2 / (3 * 6))"
+
+	evaluateTestCases := testcases.MultiEvaluateTestCase{
+		FileContents: []string{factor1, factor2, factor3, factor4},
+	}
+	return evaluateTestCases.RunAll(b, logger)
+}

--- a/internal/stage_e6.go
+++ b/internal/stage_e6.go
@@ -1,6 +1,8 @@
 package internal
 
 import (
+	"fmt"
+
 	"github.com/codecrafters-io/interpreter-tester/internal/interpreter_executable"
 	testcases "github.com/codecrafters-io/interpreter-tester/internal/test_cases"
 
@@ -12,10 +14,10 @@ func testEvaluateTerm(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	logger := stageHarness.Logger
 
-	term1 := "10 - 20"
-	term2 := "23 + 27 - 20"
-	term3 := "2 + 23 - (-(25 - 50))"
-	term4 := "-(-4 + 8) * (6 * 2) / (12 + 12)"
+	term1 := fmt.Sprintf("%d - %d", getRandInt(), getRandInt())
+	term2 := fmt.Sprintf("%d + %d - %d", getRandInt(), getRandInt(), getRandInt())
+	term3 := fmt.Sprintf("%d + %d - (-(%d - %d))", getRandInt(), getRandInt(), getRandInt(), getRandInt())
+	term4 := fmt.Sprintf("-(-%d + %d) * (%d * %d) / (1 + 4)", getRandInt(), getRandInt(), getRandInt(), getRandInt())
 
 	evaluateTestCases := testcases.MultiEvaluateTestCase{
 		FileContents: []string{term1, term2, term3, term4},

--- a/internal/stage_e6.go
+++ b/internal/stage_e6.go
@@ -1,0 +1,24 @@
+package internal
+
+import (
+	"github.com/codecrafters-io/interpreter-tester/internal/interpreter_executable"
+	testcases "github.com/codecrafters-io/interpreter-tester/internal/test_cases"
+
+	"github.com/codecrafters-io/tester-utils/test_case_harness"
+)
+
+func testEvaluateTerm(stageHarness *test_case_harness.TestCaseHarness) error {
+	b := interpreter_executable.NewInterpreterExecutable(stageHarness)
+
+	logger := stageHarness.Logger
+
+	term1 := "10 - 20"
+	term2 := "23 + 27 - 20"
+	term3 := "2 + 23 - (-(25 - 50))"
+	term4 := "-(-4 + 8) * (6 * 2) / (12 + 12)"
+
+	evaluateTestCases := testcases.MultiEvaluateTestCase{
+		FileContents: []string{term1, term2, term3, term4},
+	}
+	return evaluateTestCases.RunAll(b, logger)
+}

--- a/internal/stage_e7.go
+++ b/internal/stage_e7.go
@@ -1,0 +1,26 @@
+package internal
+
+import (
+	"fmt"
+
+	"github.com/codecrafters-io/interpreter-tester/internal/interpreter_executable"
+	testcases "github.com/codecrafters-io/interpreter-tester/internal/test_cases"
+
+	"github.com/codecrafters-io/tester-utils/test_case_harness"
+)
+
+func testEvaluateConcat(stageHarness *test_case_harness.TestCaseHarness) error {
+	b := interpreter_executable.NewInterpreterExecutable(stageHarness)
+
+	logger := stageHarness.Logger
+
+	concat1 := fmt.Sprintf("\"%s\" + \"%s\"", getRandString(), getRandString())
+	concat2 := fmt.Sprintf("\"%s\" + \"%s\"", getRandString(), getRandIntAsString())
+	concat3 := fmt.Sprintf("\"%s\" + \"%s\" + \"%s\"", getRandString(), getRandString(), getRandString())
+	concat4 := fmt.Sprintf("\"%s\" + \"%s\" + \"%s\" + \"%s\"", getRandString(), getRandString(), getRandString(), getRandString())
+
+	evaluateTestCases := testcases.MultiEvaluateTestCase{
+		FileContents: []string{concat1, concat2, concat3, concat4},
+	}
+	return evaluateTestCases.RunAll(b, logger)
+}

--- a/internal/stage_e7.go
+++ b/internal/stage_e7.go
@@ -17,7 +17,7 @@ func testEvaluateConcat(stageHarness *test_case_harness.TestCaseHarness) error {
 	concat1 := fmt.Sprintf("\"%s\" + \"%s\"", getRandString(), getRandString())
 	concat2 := fmt.Sprintf("\"%s\" + \"%s\"", getRandString(), getRandIntAsString())
 	concat3 := fmt.Sprintf("\"%s\" + \"%s\" + \"%s\"", getRandString(), getRandString(), getRandString())
-	concat4 := fmt.Sprintf("\"%s\" + \"%s\" + \"%s\" + \"%s\"", getRandString(), getRandString(), getRandString(), getRandString())
+	concat4 := fmt.Sprintf("(\"%s\" + \"%s\") + (\"%s\" + \"%s\")", getRandString(), getRandString(), getRandString(), getRandString())
 
 	evaluateTestCases := testcases.MultiEvaluateTestCase{
 		FileContents: []string{concat1, concat2, concat3, concat4},

--- a/internal/stage_e8.go
+++ b/internal/stage_e8.go
@@ -1,0 +1,27 @@
+package internal
+
+import (
+	"fmt"
+
+	"github.com/codecrafters-io/interpreter-tester/internal/interpreter_executable"
+	testcases "github.com/codecrafters-io/interpreter-tester/internal/test_cases"
+
+	"github.com/codecrafters-io/tester-utils/test_case_harness"
+)
+
+func testEvaluateRelational(stageHarness *test_case_harness.TestCaseHarness) error {
+	b := interpreter_executable.NewInterpreterExecutable(stageHarness)
+
+	logger := stageHarness.Logger
+
+	n1, n2, n3 := getRandInt(), getRandInt(), getRandInt()
+	relational1 := fmt.Sprintf("%d > -%d", n1, n1+n2)
+	relational2 := fmt.Sprintf("%d <= %d", n1, n1+n2+n3)
+	relational3 := fmt.Sprintf("%d >= %d", n3, n3)
+	relational4 := "(72 - 50) >= -(26 / 13 + 8)"
+
+	evaluateTestCases := testcases.MultiEvaluateTestCase{
+		FileContents: []string{relational1, relational2, relational3, relational4},
+	}
+	return evaluateTestCases.RunAll(b, logger)
+}

--- a/internal/stage_e8.go
+++ b/internal/stage_e8.go
@@ -18,7 +18,7 @@ func testEvaluateRelational(stageHarness *test_case_harness.TestCaseHarness) err
 	relational1 := fmt.Sprintf("%d > -%d", n1, n1+n2)
 	relational2 := fmt.Sprintf("%d <= %d", n1, n1+n2+n3)
 	relational3 := fmt.Sprintf("%d >= %d", n3, n3)
-	relational4 := "(72 - 50) >= -(26 / 13 + 8)"
+	relational4 := fmt.Sprintf("(%d - %d) >= -(%d / %d + %d)", getRandInt(), getRandInt(), n1*2, n1, getRandInt())
 
 	evaluateTestCases := testcases.MultiEvaluateTestCase{
 		FileContents: []string{relational1, relational2, relational3, relational4},

--- a/internal/stage_e9.go
+++ b/internal/stage_e9.go
@@ -1,0 +1,30 @@
+package internal
+
+import (
+	"fmt"
+
+	"github.com/codecrafters-io/interpreter-tester/internal/interpreter_executable"
+	testcases "github.com/codecrafters-io/interpreter-tester/internal/test_cases"
+
+	"github.com/codecrafters-io/tester-utils/random"
+	"github.com/codecrafters-io/tester-utils/test_case_harness"
+)
+
+func testEvaluateEquality(stageHarness *test_case_harness.TestCaseHarness) error {
+	b := interpreter_executable.NewInterpreterExecutable(stageHarness)
+
+	logger := stageHarness.Logger
+
+	strings := random.RandomElementsFromArray(STRINGS, 2)
+	s1, s2 := strings[0], strings[1]
+	n1, n2 := getRandInt(), getRandInt()
+	equality1 := fmt.Sprintf("\"%s\" != \"%s\"", s1, s2)
+	equality2 := fmt.Sprintf("\"%s\" == \"%s\"", s1, s1)
+	equality3 := fmt.Sprintf("%d == \"%d\"", n1, n1)
+	equality4 := fmt.Sprintf("%d != \"%d\"", n2, n2)
+
+	evaluateTestCases := testcases.MultiEvaluateTestCase{
+		FileContents: []string{equality1, equality2, equality3, equality4},
+	}
+	return evaluateTestCases.RunAll(b, logger)
+}

--- a/internal/stage_e9.go
+++ b/internal/stage_e9.go
@@ -17,11 +17,11 @@ func testEvaluateEquality(stageHarness *test_case_harness.TestCaseHarness) error
 
 	strings := random.RandomElementsFromArray(STRINGS, 2)
 	s1, s2 := strings[0], strings[1]
-	n1, n2 := getRandInt(), getRandInt()
+	n1, n2, n3 := getRandInt(), getRandInt(), getRandInt()
 	equality1 := fmt.Sprintf("\"%s\" != \"%s\"", s1, s2)
 	equality2 := fmt.Sprintf("\"%s\" == \"%s\"", s1, s1)
 	equality3 := fmt.Sprintf("%d == \"%d\"", n1, n1)
-	equality4 := fmt.Sprintf("%d != \"%d\"", n2, n2)
+	equality4 := fmt.Sprintf("%d == (%d + %d)", n2+n3, n2, n3)
 
 	evaluateTestCases := testcases.MultiEvaluateTestCase{
 		FileContents: []string{equality1, equality2, equality3, equality4},

--- a/internal/stage_p5.go
+++ b/internal/stage_p5.go
@@ -14,10 +14,10 @@ func testParseUnary(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	logger := stageHarness.Logger
 
-	unaryExpr1 := "!" + random.RandomElementFromArray(BOOLEANS)
+	unaryExpr1 := "!" + getRandBoolean()
 	unaryExpr2 := "-" + fmt.Sprint(random.RandomInt(10, 100))
-	unaryExpr3 := "!!" + random.RandomElementFromArray(BOOLEANS)
-	unaryExpr4 := "(!!(" + random.RandomElementFromArray(BOOLEANS) + "))"
+	unaryExpr3 := "!!" + getRandBoolean()
+	unaryExpr4 := "(!!(" + getRandBoolean() + "))"
 	parseTestCase := testcases.MultiParseTestCase{
 		FileContents: []string{unaryExpr1, unaryExpr2, unaryExpr3, unaryExpr4},
 	}

--- a/internal/stages_test.go
+++ b/internal/stages_test.go
@@ -26,7 +26,7 @@ func TestStages(t *testing.T) {
 			NormalizeOutputFunc: normalizeTesterOutput,
 		},
 		"pass_evaluating_jlox": {
-			StageSlugs:          []string{"iz6", "lv1", "oq9", "dc1"},
+			StageSlugs:          []string{"iz6", "lv1", "oq9", "dc1", "bp3", "jy2", "jx8", "et4", "hw7", "gj9"},
 			CodePath:            "../craftinginterpreters/build/gen/chap07_evaluating",
 			ExpectedExitCode:    0,
 			StdoutFixturePath:   "./test_helpers/fixtures/pass_evaluating",

--- a/internal/stages_test.go
+++ b/internal/stages_test.go
@@ -26,7 +26,7 @@ func TestStages(t *testing.T) {
 			NormalizeOutputFunc: normalizeTesterOutput,
 		},
 		"pass_evaluating_jlox": {
-			StageSlugs:          []string{"iz6", "lv1", "oq9", "dc1", "bp3", "jy2", "jx8", "et4", "hw7", "gj9"},
+			StageSlugs:          []string{"iz6", "lv1", "oq9", "dc1", "bp3", "jy2", "jx8", "et4", "hw7", "gj9", "yu6", "cq1", "ib5"},
 			CodePath:            "../craftinginterpreters/build/gen/chap07_evaluating",
 			ExpectedExitCode:    0,
 			StdoutFixturePath:   "./test_helpers/fixtures/pass_evaluating",

--- a/internal/stages_test.go
+++ b/internal/stages_test.go
@@ -19,14 +19,14 @@ func TestStages(t *testing.T) {
 			NormalizeOutputFunc: normalizeTesterOutput,
 		},
 		"pass_parsing_jlox": {
-			StageSlugs:          []string{"sc2", "ra8", "th5", "xe6", "mq1", "wa9", "yf2", "uh4", "ht8", "wz8"},
+			StageSlugs:          []string{"wz8", "ht8", "uh4", "yf2", "wa9", "mq1", "xe6", "th5", "ra8", "sc2"},
 			CodePath:            "../craftinginterpreters/build/gen/chap06_parsing",
 			ExpectedExitCode:    0,
 			StdoutFixturePath:   "./test_helpers/fixtures/pass_parsing",
 			NormalizeOutputFunc: normalizeTesterOutput,
 		},
 		"pass_evaluating_jlox": {
-			StageSlugs:          []string{"iz6", "lv1", "oq9", "dc1", "bp3", "jy2", "jx8", "et4", "hw7", "gj9", "yu6", "cq1", "ib5"},
+			StageSlugs:          []string{"ib5", "cq1", "yu6", "gj9", "hw7", "et4", "jx8", "jy2", "bp3", "dc1", "oq9", "lv1", "iz6"},
 			CodePath:            "../craftinginterpreters/build/gen/chap07_evaluating",
 			ExpectedExitCode:    0,
 			StdoutFixturePath:   "./test_helpers/fixtures/pass_evaluating",

--- a/internal/test_helpers/course_definition.yml
+++ b/internal/test_helpers/course_definition.yml
@@ -1147,3 +1147,21 @@ stages:
   - slug: "oq9"
 
   - slug: "dc1"
+
+  - slug: "bp3"
+
+  - slug: "jy2"
+
+  - slug: "jx8"
+
+  - slug: "et4"
+
+  - slug: "hw7"
+
+  - slug: "gj9"
+
+  - slug: "yu6"
+
+  - slug: "cq1"
+
+  - slug: "ib5"

--- a/internal/test_helpers/course_definition.yml
+++ b/internal/test_helpers/course_definition.yml
@@ -56,6 +56,13 @@ extensions:
 
       In this extension, you'll add the ability to parse expressions.
 
+  - slug: "evaluating-expressions"
+    name: "Evaluating Expressions"
+    description_markdown: |
+      This extension covers chapters 7 of the book ([Evaluating Expressions](https://craftinginterpreters.com/evaluating-expressions.html)).
+
+      In this extension, you'll add the ability to evaluate expressions.
+
 stages:
   - slug: "ry8"
     name: "Scanning: Empty file"
@@ -1141,27 +1148,521 @@ stages:
       In this stage, you'll implement support for handling syntax errors in expressions.
 
   - slug: "iz6"
+    primary_extension_slug: "evaluating-expressions"
+    name: "Literals: Booleans & Nil"
+    difficulty: hard
+    description_md: |-
+      In this stage you'll implement support for the `evaluate` command and handle evaluating the `true`, `false`, and `nil` literals.
+
+      ### Book reference
+
+      The code for this stage is implemented in [Section 7.2.1: Evaluating Literals](https://craftinginterpreters.com/evaluating-expressions.html#evaluating-literals).
+
+      ### The `evaluate` command
+
+      In the previous stages, the tester used the `parse` command to test your parser implementation. In this extension, the tester will need to test
+      your evaluator implementation, so it'll use a different command instead: `evaluate`.
+
+      The `evaluate` command accepts a path to a file (`test.lox` for example) and prints out the result of evaluating the file to stdout.
+
+      For example, if `test.lox` contains the following:
+
+      ```
+      2 + 3
+      ```
+
+      The `evaluate` command will return the following:
+
+      ```
+      $ ./your_program.sh evaluate test.lox
+      5
+      ```
+
+      This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/evaluate.lox).
+
+      For the same file, here's what the output from `parse` would've been:
+
+      ```
+      $ ./your_program.sh parse test.lox
+      (+ 2.0 3.0)
+      ```
+
+      ### Tests
+
+      The tester will run a series of tests with `test.lox` files that contain the boolean values `true` & `false`, and the `nil` literal.
+
+      For example, if `test.lox` contains the following:
+
+      ```
+      true
+      ```
+
+      The tester will run your program like this:
+
+      ```
+      $ ./your_program.sh evaluate test.lox
+      true
+      ```
+
+      The tester will assert that the stdout of your program matches the format above.
+
+      ### Notes
+
+      - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/evaluate.lox)
+      - For the `nil` literal, the tester will check that the program prints `nil`.
+      - For truthyness & falsyness, we will follow the convention introduced in the book, where `false` and `nil` are falsy, and everything else is truthy.
+    marketing_md: |-
+      In this stage, you'll implement support for evaluating binary values and the nil literal.
 
   - slug: "lv1"
+    primary_extension_slug: "evaluating-expressions"
+    name: "Literals: Strings & Numbers"
+    difficulty: medium
+    description_md: |-
+      In this stage, you'll add support for evaluating number and string literals.
+
+      ### Book reference
+
+      The code for this stage is implemented in [Section 7.2.1: Evaluating Literals](https://craftinginterpreters.com/evaluating-expressions.html#evaluating-literals).
+
+      ### Tests
+
+      The tester will run a series of tests with `test.lox` files that contain number literals and string literals.
+
+      For example, if `test.lox` contains the following:
+
+      ```
+      10.40
+      ```
+
+      The tester will run your program like this:
+
+      ```
+      $ ./your_program.sh evaluate test.lox
+      10.4
+      ```
+
+      The tester will assert that the stdout of your program matches the format above.
+
+      ### Notes
+
+      - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/evaluate.lox)
+      - For the string literals, the tester will check that the program prints the string without quotes.
+      - For the number literals, the tester will check that the program prints the number with the minimum number of decimal places without losing precision. (For example, you can skip 0's at the end after the decimal point, but you can't skip 0's at the beginning of the number).
+    marketing_md: |-
+      In this stage, you'll implement support for evaluating number and string literals.
 
   - slug: "oq9"
+    primary_extension_slug: "evaluating-expressions"
+    name: "Parentheses"
+    difficulty: medium
+    description_md: |-
+      In this stage, you'll add support for evaluating expressions inside parentheses.
+
+      ### Book reference
+
+      The code for this stage is implemented in [Section 7.2.2: Evaluating parentheses](https://craftinginterpreters.com/evaluating-expressions.html#evaluating-parentheses).
+
+      ### Tests
+
+      The tester will run a series of tests with `test.lox` files that contain expressions inside parentheses.
+
+      For example, if `test.lox` contains the following:
+
+      ```
+      ("hello world!")
+      ```
+
+      The tester will run your program like this:
+
+      ```
+      $ ./your_program.sh evaluate test.lox
+      hello world!
+      ```
+
+      The tester will assert that the stdout of your program matches the format above.
+
+      ### Notes
+
+      - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/evaluate.lox)
+      - For string literals, number literals follow the same rules as in the previous stage.
+    marketing_md: |-
+      In this stage, you'll implement support for evaluating expressions inside parentheses.
 
   - slug: "dc1"
+    primary_extension_slug: "evaluating-expressions"
+    name: "Unary Operators: Negation & Not"
+    difficulty: medium
+    description_md: |-
+      In this stage, you'll add support for evaluating unary operators `-` and `!`.
+
+      ### Book reference
+
+      The code for this stage is implemented in [Section 7.2.3: Evaluating unary expressions](https://craftinginterpreters.com/evaluating-expressions.html#evaluating-unary-expressions).
+
+      ### Tests
+
+      The tester will run a series of tests with `test.lox` files that contain expressions with unary operators.
+
+      For example, if `test.lox` contains the following:
+
+      ```
+      -73
+      ```
+
+      The tester will run your program like this:
+
+      ```
+      $ ./your_program.sh evaluate test.lox
+      -73
+      ```
+
+      The tester will assert that the stdout of your program matches the format above.
+
+      ### Notes
+
+      - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/evaluate.lox)
+      - For truthyness and falsyness, we will follow the convention introduced in the previous stages.
+    marketing_md: |-
+      In this stage, you'll implement support for evaluating unary operators `-` and `!`.
 
   - slug: "bp3"
+    primary_extension_slug: "evaluating-expressions"
+    name: "Arithmetic Operators (1/2)"
+    difficulty: medium
+    description_md: |-
+      In this stage, you'll add support for evaluating binary operators `*` and `/`.
+
+      ### Book reference
+
+      The code for this stage is implemented in [Section 7.2.5: Evaluating binary operators](https://craftinginterpreters.com/evaluating-expressions.html#evaluating-binary-operators).
+
+      ### Tests
+
+      The tester will run a series of tests with `test.lox` files that contain expressions with the arithmetic operators `*` and `/`.
+
+      For example, if `test.lox` contains the following:
+
+      ```
+      (18 * 3 / (3 * 6))
+      ```
+
+      The tester will run your program like this:
+
+      ```
+      $ ./your_program.sh evaluate test.lox
+      3
+      ```
+
+      The tester will assert that the stdout of your program matches the format above.
+
+      ### Notes
+
+      - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/evaluate.lox)
+      - We will introduce runtime errors in later stages. For now, we will only pass 2 numbers to the arithmetic operators.
+    marketing_md: |-
+      In this stage, you'll implement support for evaluating binary operators `*` and `/`.
 
   - slug: "jy2"
+    primary_extension_slug: "evaluating-expressions"
+    name: "Arithmetic Operators (2/2)"
+    difficulty: medium
+    description_md: |-
+      In this stage, you'll add support for evaluating binary operators `+` and `-`.
+
+      ### Book reference
+
+      The code for this stage is implemented in [Section 7.2.5: Evaluating binary operators](https://craftinginterpreters.com/evaluating-expressions.html#evaluating-binary-operators).
+
+      ### Tests
+
+      The tester will run a series of tests with `test.lox` files that contain expressions with the arithmetic operators `+` and `-`.
+
+      For example, if `test.lox` contains the following:
+
+      ```
+      20 + 74 - (-(14 - 33))
+      ```
+
+      The tester will run your program like this:
+
+      ```
+      $ ./your_program.sh evaluate test.lox
+      75
+      ```
+
+      The tester will assert that the stdout of your program matches the format above.
+
+      ### Notes
+
+      - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/evaluate.lox)
+      - We will introduce runtime errors in later stages. For now, we will only pass 2 numbers to the arithmetic operators.
+    marketing_md: |-
+      In this stage, you'll implement support for evaluating binary operators `+` and `-`.
 
   - slug: "jx8"
+    primary_extension_slug: "evaluating-expressions"
+    name: "String Concatenation"
+    difficulty: medium
+    description_md: |-
+      In this stage, you'll add support for overloading the `+` operator. When the `+` operator is applied to two strings, it should concatenate them.
+
+      ### Book reference
+
+      The code for this stage is implemented in [Section 7.2.5: Evaluating binary operators](https://craftinginterpreters.com/evaluating-expressions.html#evaluating-binary-operators).
+
+      ### Tests
+
+      The tester will run a series of tests with `test.lox` files that contain expressions with the operator `+`.
+
+      For example, if `test.lox` contains the following:
+
+      ```
+      "hello" + " world!"
+      ```
+
+      The tester will run your program like this:
+
+      ```
+      $ ./your_program.sh evaluate test.lox
+      hello world!
+      ```
+
+      The tester will assert that the stdout of your program matches the format above.
+
+      ### Notes
+
+      - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/evaluate.lox)
+      - We will introduce runtime errors in later stages. For now, we will only pass 2 strings to the `+` operator in this stage.
+    marketing_md: |-
+      In this stage, you'll implement support for overloading the `+` operator. When the `+` operator is applied to two strings, it should concatenate them.
 
   - slug: "et4"
+    primary_extension_slug: "evaluating-expressions"
+    name: "Relational Operators"
+    difficulty: medium
+    description_md: |-
+      In this stage, you'll add support for evaluating relational operators `>`, `<`, `>=` & `<=`.
+
+      ### Book reference
+
+      The code for this stage is implemented in [Section 7.2.5: Evaluating binary operators](https://craftinginterpreters.com/evaluating-expressions.html#evaluating-binary-operators).
+
+      ### Tests
+
+      The tester will run a series of tests with `test.lox` files that contain expressions with the relational operators `>`, `<`, `>=` & `<=`.
+
+      For example, if `test.lox` contains the following:
+
+      ```
+      10 > 5
+      ```
+
+      The tester will run your program like this:
+
+      ```
+      $ ./your_program.sh evaluate test.lox
+      true
+      ```
+
+      The tester will assert that the stdout of your program matches the format above.
+
+      ### Notes
+
+      - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/evaluate.lox)
+      - We will introduce runtime errors in later stages. For now, we will only pass 2 numbers to the relational operators in this stage.
+    marketing_md: |-
+      In this stage, you'll implement support for evaluating relational operators `>`, `<`, `>=` & `<=`.
 
   - slug: "hw7"
+    primary_extension_slug: "evaluating-expressions"
+    name: "Equality Operators"
+    difficulty: medium
+    description_md: |-
+      In this stage, you'll add support for evaluating equality operators `==` and `!=`.
+
+      ### Book reference
+
+      The code for this stage is implemented in [Section 7.2.5: Evaluating binary operators](https://craftinginterpreters.com/evaluating-expressions.html#evaluating-binary-operators).
+
+      ### Tests
+
+      The tester will run a series of tests with `test.lox` files that contain expressions with the equality operators `==` and `!=`.
+
+      For example, if `test.lox` contains the following:
+
+      ```
+      156 == (89 + 67)
+      ```
+
+      The tester will run your program like this:
+
+      ```
+      $ ./your_program.sh evaluate test.lox
+      true
+      ```
+
+      The tester will assert that the stdout of your program matches the format above.
+
+      ### Notes
+
+      - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/evaluate.lox)
+      - We will introduce runtime errors in later stages. For now, we will only pass numbers / strings to the equality operators in this stage.
+    marketing_md: |-
+      In this stage, you'll implement support for evaluating equality operators `==` and `!=`.
 
   - slug: "gj9"
+    primary_extension_slug: "evaluating-expressions"
+    name: "Runtime Errors: Unary Operators"
+    difficulty: medium
+    description_md: |-
+      In this stage, you'll add support for handling runtime errors while evaluating the unary operator `-`.
+
+      ### Book reference
+
+      The code for this stage is implemented in [Section 7.3: Runtime Errors](https://craftinginterpreters.com/evaluating-expressions.html#runtime-errors).
+
+      ### Tests
+
+      The tester will run a series of tests with `test.lox` files that contain expressions with the unary operator `-`, There is a high probability that the expression will throw a runtime error.
+
+      For example, if `test.lox` contains the following:
+
+      ```
+      -"hello world!"
+      ```
+
+      The tester will run your program like this:
+
+      ```
+      $ ./your_program.sh evaluate test.lox
+      Operand must be a number.
+      [line 1]
+      ```
+
+      The tester will ONLY assert that the exit code of your program is 70 in case of a runtime error.
+      Or if the exit code is 0, the tester will assert that the stdout of your program matches the format above.
+
+      ### Notes
+
+      - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/evaluate.lox)
+      - The unary operator `-` will throw a runtime error if the operand is not a number.
+    marketing_md: |-
+      In this stage, you'll implement support for handling runtime errors while evaluating the unary operator `-`.
 
   - slug: "yu6"
+    primary_extension_slug: "evaluating-expressions"
+    name: "Runtime Errors: Binary Operators (1/2)"
+    difficulty: medium
+    description_md: |-
+      In this stage, you'll add support for handling runtime errors while evaluating the binary operators `*` & `/`.
 
+      ### Book reference
+
+      The code for this stage is implemented in [Section 7.3: Runtime Errors](https://craftinginterpreters.com/evaluating-expressions.html#runtime-errors).
+
+      ### Tests
+
+      The tester will run a series of tests with `test.lox` files that contain expressions with the binary operators `*` & `/`, There is a high probability that the expression will throw a runtime error.
+
+      For example, if `test.lox` contains the following:
+
+      ```
+      "foo" / 42
+      ```
+
+      The tester will run your program like this:
+
+      ```
+      $ ./your_program.sh evaluate test.lox
+      Operands must be numbers.
+      [line 1]
+      ```
+
+      The tester will ONLY assert that the exit code of your program is 70 in case of a runtime error.
+      Or if the exit code is 0, the tester will assert that the stdout of your program matches the format above.
+
+      ### Notes
+
+      - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/evaluate.lox)
+      - The binary operators `*` & `/` will throw a runtime error if both the operands are not numbers.
+    marketing_md: |-
+      In this stage, you'll implement support for handling runtime errors while evaluating the binary operators `*` & `/`.
+  
   - slug: "cq1"
+    primary_extension_slug: "evaluating-expressions"
+    name: "Runtime Errors: Binary Operators (2/2)"
+    difficulty: medium
+    description_md: |-
+      In this stage, you'll add support for handling runtime errors while evaluating the binary operators `+` & `-`.
+
+      ### Book reference
+
+      The code for this stage is implemented in [Section 7.3: Runtime Errors](https://craftinginterpreters.com/evaluating-expressions.html#runtime-errors).
+
+      ### Tests
+
+      The tester will run a series of tests with `test.lox` files that contain expressions with the binary operators `+` & `-`, There is a high probability that the expression will throw a runtime error.
+
+      For example, if `test.lox` contains the following:
+
+      ```
+      17 + "bar"
+      ```
+
+      The tester will run your program like this:
+
+      ```
+      $ ./your_program.sh evaluate test.lox
+      Operands must be two numbers or two strings.
+      [line 1]
+      ```
+
+      The tester will ONLY assert that the exit code of your program is 70 in case of a runtime error.
+      Or if the exit code is 0, the tester will assert that the stdout of your program matches the format above.
+
+      ### Notes
+
+      - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/evaluate.lox)
+      - The binary operators `+` & `-` will throw a runtime error if both the operands are not both numbers or both strings.
+    marketing_md: |-
+      In this stage, you'll implement support for handling runtime errors while evaluating the binary operators `+` & `-`.
 
   - slug: "ib5"
+    primary_extension_slug: "evaluating-expressions"
+    name: "Runtime Errors: Relational Operators"
+    difficulty: medium
+    description_md: |-
+      In this stage, you'll add support for handling runtime errors while evaluating the relational operators `>`, `<`, `>=` & `<=`.
+
+      ### Book reference
+
+      The code for this stage is implemented in [Section 7.3: Runtime Errors](https://craftinginterpreters.com/evaluating-expressions.html#runtime-errors).
+
+      ### Tests
+
+      The tester will run a series of tests with `test.lox` files that contain expressions with the relational operators `>`, `<`, `>=` & `<=`, There is a high probability that the expression will throw a runtime error.
+
+      For example, if `test.lox` contains the following:
+
+      ```
+      17 > "bar"
+      ```
+
+      The tester will run your program like this:
+
+      ```
+      $ ./your_program.sh evaluate test.lox
+      Operands must be numbers.
+      [line 1]
+      ```
+
+      The tester will ONLY assert that the exit code of your program is 70 in case of a runtime error.
+      Or if the exit code is 0, the tester will assert that the stdout of your program matches the format above.
+
+      ### Notes
+
+      - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/evaluate.lox)
+      - The relational operators `>`, `<`, `>=` & `<=` will throw a runtime error if the operands are not numbers.
+    marketing_md: |-
+      In this stage, you'll implement support for handling runtime errors while evaluating the relational operators `>`, `<`, `>=` & `<=`.

--- a/internal/test_helpers/fixtures/pass_evaluating
+++ b/internal/test_helpers/fixtures/pass_evaluating
@@ -226,7 +226,7 @@ Debug = true
 [33m[stage-7] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-7] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-7] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-7] [test-4] [0m[33m[test.lox][0m "baz" + "hello" + "baz" + "baz"
+[33m[stage-7] [test-4] [0m[33m[test.lox][0m ("baz" + "hello") + ("baz" + "baz")
 [33m[stage-7] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
 [33m[your_program] [0mbazhellobazbaz
 [33m[stage-7] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m

--- a/internal/test_helpers/fixtures/pass_evaluating
+++ b/internal/test_helpers/fixtures/pass_evaluating
@@ -1,180 +1,203 @@
 Debug = true
 
-[33m[stage-13] [0m[94mRunning tests for Stage #13: iz6[0m
+[33m[stage-13] [0m[94mRunning tests for Stage #13: ib5[0m
 [33m[stage-13] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-13] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-13] [test-1] [0m[33m[test.lox][0m true
+[33m[stage-13] [test-1] [0m[33m[test.lox][0m "foo" < false
 [33m[stage-13] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mtrue
+[33m[your_program] [0mOperands must be numbers.
+[33m[your_program] [0m[line 1]
 [33m[stage-13] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-13] [test-1] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-13] [test-1] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-13] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-13] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-13] [test-2] [0m[33m[test.lox][0m false
+[33m[stage-13] [test-2] [0m[33m[test.lox][0m true <= (44 + 54)
 [33m[stage-13] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mfalse
+[33m[your_program] [0mOperands must be numbers.
+[33m[your_program] [0m[line 1]
 [33m[stage-13] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-13] [test-2] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-13] [test-2] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-13] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-13] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-13] [test-3] [0m[33m[test.lox][0m nil
+[33m[stage-13] [test-3] [0m[33m[test.lox][0m 80 > ("quz" + "foo")
 [33m[stage-13] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mnil
+[33m[your_program] [0mOperands must be numbers.
+[33m[your_program] [0m[line 1]
 [33m[stage-13] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-13] [test-3] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-13] [test-3] [0m[92m✓ Received exit code 70.[0m
+[33m[stage-13] [test-4] [0m[94mRunning test case: 4[0m
+[33m[stage-13] [test-4] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-13] [test-4] [0m[33m[test.lox][0m false >= true
+[33m[stage-13] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
+[33m[your_program] [0mOperands must be numbers.
+[33m[your_program] [0m[line 1]
+[33m[stage-13] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
+[33m[stage-13] [test-4] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-13] [0m[92mTest passed.[0m
 
-[33m[stage-12] [0m[94mRunning tests for Stage #12: lv1[0m
+[33m[stage-12] [0m[94mRunning tests for Stage #12: cq1[0m
 [33m[stage-12] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-12] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-12] [test-1] [0m[33m[test.lox][0m 73
+[33m[stage-12] [test-1] [0m[33m[test.lox][0m "foo" + true
 [33m[stage-12] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m73
+[33m[your_program] [0mOperands must be two numbers or two strings.
+[33m[your_program] [0m[line 1]
 [33m[stage-12] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-12] [test-1] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-12] [test-1] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-12] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-12] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-12] [test-2] [0m[33m[test.lox][0m 61.38
+[33m[stage-12] [test-2] [0m[33m[test.lox][0m 70 + "baz" + 95
 [33m[stage-12] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m61.38
+[33m[your_program] [0mOperands must be two numbers or two strings.
+[33m[your_program] [0m[line 1]
 [33m[stage-12] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-12] [test-2] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-12] [test-2] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-12] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-12] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-12] [test-3] [0m[33m[test.lox][0m "foo bar"
+[33m[stage-12] [test-3] [0m[33m[test.lox][0m 89 - false
 [33m[stage-12] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mfoo bar
+[33m[your_program] [0mOperands must be numbers.
+[33m[your_program] [0m[line 1]
 [33m[stage-12] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-12] [test-3] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-12] [test-3] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-12] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-12] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-12] [test-4] [0m[33m[test.lox][0m "61"
+[33m[stage-12] [test-4] [0m[33m[test.lox][0m true - ("bar" + "hello")
 [33m[stage-12] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m61
+[33m[your_program] [0mOperands must be numbers.
+[33m[your_program] [0m[line 1]
 [33m[stage-12] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-12] [test-4] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-12] [test-4] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-12] [0m[92mTest passed.[0m
 
-[33m[stage-11] [0m[94mRunning tests for Stage #11: oq9[0m
+[33m[stage-11] [0m[94mRunning tests for Stage #11: yu6[0m
 [33m[stage-11] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-11] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-11] [test-1] [0m[33m[test.lox][0m (true)
+[33m[stage-11] [test-1] [0m[33m[test.lox][0m 82 * "foo"
 [33m[stage-11] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mtrue
+[33m[your_program] [0mOperands must be numbers.
+[33m[your_program] [0m[line 1]
 [33m[stage-11] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-11] [test-1] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-11] [test-1] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-11] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-11] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-11] [test-2] [0m[33m[test.lox][0m (44)
+[33m[stage-11] [test-2] [0m[33m[test.lox][0m "quz" / 17
 [33m[stage-11] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m44
+[33m[your_program] [0mOperands must be numbers.
+[33m[your_program] [0m[line 1]
 [33m[stage-11] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-11] [test-2] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-11] [test-2] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-11] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-11] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-11] [test-3] [0m[33m[test.lox][0m ("world hello")
+[33m[stage-11] [test-3] [0m[33m[test.lox][0m true / false
 [33m[stage-11] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mworld hello
+[33m[your_program] [0mOperands must be numbers.
+[33m[your_program] [0m[line 1]
 [33m[stage-11] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-11] [test-3] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-11] [test-3] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-11] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-11] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-11] [test-4] [0m[33m[test.lox][0m ((false))
+[33m[stage-11] [test-4] [0m[33m[test.lox][0m ("foo" + "world") * ("foo" + "hello")
 [33m[stage-11] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mfalse
+[33m[your_program] [0mOperands must be numbers.
+[33m[your_program] [0m[line 1]
 [33m[stage-11] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-11] [test-4] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-11] [test-4] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-11] [0m[92mTest passed.[0m
 
-[33m[stage-10] [0m[94mRunning tests for Stage #10: dc1[0m
+[33m[stage-10] [0m[94mRunning tests for Stage #10: gj9[0m
 [33m[stage-10] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-10] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-10] [test-1] [0m[33m[test.lox][0m -70
+[33m[stage-10] [test-1] [0m[33m[test.lox][0m -"foo"
 [33m[stage-10] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m-70
+[33m[your_program] [0mOperand must be a number.
+[33m[your_program] [0m[line 1]
 [33m[stage-10] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-10] [test-1] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-10] [test-1] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-10] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-10] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-10] [test-2] [0m[33m[test.lox][0m !false
+[33m[stage-10] [test-2] [0m[33m[test.lox][0m -true
 [33m[stage-10] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mtrue
+[33m[your_program] [0mOperand must be a number.
+[33m[your_program] [0m[line 1]
 [33m[stage-10] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-10] [test-2] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-10] [test-2] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-10] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-10] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-10] [test-3] [0m[33m[test.lox][0m !nil
+[33m[stage-10] [test-3] [0m[33m[test.lox][0m -false
 [33m[stage-10] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mtrue
+[33m[your_program] [0mOperand must be a number.
+[33m[your_program] [0m[line 1]
 [33m[stage-10] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-10] [test-3] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-10] [test-3] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-10] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-10] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-10] [test-4] [0m[33m[test.lox][0m (!!75)
+[33m[stage-10] [test-4] [0m[33m[test.lox][0m -("foo" + "world")
 [33m[stage-10] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mtrue
+[33m[your_program] [0mOperand must be a number.
+[33m[your_program] [0m[line 1]
 [33m[stage-10] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-10] [test-4] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-10] [test-4] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-10] [0m[92mTest passed.[0m
 
-[33m[stage-9] [0m[94mRunning tests for Stage #9: bp3[0m
+[33m[stage-9] [0m[94mRunning tests for Stage #9: hw7[0m
 [33m[stage-9] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-9] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-9] [test-1] [0m[33m[test.lox][0m 90 * 20
+[33m[stage-9] [test-1] [0m[33m[test.lox][0m "baz" != "bar"
 [33m[stage-9] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m1800
+[33m[your_program] [0mtrue
 [33m[stage-9] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-9] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-9] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-9] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-9] [test-2] [0m[33m[test.lox][0m 16 / 5
+[33m[stage-9] [test-2] [0m[33m[test.lox][0m "baz" == "baz"
 [33m[stage-9] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m3.2
+[33m[your_program] [0mtrue
 [33m[stage-9] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-9] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-9] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-9] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-9] [test-3] [0m[33m[test.lox][0m 7 * 4 / 7 / 1
+[33m[stage-9] [test-3] [0m[33m[test.lox][0m 82 == "82"
 [33m[stage-9] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m4
+[33m[your_program] [0mfalse
 [33m[stage-9] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-9] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-9] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-9] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-9] [test-4] [0m[33m[test.lox][0m (18 * 4 / (3 * 6))
+[33m[stage-9] [test-4] [0m[33m[test.lox][0m 129 == (35 + 94)
 [33m[stage-9] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m4
+[33m[your_program] [0mtrue
 [33m[stage-9] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-9] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-9] [0m[92mTest passed.[0m
 
-[33m[stage-8] [0m[94mRunning tests for Stage #8: jy2[0m
+[33m[stage-8] [0m[94mRunning tests for Stage #8: et4[0m
 [33m[stage-8] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-8] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-8] [test-1] [0m[33m[test.lox][0m 12 - 53
+[33m[stage-8] [test-1] [0m[33m[test.lox][0m 58 > -116
 [33m[stage-8] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m-41
+[33m[your_program] [0mtrue
 [33m[stage-8] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-8] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-8] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-8] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-8] [test-2] [0m[33m[test.lox][0m 30 + 19 - 96
+[33m[stage-8] [test-2] [0m[33m[test.lox][0m 58 <= 134
 [33m[stage-8] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m-47
+[33m[your_program] [0mtrue
 [33m[stage-8] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-8] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-8] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-8] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-8] [test-3] [0m[33m[test.lox][0m 42 + 53 - (-(67 - 43))
+[33m[stage-8] [test-3] [0m[33m[test.lox][0m 18 >= 18
 [33m[stage-8] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m119
+[33m[your_program] [0mtrue
 [33m[stage-8] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-8] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-8] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-8] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-8] [test-4] [0m[33m[test.lox][0m -(-15 + 70) * (99 * 91) / (1 + 4)
+[33m[stage-8] [test-4] [0m[33m[test.lox][0m (49 - 98) >= -(116 / 58 + 65)
 [33m[stage-8] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m-99099
+[33m[your_program] [0mtrue
 [33m[stage-8] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-8] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-8] [0m[92mTest passed.[0m
@@ -182,232 +205,209 @@ Debug = true
 [33m[stage-7] [0m[94mRunning tests for Stage #7: jx8[0m
 [33m[stage-7] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-7] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-7] [test-1] [0m[33m[test.lox][0m "hello" + "hello"
+[33m[stage-7] [test-1] [0m[33m[test.lox][0m "world" + "foo"
 [33m[stage-7] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mhellohello
+[33m[your_program] [0mworldfoo
 [33m[stage-7] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-7] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-7] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-7] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-7] [test-2] [0m[33m[test.lox][0m "bar" + "80"
+[33m[stage-7] [test-2] [0m[33m[test.lox][0m "foo" + "37"
 [33m[stage-7] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mbar80
+[33m[your_program] [0mfoo37
 [33m[stage-7] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-7] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-7] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-7] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-7] [test-3] [0m[33m[test.lox][0m "quz" + "baz" + "bar"
+[33m[stage-7] [test-3] [0m[33m[test.lox][0m "quz" + "world" + "quz"
 [33m[stage-7] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mquzbazbar
+[33m[your_program] [0mquzworldquz
 [33m[stage-7] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-7] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-7] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-7] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-7] [test-4] [0m[33m[test.lox][0m "baz" + "world" + "quz" + "bar"
+[33m[stage-7] [test-4] [0m[33m[test.lox][0m "baz" + "hello" + "baz" + "baz"
 [33m[stage-7] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mbazworldquzbar
+[33m[your_program] [0mbazhellobazbaz
 [33m[stage-7] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-7] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-7] [0m[92mTest passed.[0m
 
-[33m[stage-6] [0m[94mRunning tests for Stage #6: et4[0m
+[33m[stage-6] [0m[94mRunning tests for Stage #6: jy2[0m
 [33m[stage-6] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-6] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-6] [test-1] [0m[33m[test.lox][0m 44 > -129
+[33m[stage-6] [test-1] [0m[33m[test.lox][0m 97 - 64
 [33m[stage-6] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mtrue
+[33m[your_program] [0m33
 [33m[stage-6] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-6] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-6] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-6] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-6] [test-2] [0m[33m[test.lox][0m 44 <= 148
+[33m[stage-6] [test-2] [0m[33m[test.lox][0m 68 + 92 - 53
 [33m[stage-6] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mtrue
+[33m[your_program] [0m107
 [33m[stage-6] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-6] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-6] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-6] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-6] [test-3] [0m[33m[test.lox][0m 19 >= 19
+[33m[stage-6] [test-3] [0m[33m[test.lox][0m 75 + 57 - (-(93 - 67))
 [33m[stage-6] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mtrue
+[33m[your_program] [0m158
 [33m[stage-6] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-6] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-6] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-6] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-6] [test-4] [0m[33m[test.lox][0m (45 - 99) >= -(88 / 44 + 35)
+[33m[stage-6] [test-4] [0m[33m[test.lox][0m -(-57 + 34) * (77 * 51) / (1 + 4)
 [33m[stage-6] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mfalse
+[33m[your_program] [0m18064.2
 [33m[stage-6] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-6] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-6] [0m[92mTest passed.[0m
 
-[33m[stage-5] [0m[94mRunning tests for Stage #5: hw7[0m
+[33m[stage-5] [0m[94mRunning tests for Stage #5: bp3[0m
 [33m[stage-5] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-5] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-5] [test-1] [0m[33m[test.lox][0m "quz" != "bar"
+[33m[stage-5] [test-1] [0m[33m[test.lox][0m 29 * 75
 [33m[stage-5] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mtrue
+[33m[your_program] [0m2175
 [33m[stage-5] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-5] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-5] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-5] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-5] [test-2] [0m[33m[test.lox][0m "quz" == "quz"
+[33m[stage-5] [test-2] [0m[33m[test.lox][0m 75 / 5
 [33m[stage-5] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mtrue
+[33m[your_program] [0m15
 [33m[stage-5] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-5] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-5] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-5] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-5] [test-3] [0m[33m[test.lox][0m 71 == "71"
+[33m[stage-5] [test-3] [0m[33m[test.lox][0m 7 * 2 / 7 / 1
 [33m[stage-5] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mfalse
+[33m[your_program] [0m2
 [33m[stage-5] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-5] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-5] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-5] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-5] [test-4] [0m[33m[test.lox][0m 86 == (62 + 24)
+[33m[stage-5] [test-4] [0m[33m[test.lox][0m (18 * 2 / (3 * 6))
 [33m[stage-5] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mtrue
+[33m[your_program] [0m2
 [33m[stage-5] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-5] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-5] [0m[92mTest passed.[0m
 
-[33m[stage-4] [0m[94mRunning tests for Stage #4: gj9[0m
+[33m[stage-4] [0m[94mRunning tests for Stage #4: dc1[0m
 [33m[stage-4] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-4] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-4] [test-1] [0m[33m[test.lox][0m -"world"
+[33m[stage-4] [test-1] [0m[33m[test.lox][0m -32
 [33m[stage-4] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mOperand must be a number.
-[33m[your_program] [0m[line 1]
+[33m[your_program] [0m-32
 [33m[stage-4] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-4] [test-1] [0m[92m✓ Received exit code 70.[0m
+[33m[stage-4] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-4] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-4] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-4] [test-2] [0m[33m[test.lox][0m -true
+[33m[stage-4] [test-2] [0m[33m[test.lox][0m !true
 [33m[stage-4] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mOperand must be a number.
-[33m[your_program] [0m[line 1]
+[33m[your_program] [0mfalse
 [33m[stage-4] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-4] [test-2] [0m[92m✓ Received exit code 70.[0m
+[33m[stage-4] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-4] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-4] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-4] [test-3] [0m[33m[test.lox][0m -false
+[33m[stage-4] [test-3] [0m[33m[test.lox][0m !nil
 [33m[stage-4] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mOperand must be a number.
-[33m[your_program] [0m[line 1]
+[33m[your_program] [0mtrue
 [33m[stage-4] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-4] [test-3] [0m[92m✓ Received exit code 70.[0m
+[33m[stage-4] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-4] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-4] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-4] [test-4] [0m[33m[test.lox][0m -("baz" + "baz")
+[33m[stage-4] [test-4] [0m[33m[test.lox][0m (!!95)
 [33m[stage-4] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mOperand must be a number.
-[33m[your_program] [0m[line 1]
+[33m[your_program] [0mtrue
 [33m[stage-4] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-4] [test-4] [0m[92m✓ Received exit code 70.[0m
+[33m[stage-4] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-4] [0m[92mTest passed.[0m
 
-[33m[stage-3] [0m[94mRunning tests for Stage #3: yu6[0m
+[33m[stage-3] [0m[94mRunning tests for Stage #3: oq9[0m
 [33m[stage-3] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-3] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-3] [test-1] [0m[33m[test.lox][0m 49 * "quz"
+[33m[stage-3] [test-1] [0m[33m[test.lox][0m (true)
 [33m[stage-3] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mOperands must be numbers.
-[33m[your_program] [0m[line 1]
+[33m[your_program] [0mtrue
 [33m[stage-3] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-3] [test-1] [0m[92m✓ Received exit code 70.[0m
+[33m[stage-3] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-3] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-3] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-3] [test-2] [0m[33m[test.lox][0m "bar" / 14
+[33m[stage-3] [test-2] [0m[33m[test.lox][0m (61)
 [33m[stage-3] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mOperands must be numbers.
-[33m[your_program] [0m[line 1]
+[33m[your_program] [0m61
 [33m[stage-3] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-3] [test-2] [0m[92m✓ Received exit code 70.[0m
+[33m[stage-3] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-3] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-3] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-3] [test-3] [0m[33m[test.lox][0m true / true
+[33m[stage-3] [test-3] [0m[33m[test.lox][0m ("foo quz")
 [33m[stage-3] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mOperands must be numbers.
-[33m[your_program] [0m[line 1]
+[33m[your_program] [0mfoo quz
 [33m[stage-3] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-3] [test-3] [0m[92m✓ Received exit code 70.[0m
+[33m[stage-3] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-3] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-3] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-3] [test-4] [0m[33m[test.lox][0m ("bar" + "quz") * ("hello" + "bar")
+[33m[stage-3] [test-4] [0m[33m[test.lox][0m ((true))
 [33m[stage-3] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mOperands must be numbers.
-[33m[your_program] [0m[line 1]
+[33m[your_program] [0mtrue
 [33m[stage-3] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-3] [test-4] [0m[92m✓ Received exit code 70.[0m
+[33m[stage-3] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-3] [0m[92mTest passed.[0m
 
-[33m[stage-2] [0m[94mRunning tests for Stage #2: cq1[0m
+[33m[stage-2] [0m[94mRunning tests for Stage #2: lv1[0m
 [33m[stage-2] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-2] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-2] [test-1] [0m[33m[test.lox][0m "quz" + true
+[33m[stage-2] [test-1] [0m[33m[test.lox][0m 51
 [33m[stage-2] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mOperands must be two numbers or two strings.
-[33m[your_program] [0m[line 1]
+[33m[your_program] [0m51
 [33m[stage-2] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-2] [test-1] [0m[92m✓ Received exit code 70.[0m
+[33m[stage-2] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-2] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-2] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-2] [test-2] [0m[33m[test.lox][0m 50 + "foo" + 37
+[33m[stage-2] [test-2] [0m[33m[test.lox][0m 96.50
 [33m[stage-2] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mOperands must be two numbers or two strings.
-[33m[your_program] [0m[line 1]
+[33m[your_program] [0m96.5
 [33m[stage-2] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-2] [test-2] [0m[92m✓ Received exit code 70.[0m
+[33m[stage-2] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-2] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-2] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-2] [test-3] [0m[33m[test.lox][0m 99 - false
+[33m[stage-2] [test-3] [0m[33m[test.lox][0m "baz world"
 [33m[stage-2] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mOperands must be numbers.
-[33m[your_program] [0m[line 1]
+[33m[your_program] [0mbaz world
 [33m[stage-2] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-2] [test-3] [0m[92m✓ Received exit code 70.[0m
+[33m[stage-2] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-2] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-2] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-2] [test-4] [0m[33m[test.lox][0m false - ("quz" + "world")
+[33m[stage-2] [test-4] [0m[33m[test.lox][0m "24"
 [33m[stage-2] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mOperands must be numbers.
-[33m[your_program] [0m[line 1]
+[33m[your_program] [0m24
 [33m[stage-2] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-2] [test-4] [0m[92m✓ Received exit code 70.[0m
+[33m[stage-2] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-2] [0m[92mTest passed.[0m
 
-[33m[stage-1] [0m[94mRunning tests for Stage #1: ib5[0m
+[33m[stage-1] [0m[94mRunning tests for Stage #1: iz6[0m
 [33m[stage-1] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-1] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-1] [test-1] [0m[33m[test.lox][0m "hello" < true
+[33m[stage-1] [test-1] [0m[33m[test.lox][0m true
 [33m[stage-1] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mOperands must be numbers.
-[33m[your_program] [0m[line 1]
+[33m[your_program] [0mtrue
 [33m[stage-1] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-1] [test-1] [0m[92m✓ Received exit code 70.[0m
+[33m[stage-1] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-1] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-1] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-1] [test-2] [0m[33m[test.lox][0m true <= (61 + 71)
+[33m[stage-1] [test-2] [0m[33m[test.lox][0m false
 [33m[stage-1] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mOperands must be numbers.
-[33m[your_program] [0m[line 1]
+[33m[your_program] [0mfalse
 [33m[stage-1] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-1] [test-2] [0m[92m✓ Received exit code 70.[0m
+[33m[stage-1] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-1] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-1] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-1] [test-3] [0m[33m[test.lox][0m 97 > ("baz" + "world")
+[33m[stage-1] [test-3] [0m[33m[test.lox][0m nil
 [33m[stage-1] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mOperands must be numbers.
-[33m[your_program] [0m[line 1]
+[33m[your_program] [0mnil
 [33m[stage-1] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-1] [test-3] [0m[92m✓ Received exit code 70.[0m
-[33m[stage-1] [test-4] [0m[94mRunning test case: 4[0m
-[33m[stage-1] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-1] [test-4] [0m[33m[test.lox][0m false >= false
-[33m[stage-1] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mOperands must be numbers.
-[33m[your_program] [0m[line 1]
-[33m[stage-1] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-1] [test-4] [0m[92m✓ Received exit code 70.[0m
+[33m[stage-1] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-1] [0m[92mTest passed.[0m

--- a/internal/test_helpers/fixtures/pass_evaluating
+++ b/internal/test_helpers/fixtures/pass_evaluating
@@ -151,30 +151,30 @@ Debug = true
 [33m[stage-8] [0m[94mRunning tests for Stage #8: jy2[0m
 [33m[stage-8] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-8] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-8] [test-1] [0m[33m[test.lox][0m 10 - 20
+[33m[stage-8] [test-1] [0m[33m[test.lox][0m 12 - 53
 [33m[stage-8] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m-10
+[33m[your_program] [0m-41
 [33m[stage-8] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-8] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-8] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-8] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-8] [test-2] [0m[33m[test.lox][0m 23 + 27 - 20
+[33m[stage-8] [test-2] [0m[33m[test.lox][0m 30 + 19 - 96
 [33m[stage-8] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m30
+[33m[your_program] [0m-47
 [33m[stage-8] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-8] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-8] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-8] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-8] [test-3] [0m[33m[test.lox][0m 2 + 23 - (-(25 - 50))
+[33m[stage-8] [test-3] [0m[33m[test.lox][0m 42 + 53 - (-(67 - 43))
 [33m[stage-8] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m0
+[33m[your_program] [0m119
 [33m[stage-8] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-8] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-8] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-8] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-8] [test-4] [0m[33m[test.lox][0m -(-4 + 8) * (6 * 2) / (12 + 12)
+[33m[stage-8] [test-4] [0m[33m[test.lox][0m -(-15 + 70) * (99 * 91) / (1 + 4)
 [33m[stage-8] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m-2
+[33m[your_program] [0m-99099
 [33m[stage-8] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-8] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-8] [0m[92mTest passed.[0m
@@ -182,30 +182,30 @@ Debug = true
 [33m[stage-7] [0m[94mRunning tests for Stage #7: jx8[0m
 [33m[stage-7] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-7] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-7] [test-1] [0m[33m[test.lox][0m "foo" + "hello"
+[33m[stage-7] [test-1] [0m[33m[test.lox][0m "hello" + "hello"
 [33m[stage-7] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mfoohello
+[33m[your_program] [0mhellohello
 [33m[stage-7] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-7] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-7] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-7] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-7] [test-2] [0m[33m[test.lox][0m "hello" + "89"
+[33m[stage-7] [test-2] [0m[33m[test.lox][0m "bar" + "80"
 [33m[stage-7] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mhello89
+[33m[your_program] [0mbar80
 [33m[stage-7] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-7] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-7] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-7] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-7] [test-3] [0m[33m[test.lox][0m "hello" + "bar" + "bar"
+[33m[stage-7] [test-3] [0m[33m[test.lox][0m "quz" + "baz" + "bar"
 [33m[stage-7] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mhellobarbar
+[33m[your_program] [0mquzbazbar
 [33m[stage-7] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-7] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-7] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-7] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-7] [test-4] [0m[33m[test.lox][0m "world" + "bar" + "quz" + "bar"
+[33m[stage-7] [test-4] [0m[33m[test.lox][0m "baz" + "world" + "quz" + "bar"
 [33m[stage-7] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mworldbarquzbar
+[33m[your_program] [0mbazworldquzbar
 [33m[stage-7] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-7] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-7] [0m[92mTest passed.[0m
@@ -213,30 +213,30 @@ Debug = true
 [33m[stage-6] [0m[94mRunning tests for Stage #6: et4[0m
 [33m[stage-6] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-6] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-6] [test-1] [0m[33m[test.lox][0m 52 > -141
+[33m[stage-6] [test-1] [0m[33m[test.lox][0m 44 > -129
 [33m[stage-6] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
 [33m[your_program] [0mtrue
 [33m[stage-6] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-6] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-6] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-6] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-6] [test-2] [0m[33m[test.lox][0m 52 <= 192
+[33m[stage-6] [test-2] [0m[33m[test.lox][0m 44 <= 148
 [33m[stage-6] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
 [33m[your_program] [0mtrue
 [33m[stage-6] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-6] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-6] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-6] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-6] [test-3] [0m[33m[test.lox][0m 51 >= 51
+[33m[stage-6] [test-3] [0m[33m[test.lox][0m 19 >= 19
 [33m[stage-6] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
 [33m[your_program] [0mtrue
 [33m[stage-6] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-6] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-6] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-6] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-6] [test-4] [0m[33m[test.lox][0m (72 - 50) >= -(26 / 13 + 8)
+[33m[stage-6] [test-4] [0m[33m[test.lox][0m (45 - 99) >= -(88 / 44 + 35)
 [33m[stage-6] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mtrue
+[33m[your_program] [0mfalse
 [33m[stage-6] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-6] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-6] [0m[92mTest passed.[0m
@@ -244,28 +244,28 @@ Debug = true
 [33m[stage-5] [0m[94mRunning tests for Stage #5: hw7[0m
 [33m[stage-5] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-5] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-5] [test-1] [0m[33m[test.lox][0m "world" != "foo"
+[33m[stage-5] [test-1] [0m[33m[test.lox][0m "quz" != "bar"
 [33m[stage-5] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
 [33m[your_program] [0mtrue
 [33m[stage-5] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-5] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-5] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-5] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-5] [test-2] [0m[33m[test.lox][0m "world" == "world"
+[33m[stage-5] [test-2] [0m[33m[test.lox][0m "quz" == "quz"
 [33m[stage-5] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
 [33m[your_program] [0mtrue
 [33m[stage-5] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-5] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-5] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-5] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-5] [test-3] [0m[33m[test.lox][0m 68 == "68"
+[33m[stage-5] [test-3] [0m[33m[test.lox][0m 71 == "71"
 [33m[stage-5] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
 [33m[your_program] [0mfalse
 [33m[stage-5] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-5] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-5] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-5] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-5] [test-4] [0m[33m[test.lox][0m 142 == (93 + 49)
+[33m[stage-5] [test-4] [0m[33m[test.lox][0m 86 == (62 + 24)
 [33m[stage-5] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
 [33m[your_program] [0mtrue
 [33m[stage-5] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
@@ -275,7 +275,7 @@ Debug = true
 [33m[stage-4] [0m[94mRunning tests for Stage #4: gj9[0m
 [33m[stage-4] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-4] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-4] [test-1] [0m[33m[test.lox][0m -"hello"
+[33m[stage-4] [test-1] [0m[33m[test.lox][0m -"world"
 [33m[stage-4] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
 [33m[your_program] [0mOperand must be a number.
 [33m[your_program] [0m[line 1]
@@ -299,7 +299,7 @@ Debug = true
 [33m[stage-4] [test-3] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-4] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-4] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-4] [test-4] [0m[33m[test.lox][0m -("foo" + "quz")
+[33m[stage-4] [test-4] [0m[33m[test.lox][0m -("baz" + "baz")
 [33m[stage-4] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
 [33m[your_program] [0mOperand must be a number.
 [33m[your_program] [0m[line 1]
@@ -310,7 +310,7 @@ Debug = true
 [33m[stage-3] [0m[94mRunning tests for Stage #3: yu6[0m
 [33m[stage-3] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-3] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-3] [test-1] [0m[33m[test.lox][0m 83 * "baz"
+[33m[stage-3] [test-1] [0m[33m[test.lox][0m 49 * "quz"
 [33m[stage-3] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
 [33m[your_program] [0mOperands must be numbers.
 [33m[your_program] [0m[line 1]
@@ -318,7 +318,7 @@ Debug = true
 [33m[stage-3] [test-1] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-3] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-3] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-3] [test-2] [0m[33m[test.lox][0m "world" / 58
+[33m[stage-3] [test-2] [0m[33m[test.lox][0m "bar" / 14
 [33m[stage-3] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
 [33m[your_program] [0mOperands must be numbers.
 [33m[your_program] [0m[line 1]
@@ -326,7 +326,7 @@ Debug = true
 [33m[stage-3] [test-2] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-3] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-3] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-3] [test-3] [0m[33m[test.lox][0m false / false
+[33m[stage-3] [test-3] [0m[33m[test.lox][0m true / true
 [33m[stage-3] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
 [33m[your_program] [0mOperands must be numbers.
 [33m[your_program] [0m[line 1]
@@ -334,7 +334,7 @@ Debug = true
 [33m[stage-3] [test-3] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-3] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-3] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-3] [test-4] [0m[33m[test.lox][0m ("baz" + "quz") * ("hello" + "world")
+[33m[stage-3] [test-4] [0m[33m[test.lox][0m ("bar" + "quz") * ("hello" + "bar")
 [33m[stage-3] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
 [33m[your_program] [0mOperands must be numbers.
 [33m[your_program] [0m[line 1]
@@ -345,7 +345,7 @@ Debug = true
 [33m[stage-2] [0m[94mRunning tests for Stage #2: cq1[0m
 [33m[stage-2] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-2] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-2] [test-1] [0m[33m[test.lox][0m "world" + false
+[33m[stage-2] [test-1] [0m[33m[test.lox][0m "quz" + true
 [33m[stage-2] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
 [33m[your_program] [0mOperands must be two numbers or two strings.
 [33m[your_program] [0m[line 1]
@@ -353,7 +353,7 @@ Debug = true
 [33m[stage-2] [test-1] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-2] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-2] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-2] [test-2] [0m[33m[test.lox][0m 85 + "baz" + 33
+[33m[stage-2] [test-2] [0m[33m[test.lox][0m 50 + "foo" + 37
 [33m[stage-2] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
 [33m[your_program] [0mOperands must be two numbers or two strings.
 [33m[your_program] [0m[line 1]
@@ -361,7 +361,7 @@ Debug = true
 [33m[stage-2] [test-2] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-2] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-2] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-2] [test-3] [0m[33m[test.lox][0m 19 - true
+[33m[stage-2] [test-3] [0m[33m[test.lox][0m 99 - false
 [33m[stage-2] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
 [33m[your_program] [0mOperands must be numbers.
 [33m[your_program] [0m[line 1]
@@ -369,7 +369,7 @@ Debug = true
 [33m[stage-2] [test-3] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-2] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-2] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-2] [test-4] [0m[33m[test.lox][0m false - ("bar" + "foo")
+[33m[stage-2] [test-4] [0m[33m[test.lox][0m false - ("quz" + "world")
 [33m[stage-2] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
 [33m[your_program] [0mOperands must be numbers.
 [33m[your_program] [0m[line 1]
@@ -380,7 +380,7 @@ Debug = true
 [33m[stage-1] [0m[94mRunning tests for Stage #1: ib5[0m
 [33m[stage-1] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-1] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-1] [test-1] [0m[33m[test.lox][0m "bar" < false
+[33m[stage-1] [test-1] [0m[33m[test.lox][0m "hello" < true
 [33m[stage-1] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
 [33m[your_program] [0mOperands must be numbers.
 [33m[your_program] [0m[line 1]
@@ -388,7 +388,7 @@ Debug = true
 [33m[stage-1] [test-1] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-1] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-1] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-1] [test-2] [0m[33m[test.lox][0m true <= (75 + 57)
+[33m[stage-1] [test-2] [0m[33m[test.lox][0m true <= (61 + 71)
 [33m[stage-1] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
 [33m[your_program] [0mOperands must be numbers.
 [33m[your_program] [0m[line 1]
@@ -396,7 +396,7 @@ Debug = true
 [33m[stage-1] [test-2] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-1] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-1] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-1] [test-3] [0m[33m[test.lox][0m 93 > ("world" + "hello")
+[33m[stage-1] [test-3] [0m[33m[test.lox][0m 97 > ("baz" + "world")
 [33m[stage-1] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
 [33m[your_program] [0mOperands must be numbers.
 [33m[your_program] [0m[line 1]
@@ -404,7 +404,7 @@ Debug = true
 [33m[stage-1] [test-3] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-1] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-1] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-1] [test-4] [0m[33m[test.lox][0m true >= true
+[33m[stage-1] [test-4] [0m[33m[test.lox][0m false >= false
 [33m[stage-1] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
 [33m[your_program] [0mOperands must be numbers.
 [33m[your_program] [0m[line 1]

--- a/internal/test_helpers/fixtures/pass_evaluating
+++ b/internal/test_helpers/fixtures/pass_evaluating
@@ -1,118 +1,413 @@
 Debug = true
 
-[33m[stage-4] [0m[94mRunning tests for Stage #4: iz6[0m
+[33m[stage-13] [0m[94mRunning tests for Stage #13: iz6[0m
+[33m[stage-13] [test-1] [0m[94mRunning test case: 1[0m
+[33m[stage-13] [test-1] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-13] [test-1] [0m[33m[test.lox][0m true
+[33m[stage-13] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
+[33m[your_program] [0mtrue
+[33m[stage-13] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
+[33m[stage-13] [test-1] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-13] [test-2] [0m[94mRunning test case: 2[0m
+[33m[stage-13] [test-2] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-13] [test-2] [0m[33m[test.lox][0m false
+[33m[stage-13] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
+[33m[your_program] [0mfalse
+[33m[stage-13] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
+[33m[stage-13] [test-2] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-13] [test-3] [0m[94mRunning test case: 3[0m
+[33m[stage-13] [test-3] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-13] [test-3] [0m[33m[test.lox][0m nil
+[33m[stage-13] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
+[33m[your_program] [0mnil
+[33m[stage-13] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
+[33m[stage-13] [test-3] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-13] [0m[92mTest passed.[0m
+
+[33m[stage-12] [0m[94mRunning tests for Stage #12: lv1[0m
+[33m[stage-12] [test-1] [0m[94mRunning test case: 1[0m
+[33m[stage-12] [test-1] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-12] [test-1] [0m[33m[test.lox][0m 73
+[33m[stage-12] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
+[33m[your_program] [0m73
+[33m[stage-12] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
+[33m[stage-12] [test-1] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-12] [test-2] [0m[94mRunning test case: 2[0m
+[33m[stage-12] [test-2] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-12] [test-2] [0m[33m[test.lox][0m 61.38
+[33m[stage-12] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
+[33m[your_program] [0m61.38
+[33m[stage-12] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
+[33m[stage-12] [test-2] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-12] [test-3] [0m[94mRunning test case: 3[0m
+[33m[stage-12] [test-3] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-12] [test-3] [0m[33m[test.lox][0m "foo bar"
+[33m[stage-12] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
+[33m[your_program] [0mfoo bar
+[33m[stage-12] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
+[33m[stage-12] [test-3] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-12] [test-4] [0m[94mRunning test case: 4[0m
+[33m[stage-12] [test-4] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-12] [test-4] [0m[33m[test.lox][0m "61"
+[33m[stage-12] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
+[33m[your_program] [0m61
+[33m[stage-12] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
+[33m[stage-12] [test-4] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-12] [0m[92mTest passed.[0m
+
+[33m[stage-11] [0m[94mRunning tests for Stage #11: oq9[0m
+[33m[stage-11] [test-1] [0m[94mRunning test case: 1[0m
+[33m[stage-11] [test-1] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-11] [test-1] [0m[33m[test.lox][0m (true)
+[33m[stage-11] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
+[33m[your_program] [0mtrue
+[33m[stage-11] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
+[33m[stage-11] [test-1] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-11] [test-2] [0m[94mRunning test case: 2[0m
+[33m[stage-11] [test-2] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-11] [test-2] [0m[33m[test.lox][0m (44)
+[33m[stage-11] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
+[33m[your_program] [0m44
+[33m[stage-11] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
+[33m[stage-11] [test-2] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-11] [test-3] [0m[94mRunning test case: 3[0m
+[33m[stage-11] [test-3] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-11] [test-3] [0m[33m[test.lox][0m ("world hello")
+[33m[stage-11] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
+[33m[your_program] [0mworld hello
+[33m[stage-11] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
+[33m[stage-11] [test-3] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-11] [test-4] [0m[94mRunning test case: 4[0m
+[33m[stage-11] [test-4] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-11] [test-4] [0m[33m[test.lox][0m ((false))
+[33m[stage-11] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
+[33m[your_program] [0mfalse
+[33m[stage-11] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
+[33m[stage-11] [test-4] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-11] [0m[92mTest passed.[0m
+
+[33m[stage-10] [0m[94mRunning tests for Stage #10: dc1[0m
+[33m[stage-10] [test-1] [0m[94mRunning test case: 1[0m
+[33m[stage-10] [test-1] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-10] [test-1] [0m[33m[test.lox][0m -70
+[33m[stage-10] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
+[33m[your_program] [0m-70
+[33m[stage-10] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
+[33m[stage-10] [test-1] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-10] [test-2] [0m[94mRunning test case: 2[0m
+[33m[stage-10] [test-2] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-10] [test-2] [0m[33m[test.lox][0m !false
+[33m[stage-10] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
+[33m[your_program] [0mtrue
+[33m[stage-10] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
+[33m[stage-10] [test-2] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-10] [test-3] [0m[94mRunning test case: 3[0m
+[33m[stage-10] [test-3] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-10] [test-3] [0m[33m[test.lox][0m !nil
+[33m[stage-10] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
+[33m[your_program] [0mtrue
+[33m[stage-10] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
+[33m[stage-10] [test-3] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-10] [test-4] [0m[94mRunning test case: 4[0m
+[33m[stage-10] [test-4] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-10] [test-4] [0m[33m[test.lox][0m (!!75)
+[33m[stage-10] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
+[33m[your_program] [0mtrue
+[33m[stage-10] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
+[33m[stage-10] [test-4] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-10] [0m[92mTest passed.[0m
+
+[33m[stage-9] [0m[94mRunning tests for Stage #9: bp3[0m
+[33m[stage-9] [test-1] [0m[94mRunning test case: 1[0m
+[33m[stage-9] [test-1] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-9] [test-1] [0m[33m[test.lox][0m 90 * 20
+[33m[stage-9] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
+[33m[your_program] [0m1800
+[33m[stage-9] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
+[33m[stage-9] [test-1] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-9] [test-2] [0m[94mRunning test case: 2[0m
+[33m[stage-9] [test-2] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-9] [test-2] [0m[33m[test.lox][0m 16 / 5
+[33m[stage-9] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
+[33m[your_program] [0m3.2
+[33m[stage-9] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
+[33m[stage-9] [test-2] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-9] [test-3] [0m[94mRunning test case: 3[0m
+[33m[stage-9] [test-3] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-9] [test-3] [0m[33m[test.lox][0m 7 * 4 / 7 / 1
+[33m[stage-9] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
+[33m[your_program] [0m4
+[33m[stage-9] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
+[33m[stage-9] [test-3] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-9] [test-4] [0m[94mRunning test case: 4[0m
+[33m[stage-9] [test-4] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-9] [test-4] [0m[33m[test.lox][0m (18 * 4 / (3 * 6))
+[33m[stage-9] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
+[33m[your_program] [0m4
+[33m[stage-9] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
+[33m[stage-9] [test-4] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-9] [0m[92mTest passed.[0m
+
+[33m[stage-8] [0m[94mRunning tests for Stage #8: jy2[0m
+[33m[stage-8] [test-1] [0m[94mRunning test case: 1[0m
+[33m[stage-8] [test-1] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-8] [test-1] [0m[33m[test.lox][0m 10 - 20
+[33m[stage-8] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
+[33m[your_program] [0m-10
+[33m[stage-8] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
+[33m[stage-8] [test-1] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-8] [test-2] [0m[94mRunning test case: 2[0m
+[33m[stage-8] [test-2] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-8] [test-2] [0m[33m[test.lox][0m 23 + 27 - 20
+[33m[stage-8] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
+[33m[your_program] [0m30
+[33m[stage-8] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
+[33m[stage-8] [test-2] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-8] [test-3] [0m[94mRunning test case: 3[0m
+[33m[stage-8] [test-3] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-8] [test-3] [0m[33m[test.lox][0m 2 + 23 - (-(25 - 50))
+[33m[stage-8] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
+[33m[your_program] [0m0
+[33m[stage-8] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
+[33m[stage-8] [test-3] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-8] [test-4] [0m[94mRunning test case: 4[0m
+[33m[stage-8] [test-4] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-8] [test-4] [0m[33m[test.lox][0m -(-4 + 8) * (6 * 2) / (12 + 12)
+[33m[stage-8] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
+[33m[your_program] [0m-2
+[33m[stage-8] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
+[33m[stage-8] [test-4] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-8] [0m[92mTest passed.[0m
+
+[33m[stage-7] [0m[94mRunning tests for Stage #7: jx8[0m
+[33m[stage-7] [test-1] [0m[94mRunning test case: 1[0m
+[33m[stage-7] [test-1] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-7] [test-1] [0m[33m[test.lox][0m "foo" + "hello"
+[33m[stage-7] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
+[33m[your_program] [0mfoohello
+[33m[stage-7] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
+[33m[stage-7] [test-1] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-7] [test-2] [0m[94mRunning test case: 2[0m
+[33m[stage-7] [test-2] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-7] [test-2] [0m[33m[test.lox][0m "hello" + "89"
+[33m[stage-7] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
+[33m[your_program] [0mhello89
+[33m[stage-7] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
+[33m[stage-7] [test-2] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-7] [test-3] [0m[94mRunning test case: 3[0m
+[33m[stage-7] [test-3] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-7] [test-3] [0m[33m[test.lox][0m "hello" + "bar" + "bar"
+[33m[stage-7] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
+[33m[your_program] [0mhellobarbar
+[33m[stage-7] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
+[33m[stage-7] [test-3] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-7] [test-4] [0m[94mRunning test case: 4[0m
+[33m[stage-7] [test-4] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-7] [test-4] [0m[33m[test.lox][0m "world" + "bar" + "quz" + "bar"
+[33m[stage-7] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
+[33m[your_program] [0mworldbarquzbar
+[33m[stage-7] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
+[33m[stage-7] [test-4] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-7] [0m[92mTest passed.[0m
+
+[33m[stage-6] [0m[94mRunning tests for Stage #6: et4[0m
+[33m[stage-6] [test-1] [0m[94mRunning test case: 1[0m
+[33m[stage-6] [test-1] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-6] [test-1] [0m[33m[test.lox][0m 52 > -141
+[33m[stage-6] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
+[33m[your_program] [0mtrue
+[33m[stage-6] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
+[33m[stage-6] [test-1] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-6] [test-2] [0m[94mRunning test case: 2[0m
+[33m[stage-6] [test-2] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-6] [test-2] [0m[33m[test.lox][0m 52 <= 192
+[33m[stage-6] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
+[33m[your_program] [0mtrue
+[33m[stage-6] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
+[33m[stage-6] [test-2] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-6] [test-3] [0m[94mRunning test case: 3[0m
+[33m[stage-6] [test-3] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-6] [test-3] [0m[33m[test.lox][0m 51 >= 51
+[33m[stage-6] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
+[33m[your_program] [0mtrue
+[33m[stage-6] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
+[33m[stage-6] [test-3] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-6] [test-4] [0m[94mRunning test case: 4[0m
+[33m[stage-6] [test-4] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-6] [test-4] [0m[33m[test.lox][0m (72 - 50) >= -(26 / 13 + 8)
+[33m[stage-6] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
+[33m[your_program] [0mtrue
+[33m[stage-6] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
+[33m[stage-6] [test-4] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-6] [0m[92mTest passed.[0m
+
+[33m[stage-5] [0m[94mRunning tests for Stage #5: hw7[0m
+[33m[stage-5] [test-1] [0m[94mRunning test case: 1[0m
+[33m[stage-5] [test-1] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-5] [test-1] [0m[33m[test.lox][0m "world" != "foo"
+[33m[stage-5] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
+[33m[your_program] [0mtrue
+[33m[stage-5] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
+[33m[stage-5] [test-1] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-5] [test-2] [0m[94mRunning test case: 2[0m
+[33m[stage-5] [test-2] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-5] [test-2] [0m[33m[test.lox][0m "world" == "world"
+[33m[stage-5] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
+[33m[your_program] [0mtrue
+[33m[stage-5] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
+[33m[stage-5] [test-2] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-5] [test-3] [0m[94mRunning test case: 3[0m
+[33m[stage-5] [test-3] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-5] [test-3] [0m[33m[test.lox][0m 68 == "68"
+[33m[stage-5] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
+[33m[your_program] [0mfalse
+[33m[stage-5] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
+[33m[stage-5] [test-3] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-5] [test-4] [0m[94mRunning test case: 4[0m
+[33m[stage-5] [test-4] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-5] [test-4] [0m[33m[test.lox][0m 142 == (93 + 49)
+[33m[stage-5] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
+[33m[your_program] [0mtrue
+[33m[stage-5] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
+[33m[stage-5] [test-4] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-5] [0m[92mTest passed.[0m
+
+[33m[stage-4] [0m[94mRunning tests for Stage #4: gj9[0m
 [33m[stage-4] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-4] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-4] [test-1] [0m[33m[test.lox][0m true
+[33m[stage-4] [test-1] [0m[33m[test.lox][0m -"hello"
 [33m[stage-4] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mtrue
+[33m[your_program] [0mOperand must be a number.
+[33m[your_program] [0m[line 1]
 [33m[stage-4] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-4] [test-1] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-4] [test-1] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-4] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-4] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-4] [test-2] [0m[33m[test.lox][0m false
+[33m[stage-4] [test-2] [0m[33m[test.lox][0m -true
 [33m[stage-4] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mfalse
+[33m[your_program] [0mOperand must be a number.
+[33m[your_program] [0m[line 1]
 [33m[stage-4] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-4] [test-2] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-4] [test-2] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-4] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-4] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-4] [test-3] [0m[33m[test.lox][0m nil
+[33m[stage-4] [test-3] [0m[33m[test.lox][0m -false
 [33m[stage-4] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mnil
+[33m[your_program] [0mOperand must be a number.
+[33m[your_program] [0m[line 1]
 [33m[stage-4] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-4] [test-3] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-4] [test-3] [0m[92m✓ Received exit code 70.[0m
+[33m[stage-4] [test-4] [0m[94mRunning test case: 4[0m
+[33m[stage-4] [test-4] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-4] [test-4] [0m[33m[test.lox][0m -("foo" + "quz")
+[33m[stage-4] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
+[33m[your_program] [0mOperand must be a number.
+[33m[your_program] [0m[line 1]
+[33m[stage-4] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
+[33m[stage-4] [test-4] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-4] [0m[92mTest passed.[0m
 
-[33m[stage-3] [0m[94mRunning tests for Stage #3: lv1[0m
+[33m[stage-3] [0m[94mRunning tests for Stage #3: yu6[0m
 [33m[stage-3] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-3] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-3] [test-1] [0m[33m[test.lox][0m 73
+[33m[stage-3] [test-1] [0m[33m[test.lox][0m 83 * "baz"
 [33m[stage-3] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m73
+[33m[your_program] [0mOperands must be numbers.
+[33m[your_program] [0m[line 1]
 [33m[stage-3] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-3] [test-1] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-3] [test-1] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-3] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-3] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-3] [test-2] [0m[33m[test.lox][0m 61.38
+[33m[stage-3] [test-2] [0m[33m[test.lox][0m "world" / 58
 [33m[stage-3] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m61.38
+[33m[your_program] [0mOperands must be numbers.
+[33m[your_program] [0m[line 1]
 [33m[stage-3] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-3] [test-2] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-3] [test-2] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-3] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-3] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-3] [test-3] [0m[33m[test.lox][0m "foo bar"
+[33m[stage-3] [test-3] [0m[33m[test.lox][0m false / false
 [33m[stage-3] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mfoo bar
+[33m[your_program] [0mOperands must be numbers.
+[33m[your_program] [0m[line 1]
 [33m[stage-3] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-3] [test-3] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-3] [test-3] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-3] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-3] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-3] [test-4] [0m[33m[test.lox][0m "61"
+[33m[stage-3] [test-4] [0m[33m[test.lox][0m ("baz" + "quz") * ("hello" + "world")
 [33m[stage-3] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m61
+[33m[your_program] [0mOperands must be numbers.
+[33m[your_program] [0m[line 1]
 [33m[stage-3] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-3] [test-4] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-3] [test-4] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-3] [0m[92mTest passed.[0m
 
-[33m[stage-2] [0m[94mRunning tests for Stage #2: oq9[0m
+[33m[stage-2] [0m[94mRunning tests for Stage #2: cq1[0m
 [33m[stage-2] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-2] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-2] [test-1] [0m[33m[test.lox][0m (true)
+[33m[stage-2] [test-1] [0m[33m[test.lox][0m "world" + false
 [33m[stage-2] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mtrue
+[33m[your_program] [0mOperands must be two numbers or two strings.
+[33m[your_program] [0m[line 1]
 [33m[stage-2] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-2] [test-1] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-2] [test-1] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-2] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-2] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-2] [test-2] [0m[33m[test.lox][0m (44)
+[33m[stage-2] [test-2] [0m[33m[test.lox][0m 85 + "baz" + 33
 [33m[stage-2] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m44
+[33m[your_program] [0mOperands must be two numbers or two strings.
+[33m[your_program] [0m[line 1]
 [33m[stage-2] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-2] [test-2] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-2] [test-2] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-2] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-2] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-2] [test-3] [0m[33m[test.lox][0m ("world hello")
+[33m[stage-2] [test-3] [0m[33m[test.lox][0m 19 - true
 [33m[stage-2] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mworld hello
+[33m[your_program] [0mOperands must be numbers.
+[33m[your_program] [0m[line 1]
 [33m[stage-2] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-2] [test-3] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-2] [test-3] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-2] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-2] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-2] [test-4] [0m[33m[test.lox][0m ((false))
+[33m[stage-2] [test-4] [0m[33m[test.lox][0m false - ("bar" + "foo")
 [33m[stage-2] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mfalse
+[33m[your_program] [0mOperands must be numbers.
+[33m[your_program] [0m[line 1]
 [33m[stage-2] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-2] [test-4] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-2] [test-4] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-2] [0m[92mTest passed.[0m
 
-[33m[stage-1] [0m[94mRunning tests for Stage #1: dc1[0m
+[33m[stage-1] [0m[94mRunning tests for Stage #1: ib5[0m
 [33m[stage-1] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-1] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-1] [test-1] [0m[33m[test.lox][0m -70
+[33m[stage-1] [test-1] [0m[33m[test.lox][0m "bar" < false
 [33m[stage-1] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m-70
+[33m[your_program] [0mOperands must be numbers.
+[33m[your_program] [0m[line 1]
 [33m[stage-1] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-1] [test-1] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-1] [test-1] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-1] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-1] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-1] [test-2] [0m[33m[test.lox][0m !false
+[33m[stage-1] [test-2] [0m[33m[test.lox][0m true <= (75 + 57)
 [33m[stage-1] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mtrue
+[33m[your_program] [0mOperands must be numbers.
+[33m[your_program] [0m[line 1]
 [33m[stage-1] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-1] [test-2] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-1] [test-2] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-1] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-1] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-1] [test-3] [0m[33m[test.lox][0m !nil
+[33m[stage-1] [test-3] [0m[33m[test.lox][0m 93 > ("world" + "hello")
 [33m[stage-1] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mtrue
+[33m[your_program] [0mOperands must be numbers.
+[33m[your_program] [0m[line 1]
 [33m[stage-1] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-1] [test-3] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-1] [test-3] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-1] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-1] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-1] [test-4] [0m[33m[test.lox][0m (!!75)
+[33m[stage-1] [test-4] [0m[33m[test.lox][0m true >= true
 [33m[stage-1] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mtrue
+[33m[your_program] [0mOperands must be numbers.
+[33m[your_program] [0m[line 1]
 [33m[stage-1] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-1] [test-4] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-1] [test-4] [0m[92m✓ Received exit code 70.[0m
 [33m[stage-1] [0m[92mTest passed.[0m

--- a/internal/test_helpers/fixtures/pass_parsing
+++ b/internal/test_helpers/fixtures/pass_parsing
@@ -1,291 +1,291 @@
 Debug = true
 
-[33m[stage-10] [0m[94mRunning tests for Stage #10: sc2[0m
+[33m[stage-10] [0m[94mRunning tests for Stage #10: wz8[0m
 [33m[stage-10] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-10] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-10] [test-1] [0m[33m[test.lox][0m true
+[33m[stage-10] [test-1] [0m[33m[test.lox][0m "foo
 [33m[stage-10] [test-1] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0mtrue
+[33m[your_program] [0m[line 1] Error: Unterminated string.
+[33m[your_program] [0m[line 1] Error at end: Expect expression.
 [33m[stage-10] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-10] [test-1] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-10] [test-1] [0m[92m✓ Received exit code 65.[0m
 [33m[stage-10] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-10] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-10] [test-2] [0m[33m[test.lox][0m false
+[33m[stage-10] [test-2] [0m[33m[test.lox][0m (49 +)
 [33m[stage-10] [test-2] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0mfalse
+[33m[your_program] [0m[line 1] Error at ')': Expect expression.
 [33m[stage-10] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-10] [test-2] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-10] [test-2] [0m[92m✓ Received exit code 65.[0m
 [33m[stage-10] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-10] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-10] [test-3] [0m[33m[test.lox][0m nil
+[33m[stage-10] [test-3] [0m[33m[test.lox][0m +
 [33m[stage-10] [test-3] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0mnil
+[33m[your_program] [0m[line 1] Error at '+': Expect expression.
 [33m[stage-10] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-10] [test-3] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-10] [test-3] [0m[92m✓ Received exit code 65.[0m
 [33m[stage-10] [0m[92mTest passed.[0m
 
-[33m[stage-9] [0m[94mRunning tests for Stage #9: ra8[0m
+[33m[stage-9] [0m[94mRunning tests for Stage #9: ht8[0m
 [33m[stage-9] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-9] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-9] [test-1] [0m[33m[test.lox][0m 73
+[33m[stage-9] [test-1] [0m[33m[test.lox][0m "foo"!="hello"
 [33m[stage-9] [test-1] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m73.0
+[33m[your_program] [0m(!= foo hello)
 [33m[stage-9] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-9] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-9] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-9] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-9] [test-2] [0m[33m[test.lox][0m 0.0
+[33m[stage-9] [test-2] [0m[33m[test.lox][0m "bar" == "bar"
 [33m[stage-9] [test-2] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m0.0
+[33m[your_program] [0m(== bar bar)
 [33m[stage-9] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-9] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-9] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-9] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-9] [test-3] [0m[33m[test.lox][0m 61.38
+[33m[stage-9] [test-3] [0m[33m[test.lox][0m 32 == 56
 [33m[stage-9] [test-3] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m61.38
+[33m[your_program] [0m(== 32.0 56.0)
 [33m[stage-9] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-9] [test-3] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-9] [test-4] [0m[94mRunning test case: 4[0m
+[33m[stage-9] [test-4] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-9] [test-4] [0m[33m[test.lox][0m (70 != 33) == ((-92 + 75) >= (78 * 90))
+[33m[stage-9] [test-4] [0m[94m$ ./your_program.sh parse test.lox[0m
+[33m[your_program] [0m(== (group (!= 70.0 33.0)) (group (>= (group (+ (- 92.0) 75.0)) (group (* 78.0 90.0)))))
+[33m[stage-9] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
+[33m[stage-9] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-9] [0m[92mTest passed.[0m
 
-[33m[stage-8] [0m[94mRunning tests for Stage #8: th5[0m
+[33m[stage-8] [0m[94mRunning tests for Stage #8: uh4[0m
 [33m[stage-8] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-8] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-8] [test-1] [0m[33m[test.lox][0m "foo bar"
+[33m[stage-8] [test-1] [0m[33m[test.lox][0m 20 > 4
 [33m[stage-8] [test-1] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0mfoo bar
+[33m[your_program] [0m(> 20.0 4.0)
 [33m[stage-8] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-8] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-8] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-8] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-8] [test-2] [0m[33m[test.lox][0m "'world'"
+[33m[stage-8] [test-2] [0m[33m[test.lox][0m 16 <= 36
 [33m[stage-8] [test-2] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m'world'
+[33m[your_program] [0m(<= 16.0 36.0)
 [33m[stage-8] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-8] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-8] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-8] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-8] [test-3] [0m[33m[test.lox][0m "// hello"
+[33m[stage-8] [test-3] [0m[33m[test.lox][0m 20 < 36 < 52
 [33m[stage-8] [test-3] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m// hello
+[33m[your_program] [0m(< (< 20.0 36.0) 52.0)
 [33m[stage-8] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-8] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-8] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-8] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-8] [test-4] [0m[33m[test.lox][0m "92"
+[33m[stage-8] [test-4] [0m[33m[test.lox][0m (12 - 53) >= -(30 / 19 + 96)
 [33m[stage-8] [test-4] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m92
+[33m[your_program] [0m(>= (group (- 12.0 53.0)) (- (group (+ (/ 30.0 19.0) 96.0))))
 [33m[stage-8] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-8] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-8] [0m[92mTest passed.[0m
 
-[33m[stage-7] [0m[94mRunning tests for Stage #7: xe6[0m
+[33m[stage-7] [0m[94mRunning tests for Stage #7: yf2[0m
 [33m[stage-7] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-7] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-7] [test-1] [0m[33m[test.lox][0m ("foo")
+[33m[stage-7] [test-1] [0m[33m[test.lox][0m "hello" + "world"
 [33m[stage-7] [test-1] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(group foo)
+[33m[your_program] [0m(+ hello world)
 [33m[stage-7] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-7] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-7] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-7] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-7] [test-2] [0m[33m[test.lox][0m ((true))
+[33m[stage-7] [test-2] [0m[33m[test.lox][0m 42 - 53 - 67
 [33m[stage-7] [test-2] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(group (group true))
+[33m[your_program] [0m(- (- 42.0 53.0) 67.0)
 [33m[stage-7] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-7] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-7] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-7] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-7] [test-3] [0m[33m[test.lox][0m ()
+[33m[stage-7] [test-3] [0m[33m[test.lox][0m 43 + 15 - 70
 [33m[stage-7] [test-3] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m[line 1] Error at ')': Expect expression.
+[33m[your_program] [0m(- (+ 43.0 15.0) 70.0)
 [33m[stage-7] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-7] [test-3] [0m[92m✓ Received exit code 65.[0m
+[33m[stage-7] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-7] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-7] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-7] [test-4] [0m[33m[test.lox][0m ("foo"
+[33m[stage-7] [test-4] [0m[33m[test.lox][0m -(-99 + 91) * (10 * 69) / (52 + 20)
 [33m[stage-7] [test-4] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m[line 1] Error at end: Expect ')' after expression.
+[33m[your_program] [0m(/ (* (- (group (+ (- 99.0) 91.0))) (group (* 10.0 69.0))) (group (+ 52.0 20.0)))
 [33m[stage-7] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-7] [test-4] [0m[92m✓ Received exit code 65.[0m
+[33m[stage-7] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-7] [0m[92mTest passed.[0m
 
-[33m[stage-6] [0m[94mRunning tests for Stage #6: mq1[0m
+[33m[stage-6] [0m[94mRunning tests for Stage #6: wa9[0m
 [33m[stage-6] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-6] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-6] [test-1] [0m[33m[test.lox][0m !false
+[33m[stage-6] [test-1] [0m[33m[test.lox][0m 95 * 89 / 64
 [33m[stage-6] [test-1] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(! false)
+[33m[your_program] [0m(/ (* 95.0 89.0) 64.0)
 [33m[stage-6] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-6] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-6] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-6] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-6] [test-2] [0m[33m[test.lox][0m -90
+[33m[stage-6] [test-2] [0m[33m[test.lox][0m 28 / 32 / 19
 [33m[stage-6] [test-2] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(- 90.0)
+[33m[your_program] [0m(/ (/ 28.0 32.0) 19.0)
 [33m[stage-6] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-6] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-6] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-6] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-6] [test-3] [0m[33m[test.lox][0m !!false
+[33m[stage-6] [test-3] [0m[33m[test.lox][0m 80 * 32 * 54 / 34
 [33m[stage-6] [test-3] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(! (! false))
+[33m[your_program] [0m(/ (* (* 80.0 32.0) 54.0) 34.0)
 [33m[stage-6] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-6] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-6] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-6] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-6] [test-4] [0m[33m[test.lox][0m (!!(true))
+[33m[stage-6] [test-4] [0m[33m[test.lox][0m (77 * -67 / (82 * 83))
 [33m[stage-6] [test-4] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(group (! (! (group true))))
+[33m[your_program] [0m(group (/ (* 77.0 (- 67.0)) (group (* 82.0 83.0))))
 [33m[stage-6] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-6] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-6] [0m[92mTest passed.[0m
 
-[33m[stage-5] [0m[94mRunning tests for Stage #5: wa9[0m
+[33m[stage-5] [0m[94mRunning tests for Stage #5: mq1[0m
 [33m[stage-5] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-5] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-5] [test-1] [0m[33m[test.lox][0m 30 * 19 / 96
+[33m[stage-5] [test-1] [0m[33m[test.lox][0m !false
 [33m[stage-5] [test-1] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(/ (* 30.0 19.0) 96.0)
+[33m[your_program] [0m(! false)
 [33m[stage-5] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-5] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-5] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-5] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-5] [test-2] [0m[33m[test.lox][0m 42 / 53 / 67
+[33m[stage-5] [test-2] [0m[33m[test.lox][0m -80
 [33m[stage-5] [test-2] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(/ (/ 42.0 53.0) 67.0)
+[33m[your_program] [0m(- 80.0)
 [33m[stage-5] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-5] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-5] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-5] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-5] [test-3] [0m[33m[test.lox][0m 43 * 15 * 70 / 99
+[33m[stage-5] [test-3] [0m[33m[test.lox][0m !!false
 [33m[stage-5] [test-3] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(/ (* (* 43.0 15.0) 70.0) 99.0)
+[33m[your_program] [0m(! (! false))
 [33m[stage-5] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-5] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-5] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-5] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-5] [test-4] [0m[33m[test.lox][0m (91 * -10 / (69 * 52))
+[33m[stage-5] [test-4] [0m[33m[test.lox][0m (!!(true))
 [33m[stage-5] [test-4] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(group (/ (* 91.0 (- 10.0)) (group (* 69.0 52.0))))
+[33m[your_program] [0m(group (! (! (group true))))
 [33m[stage-5] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-5] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-5] [0m[92mTest passed.[0m
 
-[33m[stage-4] [0m[94mRunning tests for Stage #4: yf2[0m
+[33m[stage-4] [0m[94mRunning tests for Stage #4: xe6[0m
 [33m[stage-4] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-4] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-4] [test-1] [0m[33m[test.lox][0m "hello" + "world"
+[33m[stage-4] [test-1] [0m[33m[test.lox][0m ("foo")
 [33m[stage-4] [test-1] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(+ hello world)
+[33m[your_program] [0m(group foo)
 [33m[stage-4] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-4] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-4] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-4] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-4] [test-2] [0m[33m[test.lox][0m 20 - 95 - 89
+[33m[stage-4] [test-2] [0m[33m[test.lox][0m ((true))
 [33m[stage-4] [test-2] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(- (- 20.0 95.0) 89.0)
+[33m[your_program] [0m(group (group true))
 [33m[stage-4] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-4] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-4] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-4] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-4] [test-3] [0m[33m[test.lox][0m 64 + 28 - 32
+[33m[stage-4] [test-3] [0m[33m[test.lox][0m ()
 [33m[stage-4] [test-3] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(- (+ 64.0 28.0) 32.0)
+[33m[your_program] [0m[line 1] Error at ')': Expect expression.
 [33m[stage-4] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-4] [test-3] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-4] [test-3] [0m[92m✓ Received exit code 65.[0m
 [33m[stage-4] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-4] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-4] [test-4] [0m[33m[test.lox][0m -(-19 + 80) * (32 * 54) / (34 + 77)
+[33m[stage-4] [test-4] [0m[33m[test.lox][0m ("foo"
 [33m[stage-4] [test-4] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(/ (* (- (group (+ (- 19.0) 80.0))) (group (* 32.0 54.0))) (group (+ 34.0 77.0)))
+[33m[your_program] [0m[line 1] Error at end: Expect ')' after expression.
 [33m[stage-4] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-4] [test-4] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-4] [test-4] [0m[92m✓ Received exit code 65.[0m
 [33m[stage-4] [0m[92mTest passed.[0m
 
-[33m[stage-3] [0m[94mRunning tests for Stage #3: uh4[0m
+[33m[stage-3] [0m[94mRunning tests for Stage #3: th5[0m
 [33m[stage-3] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-3] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-3] [test-1] [0m[33m[test.lox][0m 67 > -15
+[33m[stage-3] [test-1] [0m[33m[test.lox][0m "baz bar"
 [33m[stage-3] [test-1] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(> 67.0 (- 15.0))
+[33m[your_program] [0mbaz bar
 [33m[stage-3] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-3] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-3] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-3] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-3] [test-2] [0m[33m[test.lox][0m 82 <= 149
+[33m[stage-3] [test-2] [0m[33m[test.lox][0m "'bar'"
 [33m[stage-3] [test-2] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(<= 82.0 149.0)
+[33m[your_program] [0m'bar'
 [33m[stage-3] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-3] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-3] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-3] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-3] [test-3] [0m[33m[test.lox][0m 67 < 149 < 231
+[33m[stage-3] [test-3] [0m[33m[test.lox][0m "// baz"
 [33m[stage-3] [test-3] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(< (< 67.0 149.0) 231.0)
+[33m[your_program] [0m// baz
 [33m[stage-3] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-3] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-3] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-3] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-3] [test-4] [0m[33m[test.lox][0m (83 - 80) >= -(80 / 80 + 19)
+[33m[stage-3] [test-4] [0m[33m[test.lox][0m "72"
 [33m[stage-3] [test-4] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(>= (group (- 83.0 80.0)) (- (group (+ (/ 80.0 80.0) 19.0))))
+[33m[your_program] [0m72
 [33m[stage-3] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-3] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-3] [0m[92mTest passed.[0m
 
-[33m[stage-2] [0m[94mRunning tests for Stage #2: ht8[0m
+[33m[stage-2] [0m[94mRunning tests for Stage #2: ra8[0m
 [33m[stage-2] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-2] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-2] [test-1] [0m[33m[test.lox][0m "bar"!="hello"
+[33m[stage-2] [test-1] [0m[33m[test.lox][0m 83
 [33m[stage-2] [test-1] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(!= bar hello)
+[33m[your_program] [0m83.0
 [33m[stage-2] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-2] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-2] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-2] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-2] [test-2] [0m[33m[test.lox][0m "baz" == "baz"
+[33m[stage-2] [test-2] [0m[33m[test.lox][0m 0.0
 [33m[stage-2] [test-2] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(== baz baz)
+[33m[your_program] [0m0.0
 [33m[stage-2] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-2] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-2] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-2] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-2] [test-3] [0m[33m[test.lox][0m 30 == 89
+[33m[stage-2] [test-3] [0m[33m[test.lox][0m 90.91
 [33m[stage-2] [test-3] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(== 30.0 89.0)
+[33m[your_program] [0m90.91
 [33m[stage-2] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-2] [test-3] [0m[92m✓ Received exit code 0.[0m
-[33m[stage-2] [test-4] [0m[94mRunning test case: 4[0m
-[33m[stage-2] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-2] [test-4] [0m[33m[test.lox][0m (29 != 17) == ((-54 + 47) >= (83 * 88))
-[33m[stage-2] [test-4] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(== (group (!= 29.0 17.0)) (group (>= (group (+ (- 54.0) 47.0)) (group (* 83.0 88.0)))))
-[33m[stage-2] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-2] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-2] [0m[92mTest passed.[0m
 
-[33m[stage-1] [0m[94mRunning tests for Stage #1: wz8[0m
+[33m[stage-1] [0m[94mRunning tests for Stage #1: sc2[0m
 [33m[stage-1] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-1] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-1] [test-1] [0m[33m[test.lox][0m "foo
+[33m[stage-1] [test-1] [0m[33m[test.lox][0m true
 [33m[stage-1] [test-1] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m[line 1] Error: Unterminated string.
-[33m[your_program] [0m[line 1] Error at end: Expect expression.
+[33m[your_program] [0mtrue
 [33m[stage-1] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-1] [test-1] [0m[92m✓ Received exit code 65.[0m
+[33m[stage-1] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-1] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-1] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-1] [test-2] [0m[33m[test.lox][0m (91 +)
+[33m[stage-1] [test-2] [0m[33m[test.lox][0m false
 [33m[stage-1] [test-2] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m[line 1] Error at ')': Expect expression.
+[33m[your_program] [0mfalse
 [33m[stage-1] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-1] [test-2] [0m[92m✓ Received exit code 65.[0m
+[33m[stage-1] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-1] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-1] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-1] [test-3] [0m[33m[test.lox][0m +
+[33m[stage-1] [test-3] [0m[33m[test.lox][0m nil
 [33m[stage-1] [test-3] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m[line 1] Error at '+': Expect expression.
+[33m[your_program] [0mnil
 [33m[stage-1] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
-[33m[stage-1] [test-3] [0m[92m✓ Received exit code 65.[0m
+[33m[stage-1] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-1] [0m[92mTest passed.[0m

--- a/internal/tester_definition.go
+++ b/internal/tester_definition.go
@@ -147,7 +147,19 @@ var testerDefinition = tester_definition.TesterDefinition{
 		},
 		{
 			Slug:     "gj9",
-			TestFunc: testEvaluateErrors,
+			TestFunc: testEvaluateUnaryErrors,
+		},
+		{
+			Slug:     "yu6",
+			TestFunc: testEvaluateMultErrors,
+		},
+		{
+			Slug:     "cq1",
+			TestFunc: testEvaluateAddErrors,
+		},
+		{
+			Slug:     "ib5",
+			TestFunc: testEvaluateCompErrors,
 		},
 	},
 }

--- a/internal/tester_definition.go
+++ b/internal/tester_definition.go
@@ -125,5 +125,29 @@ var testerDefinition = tester_definition.TesterDefinition{
 			Slug:     "dc1",
 			TestFunc: testEvaluateUnary,
 		},
+		{
+			Slug:     "bp3",
+			TestFunc: testEvaluateFactor,
+		},
+		{
+			Slug:     "jy2",
+			TestFunc: testEvaluateTerm,
+		},
+		{
+			Slug:     "jx8",
+			TestFunc: testEvaluateConcat,
+		},
+		{
+			Slug:     "et4",
+			TestFunc: testEvaluateRelational,
+		},
+		{
+			Slug:     "hw7",
+			TestFunc: testEvaluateEquality,
+		},
+		{
+			Slug:     "gj9",
+			TestFunc: testEvaluateErrors,
+		},
 	},
 }

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -17,3 +17,7 @@ func getRandIntAsString() string {
 func getRandString() string {
 	return random.RandomElementFromArray(STRINGS)
 }
+
+func getRandBoolean() string {
+	return random.RandomElementFromArray(BOOLEANS)
+}


### PR DESCRIPTION
This pull request introduces several changes to the codebase, primarily focusing on expanding the test coverage and correcting file paths. The main changes include adding new test stages for evaluating unary errors, multiplication errors, addition errors, and comparison errors. The file paths in the `Makefile` have also been corrected.

New test stages:

* [`internal/stage_e10.go`](diffhunk://#diff-3df66691f0ffa88e3bb7c9f979b563f28e5f9d09d2568f922ad60580506e5e0aR1-R26): Introduced a new test stage to evaluate unary errors.
* [`internal/stage_e11.go`](diffhunk://#diff-3693a348fb8f6fe465a60c44d72b3ddb6fd86e02b00b825121729e2e79874db9R1-R26): Introduced a new test stage to evaluate multiplication errors.
* [`internal/stage_e12.go`](diffhunk://#diff-b272d9e5162878c4e5018179a1059040f48fa0ac0982b0a553b827139637f941R1-R26): Introduced a new test stage to evaluate addition errors.
* [`internal/stage_e13.go`](diffhunk://#diff-feea272c80b6b36ae9f3e8c2168060c425e149e7a62ebf287d1a9d10ca20db2aR1-R26): Introduced a new test stage to evaluate comparison errors.

File path corrections:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L21-R21): Corrected the file path in the `copy_course_file` command.

Test stage expansions:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L96-R105): Expanded the `test_evaluation_w_jlox: build` command to include new test stages.
* [`internal/test_helpers/course_definition.yml`](diffhunk://#diff-030aa4b340e90678602fd2695f4008778d2e2efa2af2597ce4ffecf206a38e63R1150-R1167): Added new test stages to the course definition.
* [`internal/stages_test.go`](diffhunk://#diff-b93ecc54a4e5fbf48fec8173ed2fc352a2e4bd0df87bc465c5c41561bab8439cL29-R29): Included new test stages in the `TestStages` function.

Minor changes:

* `internal/stage_e3.go`, `internal/stage_e4.go`, `internal/stage_p5.go`: Replaced `random.RandomElementFromArray(BOOLEANS)` with `getRandBoolean()`. [[1]](diffhunk://#diff-934fd9532b47bc8df1da33cef866a437e8caeb34efd64ccd895b00989c11873cL22-R22) [[2]](diffhunk://#diff-814ff1ef5fc3a58a56d07cd5bb569caed3df29a8a7c053ca18d6cdb0fa2f2010L19-R18) [[3]](diffhunk://#diff-b2156f1745c91ce5bdac8d82ff858f71d2bad5ba7e634a24161f7ab887867568L17-R20)
* [`internal/stage_e4.go`](diffhunk://#diff-814ff1ef5fc3a58a56d07cd5bb569caed3df29a8a7c053ca18d6cdb0fa2f2010L9): Removed the unused import `"github.com/codecrafters-io/tester-utils/random"`.