### PR TITLE
CC-1362: Add updated interpreter and framework for statements extension 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,5 +51,6 @@ jobs:
           cp -r ./internal/test_helpers/jlox04/* ./craftinginterpreters/build/gen/chap04_scanning
           cp -r ./internal/test_helpers/jlox06/* ./craftinginterpreters/build/gen/chap06_parsing
           cp -r ./internal/test_helpers/jlox07/* ./craftinginterpreters/build/gen/chap07_evaluating
+          cp -r ./internal/test_helpers/jlox08/* ./craftinginterpreters/build/gen/chap08_statements
 
       - run: make test

--- a/Makefile
+++ b/Makefile
@@ -106,4 +106,11 @@ test_evaluation_w_jlox: build
 	]" \
 	$(shell pwd)/dist/main.out
 
-test_all: test_scanning_w_jlox test_parsing_w_jlox
+test_statements_w_jlox: build
+	CODECRAFTERS_REPOSITORY_DIR=./craftinginterpreters/build/gen/chap08_statements \
+	CODECRAFTERS_TEST_CASES_JSON="[ \
+		{\"slug\":\"xy1\",\"tester_log_prefix\":\"stage_401\",\"title\":\"Stage #401: Statements: Print statements\"} \
+	]" \
+	$(shell pwd)/dist/main.out
+
+test_all: test_scanning_w_jlox test_parsing_w_jlox test_evaluation_w_jlox test_statements_w_jlox

--- a/internal/lox/ast.go
+++ b/internal/lox/ast.go
@@ -26,7 +26,6 @@ type Binary struct {
 
 // String pretty prints the operator
 func (b *Binary) String() string {
-	// fmt.Println("Binary")
 	var sb strings.Builder
 	sb.WriteString("(")
 	sb.WriteString(b.Operator.Lexeme)
@@ -46,7 +45,6 @@ type Grouping struct {
 
 // String pretty prints the expression grouping
 func (g *Grouping) String() string {
-	// fmt.Println("Grouping")
 	var sb strings.Builder
 	sb.WriteString("(group ")
 	sb.WriteString(g.Expression.String())
@@ -62,7 +60,6 @@ type Literal struct {
 
 // String pretty prints the literal
 func (l *Literal) String() string {
-	// fmt.Println("Literal")
 	var sb strings.Builder
 	if l.Value == nil {
 		sb.WriteString("nil")
@@ -83,7 +80,6 @@ type Unary struct {
 
 // String pretty prints the unary operator
 func (u *Unary) String() string {
-	// fmt.Println("Unary")
 	var sb strings.Builder
 	sb.WriteString("(")
 	sb.WriteString(u.Operator.Lexeme)
@@ -93,17 +89,129 @@ func (u *Unary) String() string {
 	return sb.String()
 }
 
+// Statements and state
+
+// Assign is used for variable assignment
+// name = value
+type Assign struct {
+	Expr
+	Name     Token
+	Value    Expr
+	EnvIndex int
+	EnvDepth int
+}
+
+// String pretty prints the assignment statement
+func (a *Assign) String() string {
+	var sb strings.Builder
+	sb.WriteString("(")
+	sb.WriteString("=")
+	sb.WriteString(" ")
+	sb.WriteString(a.Name.Lexeme)
+	sb.WriteString(" ")
+	sb.WriteString(a.Value.String())
+	sb.WriteString(")")
+	return sb.String()
+}
+
+// Variable access expression
+// print x
+type Variable struct {
+	Expr
+	Name     Token
+	EnvIndex int
+	EnvDepth int
+}
+
+// String pretty prints the assignment expression
+func (v *Variable) String() string {
+	var sb strings.Builder
+	sb.WriteString(v.Name.Lexeme)
+	return sb.String()
+}
+
+// Stmt form a second hierarchy of syntax nodes independent of expressions
+type Stmt interface {
+	Node
+}
+
+// Block is a curly-braced block statement that defines a local scope
+//
+//	{
+//	  ...
+//	}
+type Block struct {
+	Stmt
+	Statements []Stmt
+	EnvSize    int
+}
+
+// String pretty prints the block statement
+func (b *Block) String() string {
+	var sb strings.Builder
+	sb.WriteString("(")
+	for _, stmt := range b.Statements {
+		sb.WriteString(stmt.String())
+	}
+	sb.WriteString(")")
+	return sb.String()
+}
+
 // Expression statement
 type Expression struct {
+	Stmt
 	Expression Expr
 }
 
 // String pretty prints the expression statement
 func (e *Expression) String() string {
-	// fmt.Println("Expression")
 	var sb strings.Builder
 	sb.WriteString("(")
 	sb.WriteString(e.Expression.String())
+	sb.WriteString(")")
+	return sb.String()
+}
+
+// Print statement
+// print 1 + 2
+type Print struct {
+	Stmt
+	Expression Expr
+}
+
+// String pretty prints the print statement
+func (p *Print) String() string {
+	var sb strings.Builder
+	sb.WriteString("(")
+	sb.WriteString("print")
+	sb.WriteString(" ")
+	sb.WriteString(p.Expression.String())
+	sb.WriteString(")")
+	return sb.String()
+}
+
+// Var is the variable declaration statement
+// var <name> = <initializer>
+type Var struct {
+	Stmt
+	Name        Token
+	Initializer Expr
+	EnvIndex    int
+}
+
+// String pretty prints the var declaration
+func (v *Var) String() string {
+	var sb strings.Builder
+	sb.WriteString("(")
+	sb.WriteString("var")
+	sb.WriteString(" ")
+	sb.WriteString(v.Name.Lexeme)
+	sb.WriteString(" ")
+	if v.Initializer != nil {
+		sb.WriteString(v.Initializer.String())
+	} else {
+		sb.WriteString("nil")
+	}
 	sb.WriteString(")")
 	return sb.String()
 }

--- a/internal/lox/environment.go
+++ b/internal/lox/environment.go
@@ -1,0 +1,54 @@
+package lox
+
+import (
+	"fmt"
+)
+
+// Environment associates variables to values
+type Environment struct {
+	values    map[string]interface{}
+	enclosing *Environment
+}
+
+// New creates a new environment
+func New(env *Environment) *Environment {
+	return &Environment{values: make(map[string]interface{}), enclosing: env}
+}
+
+// NewGlobal creates a new global environment
+func NewGlobal() *Environment {
+	return New(nil)
+}
+
+// Define binds a name to a new value
+func (e *Environment) Define(name string, value interface{}) {
+	e.values[name] = value
+}
+
+// Get lookups a variable given a Token
+func (e *Environment) Get(name Token) (interface{}, error) {
+	v, prs := e.values[name.Lexeme]
+	if prs {
+		if v == nil {
+			// We want to allow uninitialized variables
+			return "nil", nil // XXX: Hack: returning nil as string here
+		}
+		return v, nil
+	}
+	if e.enclosing != nil {
+		return e.enclosing.Get(name)
+	}
+	return nil, fmt.Errorf("Undefined variable '%v'", name.Lexeme)
+}
+
+// Assign sets a new value to an old variable
+func (e *Environment) Assign(name Token, value interface{}) error {
+	if _, prs := e.values[name.Lexeme]; prs {
+		e.values[name.Lexeme] = value
+		return nil
+	}
+	if e.enclosing != nil {
+		return e.enclosing.Assign(name, value)
+	}
+	return MakeRuntimeError(name, fmt.Sprintf("Undefined variable '%s'.", name.Lexeme))
+}

--- a/internal/lox/interpreter.go
+++ b/internal/lox/interpreter.go
@@ -24,7 +24,7 @@ func Interpret(statements []Stmt, env *Environment) ([]interface{}, error) {
 	for _, stmt := range statements {
 		result, err := Eval(stmt, env)
 		if err != nil {
-			return nil, err
+			return results, err
 		}
 		results = append(results, result)
 	}

--- a/internal/lox/interpreter.go
+++ b/internal/lox/interpreter.go
@@ -18,14 +18,17 @@ func BasicInterpret(expression Expr) (interface{}, error) {
 	return result, nil
 }
 
-func Interpret(statements []Stmt, env *Environment) (interface{}, error) {
+func Interpret(statements []Stmt, env *Environment) ([]interface{}, error) {
+	var results []interface{}
+
 	for _, stmt := range statements {
-		_, err := Eval(stmt, env)
+		result, err := Eval(stmt, env)
 		if err != nil {
 			return nil, err
 		}
+		results = append(results, result)
 	}
-	return nil, nil
+	return results, nil
 }
 
 // Eval evaluates the given AST
@@ -152,8 +155,8 @@ func Eval(node Node, environment *Environment) (interface{}, error) {
 		if err != nil {
 			return value, err
 		}
-		fmt.Println(value)
-		return nil, nil
+		// fmt.Println(value) // Commented out, or would interfere with logs
+		return value, nil
 	case *Expression:
 		r, err := Eval(n.Expression, environment)
 		if err != nil {

--- a/internal/lox/interpreter.go
+++ b/internal/lox/interpreter.go
@@ -10,23 +10,33 @@ const (
 	OPERANDS_MUST_BE_TWO_NUMBERS_OR_TWO_STRINGS = "Operands must be two numbers or two strings"
 )
 
-func Interpret(expression Expr) (interface{}, error) {
-	result, err := Eval(expression)
+func BasicInterpret(expression Expr) (interface{}, error) {
+	result, err := Eval(expression, NewGlobal())
 	if err != nil {
 		return "", err
 	}
 	return result, nil
 }
 
+func Interpret(statements []Stmt, env *Environment) (interface{}, error) {
+	for _, stmt := range statements {
+		_, err := Eval(stmt, env)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return nil, nil
+}
+
 // Eval evaluates the given AST
-func Eval(node Node) (interface{}, error) {
+func Eval(node Node, environment *Environment) (interface{}, error) {
 	switch n := node.(type) {
 	case *Literal:
 		return n.Value, nil
 	case *Grouping:
-		return Eval(n.Expression)
+		return Eval(n.Expression, environment)
 	case *Unary:
-		right, err := Eval(n.Right)
+		right, err := Eval(n.Right, environment)
 		if err != nil {
 			return right, err
 		} else if n.Operator.Type == MINUS {
@@ -39,11 +49,11 @@ func Eval(node Node) (interface{}, error) {
 			return !isTruthy(right), nil
 		}
 	case *Binary:
-		left, err := Eval(n.Left)
+		left, err := Eval(n.Left, environment)
 		if err != nil {
 			return left, err
 		}
-		right, err := Eval(n.Right)
+		right, err := Eval(n.Right, environment)
 		if err != nil {
 			return right, err
 		}
@@ -137,10 +147,49 @@ func Eval(node Node) (interface{}, error) {
 		case EQUALEQUAL:
 			return isEqual(left, right), nil
 		}
+	case *Print:
+		value, err := Eval(n.Expression, environment)
+		if err != nil {
+			return value, err
+		}
+		fmt.Println(value)
+		return nil, nil
 	case *Expression:
-		r, err := Eval(n.Expression)
+		r, err := Eval(n.Expression, environment)
 		if err != nil {
 			return r, err
+		}
+		return nil, nil
+	case *Var:
+		if n.Initializer != nil {
+			value, err := Eval(n.Initializer, environment)
+			if err != nil {
+				return nil, err
+			}
+			environment.Define(n.Name.Lexeme, value)
+		} else {
+			// We initialize uninitialized variables with nil
+			environment.Define(n.Name.Lexeme, nil)
+		}
+		return nil, nil
+	case *Variable:
+		return environment.Get(n.Name)
+	case *Assign:
+		value, err := Eval(n.Value, environment)
+		if err != nil {
+			return nil, err
+		}
+		if err = environment.Assign(n.Name, value); err == nil {
+			return value, nil
+		}
+		return nil, err
+	case *Block:
+		newEnvironment := New(environment)
+		for _, stmt := range n.Statements {
+			_, err := Eval(stmt, newEnvironment)
+			if err != nil {
+				return nil, err
+			}
 		}
 		return nil, nil
 	case nil:

--- a/internal/lox/interpreter_api.go
+++ b/internal/lox/interpreter_api.go
@@ -16,12 +16,12 @@ func Evaluate(source string) (string, int, string) {
 	}
 
 	parser := NewParser(tokens)
-	expression, err := parser.Parse()
+	expression, err := parser.BasicParse()
 	if err != nil {
 		return "", 65, existingErrors + err.Error()
 	}
 
-	result, err := Interpret(expression)
+	result, err := BasicInterpret(expression)
 	if err != nil {
 		return "", 70, existingErrors + err.Error()
 	}

--- a/internal/lox/parser.go
+++ b/internal/lox/parser.go
@@ -1,13 +1,28 @@
 package lox
 
 /*
-expression -> equality ;
+program    -> declaration* EOF ;
+declaration-> varDecl
+			| stmt ;
+varDecl    -> "var" IDENTIFIER ( "=" expression )? ";" ;
+stmt       -> exprStmt
+			| printStmt ;
+			| block ;
+block      -> "{" declaration* "}" ;
+exprStmt   -> expression ";" ;
+printStmt  -> "print" expression ";" ;
+expression -> assignment ;
+assignment -> IDENTIFIER "=" assignment
+			| equality ;
 equality   -> comparison ( ( "!=" | "==") comparison )* ;
 comparison -> term ( ( ">" | ">=" | "<" | "<=") term )* ;
 term   -> factor ( ( "+" | "-" ) factor )* ;
 factor -> unary ( ( "/" | "*" ) unary )* ;
 unary      -> ( "!" | "-" ) unary | primary ;
-primary    -> NUMBER | STRING | "true" | "false" | "nil" | "(" expression ")" ;
+primary    -> "true" | "false" | "nil"
+			| NUMBER | STRING
+			| "(" expression ")"
+			IDENTIFIER ;
 */
 
 // Parser will transform an array of tokens to an AST.

--- a/internal/lox/parser_api.go
+++ b/internal/lox/parser_api.go
@@ -14,7 +14,7 @@ func Parse(source string) (string, int, string) {
 	}
 
 	parser := NewParser(tokens)
-	expression, err := parser.Parse()
+	expression, err := parser.BasicParse()
 	if err != nil {
 		return "", 65, existingErrors + err.Error()
 	}

--- a/internal/lox/run_api.go
+++ b/internal/lox/run_api.go
@@ -1,0 +1,41 @@
+package lox
+
+import (
+	"fmt"
+	"strings"
+)
+
+func Run(source string) (string, int, string) {
+	scanner := NewScanner(source)
+	tokens, errors := scanner.ScanTokens()
+
+	var existingErrors string
+	exitCode := 0
+	if len(errors) > 0 {
+		for _, err := range errors {
+			existingErrors += err + "\n"
+		}
+		exitCode = 65
+	}
+
+	parser := NewParser(tokens)
+	statements, err := parser.Parse()
+	if err != nil {
+		return "", 65, existingErrors + err.Error()
+	}
+
+	results, err := Interpret(statements, NewGlobal())
+	if err != nil {
+		return "", 70, existingErrors + err.Error()
+	}
+
+	if results == nil {
+		return "nil", exitCode, existingErrors
+	}
+
+	resultsString := []string{}
+	for _, res := range results {
+		resultsString = append(resultsString, fmt.Sprintf("%v", res))
+	}
+	return strings.Join(resultsString, "\n"), exitCode, existingErrors
+}

--- a/internal/lox/run_api.go
+++ b/internal/lox/run_api.go
@@ -25,17 +25,17 @@ func Run(source string) (string, int, string) {
 	}
 
 	results, err := Interpret(statements, NewGlobal())
-	if err != nil {
-		return "", 70, existingErrors + err.Error()
-	}
-
-	if results == nil {
-		return "nil", exitCode, existingErrors
-	}
-
 	resultsString := []string{}
 	for _, res := range results {
-		resultsString = append(resultsString, fmt.Sprintf("%v", res))
+		if res != nil {
+			resultsString = append(resultsString, fmt.Sprintf("%v", res))
+		}
 	}
-	return strings.Join(resultsString, "\n"), exitCode, existingErrors
+	output := strings.Join(resultsString, "\n")
+
+	if err != nil {
+		return output, 70, existingErrors + err.Error()
+	}
+
+	return output, exitCode, existingErrors
 }

--- a/internal/stage_s1.go
+++ b/internal/stage_s1.go
@@ -12,8 +12,14 @@ func testStatements1(stageHarness *test_case_harness.TestCaseHarness) error {
 	logger := stageHarness.Logger
 
 	fileContents := GetTestProgramsForCurrentStage()
+	var replacedFileContents []string
+	for _, fileContent := range fileContents {
+		replacedFileContent := replace(fileContent)
+		replacedFileContents = append(replacedFileContents, replacedFileContent)
+	}
+
 	runTestCases := testcases.MultiRunTestCase{
-		FileContents: fileContents,
+		FileContents: replacedFileContents,
 	}
 
 	return runTestCases.RunAll(b, logger)

--- a/internal/stage_s1.go
+++ b/internal/stage_s1.go
@@ -14,9 +14,11 @@ func testStatements1(stageHarness *test_case_harness.TestCaseHarness) error {
 	fileContents := GetTestProgramsForCurrentStage()
 	var replacedFileContents []string
 	for _, fileContent := range fileContents {
-		replacedFileContent := replace(fileContent)
+		replacedFileContent := ReplacePlaceholdersWithRandomValues(fileContent)
 		replacedFileContents = append(replacedFileContents, replacedFileContent)
 	}
+
+	// fileContents = GetTestProgramsForCurrentStageWithRandomValues()
 
 	runTestCases := testcases.MultiRunTestCase{
 		FileContents: replacedFileContents,

--- a/internal/stage_s1.go
+++ b/internal/stage_s1.go
@@ -1,0 +1,20 @@
+package internal
+
+import (
+	"github.com/codecrafters-io/interpreter-tester/internal/interpreter_executable"
+	testcases "github.com/codecrafters-io/interpreter-tester/internal/test_cases"
+	"github.com/codecrafters-io/tester-utils/test_case_harness"
+)
+
+func testStatements1(stageHarness *test_case_harness.TestCaseHarness) error {
+	b := interpreter_executable.NewInterpreterExecutable(stageHarness)
+
+	logger := stageHarness.Logger
+
+	fileContents := GetTestProgramsForCurrentStage()
+	runTestCases := testcases.MultiRunTestCase{
+		FileContents: fileContents,
+	}
+
+	return runTestCases.RunAll(b, logger)
+}

--- a/internal/stage_s1.go
+++ b/internal/stage_s1.go
@@ -11,17 +11,10 @@ func testStatements1(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	logger := stageHarness.Logger
 
-	fileContents := GetTestProgramsForCurrentStage()
-	var replacedFileContents []string
-	for _, fileContent := range fileContents {
-		replacedFileContent := ReplacePlaceholdersWithRandomValues(fileContent)
-		replacedFileContents = append(replacedFileContents, replacedFileContent)
-	}
-
-	// fileContents = GetTestProgramsForCurrentStageWithRandomValues()
+	fileContents := GetTestProgramsForCurrentStageWithRandomValues()
 
 	runTestCases := testcases.MultiRunTestCase{
-		FileContents: replacedFileContents,
+		FileContents: fileContents,
 	}
 
 	return runTestCases.RunAll(b, logger)

--- a/internal/test_cases/evaluate_test_case.go
+++ b/internal/test_cases/evaluate_test_case.go
@@ -39,10 +39,6 @@ func (t *EvaluateTestCase) Run(executable *interpreter_executable.InterpreterExe
 		return fmt.Errorf("expected exit code %v, got %v", exitCode, result.ExitCode)
 	}
 
-	// ToDo: Confirm
-	// We are intentionally not testing the errors lines printed to stderr
-	// We will just check the exitCode here
-
 	expectedStdoutLines := []string{expectedStdout}
 	if err = assertions.NewStdoutAssertion(expectedStdoutLines).Run(result, logger); err != nil {
 		return err

--- a/internal/test_cases/multi_run_test_case.go
+++ b/internal/test_cases/multi_run_test_case.go
@@ -1,0 +1,27 @@
+package testcases
+
+import (
+	"fmt"
+
+	"github.com/codecrafters-io/interpreter-tester/internal/interpreter_executable"
+	"github.com/codecrafters-io/tester-utils/logger"
+)
+
+type MultiRunTestCase struct {
+	FileContents []string
+}
+
+func (t *MultiRunTestCase) RunAll(executable *interpreter_executable.InterpreterExecutable, logger *logger.Logger) error {
+	for i, fileContents := range t.FileContents {
+		logger.UpdateSecondaryPrefix(fmt.Sprintf("test-%d", i+1))
+		logger.Infof("Running test case: %d", i+1)
+		testCase := RunTestCase{
+			FileContents: fileContents}
+		if err := testCase.Run(executable, logger); err != nil {
+			return err
+		}
+		// If err is encountered, we want the secondary prefix to be present
+		logger.ResetSecondaryPrefix()
+	}
+	return nil
+}

--- a/internal/test_cases/run_test_case.go
+++ b/internal/test_cases/run_test_case.go
@@ -1,0 +1,52 @@
+package testcases
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/codecrafters-io/interpreter-tester/internal/assertions"
+	"github.com/codecrafters-io/interpreter-tester/internal/interpreter_executable"
+	"github.com/codecrafters-io/interpreter-tester/internal/lox"
+	"github.com/codecrafters-io/tester-utils/logger"
+)
+
+// RunTestCase is a test case for testing the
+// "run" functionality of the interpreter executable.
+// A temporary file is created with R.FileContents,
+// It is sent to the "run" command of the executable,
+// the expected outputs are generated using the lox.Run function,
+// With that the output of the executable is matched.
+type RunTestCase struct {
+	FileContents string
+}
+
+func (t *RunTestCase) Run(executable *interpreter_executable.InterpreterExecutable, logger *logger.Logger) error {
+	tmpFileName, err := createTempFileWithContents(t.FileContents)
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmpFileName)
+
+	logReadableFileContents(logger, t.FileContents)
+
+	result, err := executable.Run("run", tmpFileName)
+	if err != nil {
+		return err
+	}
+
+	expectedStdout, exitCode, _ := lox.Run(t.FileContents)
+	if result.ExitCode != exitCode {
+		return fmt.Errorf("expected exit code %v, got %v", exitCode, result.ExitCode)
+	}
+	// XXX: Stderr is not checked
+
+	expectedStdoutLines := strings.Split(expectedStdout, "\n")
+	if err = assertions.NewStdoutAssertion(expectedStdoutLines).Run(result, logger); err != nil {
+		return err
+	}
+
+	logger.Successf("✓ Received exit code %d.", exitCode)
+
+	return nil
+}

--- a/internal/test_helpers/course_definition.yml
+++ b/internal/test_helpers/course_definition.yml
@@ -24,10 +24,12 @@ short_description_md: |-
 completion_percentage: 15
 
 languages:
+  - slug: "gleam"
   - slug: "go"
+  - slug: "kotlin"
+  - slug: "ocaml"
   - slug: "python"
   - slug: "rust"
-  - slug: "kotlin"
 
 marketing:
   difficulty: hard
@@ -1204,13 +1206,20 @@ stages:
       true
       ```
 
+      The tester will run multiple such tests with randomized expressions, for example:
+
+      | Input | Expected output |
+      | :---: | :-------------: |
+      | `true` | `true` |
+      | `false` | `false` |
+      | `nil` | `nil` |
+
       The tester will assert that the stdout of your program matches the format above.
 
       ### Notes
 
       - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/evaluate.lox)
       - For the `nil` literal, the tester will check that the program prints `nil`.
-      - For truthyness & falsyness, we will follow the convention introduced in the book, where `false` and `nil` are falsy, and everything else is truthy.
     marketing_md: |-
       In this stage, you'll implement support for evaluating binary values and the nil literal.
 
@@ -1232,15 +1241,23 @@ stages:
       For example, if `test.lox` contains the following:
 
       ```
-      10.40
+      "hello world!"
       ```
 
       The tester will run your program like this:
 
       ```
       $ ./your_program.sh evaluate test.lox
-      10.4
+      hello world!
       ```
+
+      The tester will run multiple such tests with randomized expressions, for example:
+
+      | Input | Expected output |
+      | :---: | :-------------: |
+      | `"hello world!"` | `hello world!` |
+      | `10.40` | `10.4` |
+      | `10` | `10` |
 
       The tester will assert that the stdout of your program matches the format above.
 
@@ -1248,7 +1265,7 @@ stages:
 
       - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/evaluate.lox)
       - For the string literals, the tester will check that the program prints the string without quotes.
-      - For the number literals, the tester will check that the program prints the number with the minimum number of decimal places without losing precision. (For example, you can skip 0's at the end after the decimal point, but you can't skip 0's at the beginning of the number).
+      - For the number literals, the tester will check that the program prints the number with the minimum number of decimal places without losing precision. (For example, 10.40 should be printed as 10.4).
     marketing_md: |-
       In this stage, you'll implement support for evaluating number and string literals.
 
@@ -1265,7 +1282,7 @@ stages:
 
       ### Tests
 
-      The tester will run a series of tests with `test.lox` files that contain expressions inside parentheses.
+      The tester will test your program using a `test.lox` file that contains an expression with parentheses.
 
       For example, if `test.lox` contains the following:
 
@@ -1280,12 +1297,21 @@ stages:
       hello world!
       ```
 
+      The tester will run multiple such tests with randomized expressions, for example:
+
+      | Input | Expected output |
+      | :---: | :-------------: |
+      | `("hello world!")` | `hello world!` |
+      | `(true)` | `true` |
+      | `(10.40)` | `10.4` |
+      | `((false))` | `false` |
+
       The tester will assert that the stdout of your program matches the format above.
 
       ### Notes
 
       - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/evaluate.lox)
-      - For string literals, number literals follow the same rules as in the previous stage.
+      - String literals & number literals must be formatted using the same rules as the previous stage.
     marketing_md: |-
       In this stage, you'll implement support for evaluating expressions inside parentheses.
 
@@ -1307,7 +1333,7 @@ stages:
       For example, if `test.lox` contains the following:
 
       ```
-      -73
+      -(73)
       ```
 
       The tester will run your program like this:
@@ -1317,12 +1343,21 @@ stages:
       -73
       ```
 
+      The tester will run multiple such tests with randomized expressions, for example:
+
+      | Input | Expected output |
+      | :---: | :-------------: |
+      | `-73` | `-73` |
+      | `!true` | `false` |
+      | `!10.40` | `false` |
+      | `!((false))` | `true` |
+
       The tester will assert that the stdout of your program matches the format above.
 
       ### Notes
 
       - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/evaluate.lox)
-      - For truthyness and falsyness, we will follow the convention introduced in the previous stages.
+      - For truthyness and falsyness, we will follow the convention introduced in the book, where `false` and `nil` are falsy, and everything else is truthy.
     marketing_md: |-
       In this stage, you'll implement support for evaluating unary operators `-` and `!`.
 
@@ -1354,12 +1389,20 @@ stages:
       3
       ```
 
+      The tester will run multiple such tests with randomized expressions, for example:
+
+      | Input | Expected output |
+      | :---: | :-------------: |
+      | `42 / 5` | `8.4` |
+      | `18 * 3 / (3 * 6)` | `3` |
+      | `(10.40 * 2) / 2` | `10.4` |
+
       The tester will assert that the stdout of your program matches the format above.
 
       ### Notes
 
       - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/evaluate.lox)
-      - We will introduce runtime errors in later stages. For now, we will only pass 2 numbers to the arithmetic operators.
+      - In this stage, you can assume we will not test for error cases. Runtime errors will be introduced in later stages. For now, all arithmetic operations will involve only two numbers.
     marketing_md: |-
       In this stage, you'll implement support for evaluating binary operators `*` and `/`.
 
@@ -1391,12 +1434,21 @@ stages:
       75
       ```
 
+      The tester will run multiple such tests with randomized expressions, for example:
+
+      | Input | Expected output |
+      | :---: | :-------------: |
+      | `70 - 65` | `5` |
+      | `69 - 93` | `-24` |
+      | `10.40 - 2` | `8.4` |
+      | `23 + 28 - (-(61 - 99))` | `13` |
+
       The tester will assert that the stdout of your program matches the format above.
 
       ### Notes
 
       - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/evaluate.lox)
-      - We will introduce runtime errors in later stages. For now, we will only pass 2 numbers to the arithmetic operators.
+      - In this stage, you can assume we will not test for error cases. Runtime errors will be introduced in later stages. For now, all arithmetic operations will involve only two numbers.
     marketing_md: |-
       In this stage, you'll implement support for evaluating binary operators `+` and `-`.
 
@@ -1428,12 +1480,20 @@ stages:
       hello world!
       ```
 
+      The tester will run multiple such tests with randomized expressions, for example:
+
+      | Input | Expected output |
+      | :---: | :-------------: |
+      | `"hello" + " world!"` | `hello world!` |
+      | `"42" + "24"` | `4224` |
+      | `"foo" + "bar"` | `foobar` |
+
       The tester will assert that the stdout of your program matches the format above.
 
       ### Notes
 
       - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/evaluate.lox)
-      - We will introduce runtime errors in later stages. For now, we will only pass 2 strings to the `+` operator in this stage.
+      - In this stage, you can assume we will not test for error cases. Runtime errors will be introduced in later stages. For now, we will only pass 2 strings to the `+` operator in this stage.
     marketing_md: |-
       In this stage, you'll implement support for overloading the `+` operator. When the `+` operator is applied to two strings, it should concatenate them.
 
@@ -1465,12 +1525,20 @@ stages:
       true
       ```
 
+      The tester will run multiple such tests with randomized expressions, for example:
+
+      | Input | Expected output |
+      | :---: | :-------------: |
+      | `57 > -65` | `true` |
+      | `11 >= 11` | `true` |
+      | `(54 - 67) >= -(114 / 57 + 11)` | `true` |
+
       The tester will assert that the stdout of your program matches the format above.
 
       ### Notes
 
       - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/evaluate.lox)
-      - We will introduce runtime errors in later stages. For now, we will only pass 2 numbers to the relational operators in this stage.
+      - In this stage, you can assume we will not test for error cases. Runtime errors will be introduced in later stages. For now, all relational operations will involve only two numbers.
     marketing_md: |-
       In this stage, you'll implement support for evaluating relational operators `>`, `<`, `>=` & `<=`.
 
@@ -1502,12 +1570,21 @@ stages:
       true
       ```
 
+      The tester will run multiple such tests with randomized expressions, for example:
+
+      | Input | Expected output |
+      | :---: | :-------------: |
+      | `"hello" == "world"` | `false` |
+      | `"foo" != "bar"` | `true` |
+      | `"foo" == "foo"` | `true` |
+      | `61 == "61"` | `false` |
+
       The tester will assert that the stdout of your program matches the format above.
 
       ### Notes
 
       - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/evaluate.lox)
-      - We will introduce runtime errors in later stages. For now, we will only pass numbers / strings to the equality operators in this stage.
+      - In this stage, you can assume we will not test for error cases. Runtime errors will be introduced in later stages. For now, all equality operations will involve only two numbers or two strings.
     marketing_md: |-
       In this stage, you'll implement support for evaluating equality operators `==` and `!=`.
 
@@ -1524,7 +1601,10 @@ stages:
 
       ### Tests
 
-      The tester will run a series of tests with `test.lox` files that contain expressions with the unary operator `-`, There is a high probability that the expression will throw a runtime error.
+      The tester will test your program using a `test.lox` file that contains an expression with the unary operator `-`. This expression
+      will contain a usage of the `-` operator that should throw a runtime error.
+
+      The unary operator `-` will throw a runtime error if the operand is not a number.
 
       For example, if `test.lox` contains the following:
 
@@ -1540,13 +1620,20 @@ stages:
       [line 1]
       ```
 
-      The tester will ONLY assert that the exit code of your program is 70 in case of a runtime error.
-      Or if the exit code is 0, the tester will assert that the stdout of your program matches the format above.
+      The tester will run multiple such tests with randomized expressions, for example:
+
+      | Input | Expected output |
+      | :---: | :-------------: |
+      | `-"foo"` | `Operand must be a number.` |
+      | `-true` | `Operand must be a number.` |
+      | `-("foo" + "bar")` | `Operand must be a number.` |
+      | `-false` | `Operand must be a number. `|
+
+      The tester will assert that the exit code is 70, signifying a runtime error. Note that this is different from the expected exit code for a syntax error, which is 65.
 
       ### Notes
 
       - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/evaluate.lox)
-      - The unary operator `-` will throw a runtime error if the operand is not a number.
     marketing_md: |-
       In this stage, you'll implement support for handling runtime errors while evaluating the unary operator `-`.
 
@@ -1563,7 +1650,10 @@ stages:
 
       ### Tests
 
-      The tester will run a series of tests with `test.lox` files that contain expressions with the binary operators `*` & `/`, There is a high probability that the expression will throw a runtime error.
+      The tester will test your program using a `test.lox` file that contains an expression with the binary operators `*` or `/`. This expression
+      will contain a usage of the `*` or `/` operator that should throw a runtime error.
+
+      The binary operators `*` & `/` will throw a runtime error if the operands are not both numbers.
 
       For example, if `test.lox` contains the following:
 
@@ -1579,16 +1669,23 @@ stages:
       [line 1]
       ```
 
-      The tester will ONLY assert that the exit code of your program is 70 in case of a runtime error.
-      Or if the exit code is 0, the tester will assert that the stdout of your program matches the format above.
+      The tester will run multiple such tests with randomized expressions, for example:
+
+      | Input | Expected output |
+      | :---: | :-------------: |
+      | `"foo" * 42` | `Operands must be numbers.` |
+      | `true / 2` | `Operands must be numbers.` |
+      | `("foo" * "bar")` | `Operands must be numbers.` |
+      | `false / true` | `Operands must be numbers. `|
+
+      The tester will assert that the exit code is 70, signifying a runtime error. Note that this is different from the expected exit code for a syntax error, which is 65.
 
       ### Notes
 
       - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/evaluate.lox)
-      - The binary operators `*` & `/` will throw a runtime error if both the operands are not numbers.
     marketing_md: |-
       In this stage, you'll implement support for handling runtime errors while evaluating the binary operators `*` & `/`.
-  
+
   - slug: "cq1"
     primary_extension_slug: "evaluating-expressions"
     name: "Runtime Errors: Binary Operators (2/2)"
@@ -1602,7 +1699,10 @@ stages:
 
       ### Tests
 
-      The tester will run a series of tests with `test.lox` files that contain expressions with the binary operators `+` & `-`, There is a high probability that the expression will throw a runtime error.
+      The tester will test your program using a `test.lox` file that contains an expression with the binary operators `+` or `-`. This expression
+      will contain usages of the `+` or `-` operator that should throw a runtime error.
+
+      The binary operators `+` & `-` will throw a runtime error if the operands are not both numbers or both strings.
 
       For example, if `test.lox` contains the following:
 
@@ -1618,13 +1718,20 @@ stages:
       [line 1]
       ```
 
-      The tester will ONLY assert that the exit code of your program is 70 in case of a runtime error.
-      Or if the exit code is 0, the tester will assert that the stdout of your program matches the format above.
+      The tester will run multiple such tests with randomized expressions, for example:
+
+      | Input | Expected output |
+      | :---: | :-------------: |
+      | `"foo" + true` | `Operands must be numbers.` |
+      | `42 - true` | `Operands must be numbers.` |
+      | `true + false` | `Operands must be numbers.` |
+      | `"foo" - "bar"` | `Operands must be numbers. `|
+
+      The tester will assert that the exit code is 70, signifying a runtime error. Note that this is different from the expected exit code for a syntax error, which is 65.
 
       ### Notes
 
       - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/evaluate.lox)
-      - The binary operators `+` & `-` will throw a runtime error if both the operands are not both numbers or both strings.
     marketing_md: |-
       In this stage, you'll implement support for handling runtime errors while evaluating the binary operators `+` & `-`.
 
@@ -1643,6 +1750,11 @@ stages:
 
       The tester will run a series of tests with `test.lox` files that contain expressions with the relational operators `>`, `<`, `>=` & `<=`, There is a high probability that the expression will throw a runtime error.
 
+      The tester will test your program using a `test.lox` file that contains an expression with the relational operator `>`, `<`, `>=` or `<=`. This expression
+      will contain a usage of the relational operator that should throw a runtime error.
+
+      The relational operators `>`, `<`, `>=` & `<=` will throw a runtime error if the operands are not numbers.
+
       For example, if `test.lox` contains the following:
 
       ```
@@ -1657,12 +1769,23 @@ stages:
       [line 1]
       ```
 
-      The tester will ONLY assert that the exit code of your program is 70 in case of a runtime error.
-      Or if the exit code is 0, the tester will assert that the stdout of your program matches the format above.
+      The tester will run multiple such tests with randomized expressions, for example:
+
+      | Input | Expected output |
+      | :---: | :-------------: |
+      | `"foo" < false` | `Operands must be numbers.` |
+      | `true < 2` | `Operands must be numbers.` |
+      | `("foo" + "bar") < 42` | `Operands must be numbers.` |
+      | `false > true` | `Operands must be numbers. `|
+
+      The tester will assert that the exit code is 70, signifying a runtime error. Note that this is different from the expected exit code for a syntax error, which is 65.
 
       ### Notes
 
       - This output format matches the spec in the [book's repository](https://github.com/munificent/craftinginterpreters/blob/01e6f5b8f3e5dfa65674c2f9cf4700d73ab41cf8/test/expressions/evaluate.lox)
-      - The relational operators `>`, `<`, `>=` & `<=` will throw a runtime error if the operands are not numbers.
     marketing_md: |-
       In this stage, you'll implement support for handling runtime errors while evaluating the relational operators `>`, `<`, `>=` & `<=`.
+
+# Statements & State
+
+  - slug: "xy1"

--- a/internal/test_helpers/jlox08/codecrafters.yml
+++ b/internal/test_helpers/jlox08/codecrafters.yml
@@ -1,0 +1,11 @@
+# Set this to true if you want debug logs.
+#
+# These can be VERY verbose, so we suggest turning them off
+# unless you really need them.
+debug: true
+
+# Use this to change the Python version used to run your code
+# on Codecrafters.
+#
+# Available versions: java-21
+language_pack: java-21

--- a/internal/test_helpers/jlox08/jlox
+++ b/internal/test_helpers/jlox08/jlox
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+script_dir=$(dirname "$0")
+java -cp ${script_dir} com.craftinginterpreters.lox.Lox $@

--- a/internal/test_helpers/jlox08/your_program.sh
+++ b/internal/test_helpers/jlox08/your_program.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 run <filename>"
+  exit 1
+fi
+
+command=$1
+filename=$2
+script_dir=$(dirname "$0")
+
+if [ ! -f "$filename" ]; then
+  echo "File $filename does not exist."
+  exit 1
+fi
+
+case "$command" in
+  run)
+    ${script_dir}/jlox "$filename"
+    ;;
+  *)
+    echo "Unknown command: $command"
+    echo "Usage: $0 run <filename>"
+    exit 1
+    ;;
+esac

--- a/internal/test_programs/s1/1.lox
+++ b/internal/test_programs/s1/1.lox
@@ -1,0 +1,3 @@
+print "one";
+print true;
+print 2 + 1;

--- a/internal/test_programs/s1/1.lox
+++ b/internal/test_programs/s1/1.lox
@@ -1,3 +1,6 @@
-print "one";
-print true;
-print 2 + 1;
+print <<RANDOM_QUOTED_STRING>>;
+print <<RANDOM_BOOLEAN>>;
+print <<RANDOM_INTEGER>> + <<RANDOM_INTEGER>>;
+print <<RANDOM_QUOTED_STRING>>;
+print <<RANDOM_BOOLEAN>>;
+print <<RANDOM_INTEGER>> + <<RANDOM_INTEGER>>;

--- a/internal/test_programs/s1/2.lox
+++ b/internal/test_programs/s1/2.lox
@@ -1,0 +1,1 @@
+print "Hello, world!";

--- a/internal/test_programs/s1/3.lox
+++ b/internal/test_programs/s1/3.lox
@@ -1,0 +1,2 @@
+<<RANDOM_INTEGER>> + <<RANDOM_INTEGER>>;
+print "this is valid";

--- a/internal/test_programs/s1/4.lox
+++ b/internal/test_programs/s1/4.lox
@@ -1,0 +1,3 @@
+print "the expression below is invalid";
+<<RANDOM_INTEGER>> + <<RANDOM_QUOTED_STRING>>;
+print "this should not be printed";

--- a/internal/tester_definition.go
+++ b/internal/tester_definition.go
@@ -161,5 +161,9 @@ var testerDefinition = tester_definition.TesterDefinition{
 			Slug:     "ib5",
 			TestFunc: testEvaluateCompErrors,
 		},
+		{
+			Slug:     "xy1",
+			TestFunc: testStatements1,
+		},
 	},
 }

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -34,8 +34,10 @@ func getRandBoolean() string {
 func GetTestProgramsForCurrentStage() []string {
 	var testPrograms []string
 
-	// Get caller info for the caller of this function
-	_, file, no, ok := runtime.Caller(1)
+	// Get caller info for the caller of this function (testStatements1())
+	// GetTestProgramsForCurrentStage() <- GetTestProgramsForCurrentStageWithRandomValues() <- testStatements1()
+	// We skip over 2 frames, to get to testStatements1()
+	_, file, no, ok := runtime.Caller(2)
 	if !ok {
 		panic(fmt.Sprintf("CodeCrafters Internal Error: Encountered error while getting caller info: %s#%d", file, no))
 	}

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 
@@ -56,4 +57,26 @@ func GetTestProgramsForCurrentStage() []string {
 		testPrograms = append(testPrograms, string(contents))
 	}
 	return testPrograms
+}
+
+func replace(program string) string {
+	rePlaceholder := regexp.MustCompile(`<<(RANDOM_QUOTED_STRING|RANDOM_BOOLEAN|RANDOM_INTEGER)>>`)
+
+	// Replace placeholders with random values
+	result := rePlaceholder.ReplaceAllStringFunc(program, func(match string) string {
+		switch match {
+		case "<<RANDOM_STRING>>":
+			return random.RandomElementFromArray(STRINGS)
+		case "<<RANDOM_QUOTED_STRING>>":
+			return random.RandomElementFromArray(QUOTED_STRINGS)
+		case "<<RANDOM_BOOLEAN>>":
+			return random.RandomElementFromArray(BOOLEANS)
+		case "<<RANDOM_INTEGER>>":
+			return getRandIntAsString()
+		default:
+			return match
+		}
+	})
+
+	return result
 }

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -59,11 +59,11 @@ func GetTestProgramsForCurrentStage() []string {
 	return testPrograms
 }
 
-func replace(program string) string {
-	rePlaceholder := regexp.MustCompile(`<<(RANDOM_QUOTED_STRING|RANDOM_BOOLEAN|RANDOM_INTEGER)>>`)
+func ReplacePlaceholdersWithRandomValues(program string) string {
+	regexPlaceholder := regexp.MustCompile(`<<(RANDOM_STRING|RANDOM_QUOTED_STRING|RANDOM_BOOLEAN|RANDOM_INTEGER)>>`)
 
 	// Replace placeholders with random values
-	result := rePlaceholder.ReplaceAllStringFunc(program, func(match string) string {
+	result := regexPlaceholder.ReplaceAllStringFunc(program, func(match string) string {
 		switch match {
 		case "<<RANDOM_STRING>>":
 			return random.RandomElementFromArray(STRINGS)
@@ -79,4 +79,14 @@ func replace(program string) string {
 	})
 
 	return result
+}
+
+func GetTestProgramsForCurrentStageWithRandomValues() []string {
+	var testPrograms []string
+
+	for _, program := range GetTestProgramsForCurrentStage() {
+		testPrograms = append(testPrograms, ReplacePlaceholdersWithRandomValues(program))
+	}
+
+	return testPrograms
 }

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -2,6 +2,10 @@ package internal
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 
 	"github.com/codecrafters-io/tester-utils/random"
 )
@@ -20,4 +24,36 @@ func getRandString() string {
 
 func getRandBoolean() string {
 	return random.RandomElementFromArray(BOOLEANS)
+}
+
+// From the "statements & state" extension onwards, we'll need to pass multi line programs for testing.
+// To make it easier to work with and track changes, all the test programs are stored in the test_programs directory.
+// Every stage has its own directory. (For example, stage_s1.go has a test_programs/s1 directory.)
+// This function reads all the files in the test_programs/<<stage_id>> directory and returns their contents as a slice of strings.
+func GetTestProgramsForCurrentStage() []string {
+	var testPrograms []string
+
+	// Get caller info for the caller of this function
+	_, file, no, ok := runtime.Caller(1)
+	if !ok {
+		panic(fmt.Sprintf("CodeCrafters Internal Error: Encountered error while getting caller info: %s#%d", file, no))
+	}
+
+	parentDir := filepath.Dir(file)
+	stageIdentifier := strings.Split(strings.Split(file, ".")[0], "_")[1]
+	testDir := filepath.Join(parentDir, "test_programs", stageIdentifier)
+	files, err := os.ReadDir(testDir)
+	if err != nil {
+		panic(fmt.Sprintf("CodeCrafters Internal Error: Encountered error while reading test directory: %s", err))
+	}
+
+	for _, file := range files {
+		filePath := filepath.Join(testDir, file.Name())
+		contents, err := os.ReadFile(filePath)
+		if err != nil {
+			panic(fmt.Sprintf("CodeCrafters Internal Error: Encountered error while reading test file: %s", err))
+		}
+		testPrograms = append(testPrograms, string(contents))
+	}
+	return testPrograms
 }

--- a/setup-local-testing.sh
+++ b/setup-local-testing.sh
@@ -15,4 +15,7 @@ sed -i '' 's/Lox\.error(line, "Unexpected character\.");/Lox\.error(line, "Unexp
 make java_chapters
 cd ..
 cp -r ./internal/test_helpers/jlox04/* ./craftinginterpreters/build/gen/chap04_scanning
+cp -r ./internal/test_helpers/jlox06/* ./craftinginterpreters/build/gen/chap06_parsing
+cp -r ./internal/test_helpers/jlox07/* ./craftinginterpreters/build/gen/chap07_evaluating
+cp -r ./internal/test_helpers/jlox08/* ./craftinginterpreters/build/gen/chap08_statements
 make test


### PR DESCRIPTION
This pull request includes enhancements to the grammar for the conclusion of chapter 8. It updates the parser and interpreter to support statements and state. Additionally, the print and interpret functions have been refactored to return results to the caller. The pull request also adds a run API and test case helpers for the `run` functionality of the interpreter. Comments have been removed as part of the chore.