### PR TITLE
CC-1368: Update tests to handle -0 and trigger 0 always

### DIFF
--- a/internal/stage_e6.go
+++ b/internal/stage_e6.go
@@ -14,10 +14,11 @@ func testEvaluateTerm(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	logger := stageHarness.Logger
 
+	n1 := getRandInt()
 	term1 := fmt.Sprintf("%d - %d", getRandInt(), getRandInt())
 	term2 := fmt.Sprintf("%d + %d - %d", getRandInt(), getRandInt(), getRandInt())
 	term3 := fmt.Sprintf("%d + %d - (-(%d - %d))", getRandInt(), getRandInt(), getRandInt(), getRandInt())
-	term4 := fmt.Sprintf("-(-%d + %d) * (%d * %d) / (1 + 4)", getRandInt(), getRandInt(), getRandInt(), getRandInt())
+	term4 := fmt.Sprintf("(-%d + %d) * (%d * %d) / (1 + 4)", n1, n1, getRandInt(), getRandInt())
 
 	evaluateTestCases := testcases.MultiEvaluateTestCase{
 		FileContents: []string{term1, term2, term3, term4},

--- a/internal/stage_p7.go
+++ b/internal/stage_p7.go
@@ -16,7 +16,7 @@ func testParseTerms(stageHarness *test_case_harness.TestCaseHarness) error {
 	termExpr1 := "\"hello\" + \"world\""
 	termExpr2 := fmt.Sprintf("%d - %d - %d", getRandInt(), getRandInt(), getRandInt())
 	termExpr3 := fmt.Sprintf("%d + %d - %d", getRandInt(), getRandInt(), getRandInt())
-	termExpr4 := fmt.Sprintf("-(-%d + %d) * (%d * %d) / (%d + %d)", getRandInt(), getRandInt(), getRandInt(), getRandInt(), getRandInt(), getRandInt())
+	termExpr4 := fmt.Sprintf("(-%d + %d) * (%d * %d) / (%d + %d)", getRandInt(), getRandInt(), getRandInt(), getRandInt(), getRandInt(), getRandInt())
 	parseTestCase := testcases.MultiParseTestCase{
 		FileContents: []string{termExpr1, termExpr2, termExpr3, termExpr4},
 	}

--- a/internal/test_helpers/fixtures/pass_evaluating
+++ b/internal/test_helpers/fixtures/pass_evaluating
@@ -236,30 +236,30 @@ Debug = true
 [33m[stage-6] [0m[94mRunning tests for Stage #6: jy2[0m
 [33m[stage-6] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-6] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-6] [test-1] [0m[33m[test.lox][0m 97 - 64
+[33m[stage-6] [test-1] [0m[33m[test.lox][0m 64 - 68
 [33m[stage-6] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m33
+[33m[your_program] [0m-4
 [33m[stage-6] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-6] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-6] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-6] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-6] [test-2] [0m[33m[test.lox][0m 68 + 92 - 53
+[33m[stage-6] [test-2] [0m[33m[test.lox][0m 92 + 53 - 75
 [33m[stage-6] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m107
+[33m[your_program] [0m70
 [33m[stage-6] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-6] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-6] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-6] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-6] [test-3] [0m[33m[test.lox][0m 75 + 57 - (-(93 - 67))
+[33m[stage-6] [test-3] [0m[33m[test.lox][0m 57 + 93 - (-(67 - 57))
 [33m[stage-6] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m158
+[33m[your_program] [0m160
 [33m[stage-6] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-6] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-6] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-6] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-6] [test-4] [0m[33m[test.lox][0m -(-57 + 34) * (77 * 51) / (1 + 4)
+[33m[stage-6] [test-4] [0m[33m[test.lox][0m (-97 + 97) * (34 * 77) / (1 + 4)
 [33m[stage-6] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m18064.2
+[33m[your_program] [0m0
 [33m[stage-6] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-6] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-6] [0m[92mTest passed.[0m
@@ -267,9 +267,9 @@ Debug = true
 [33m[stage-5] [0m[94mRunning tests for Stage #5: bp3[0m
 [33m[stage-5] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-5] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-5] [test-1] [0m[33m[test.lox][0m 29 * 75
+[33m[stage-5] [test-1] [0m[33m[test.lox][0m 52 * 29
 [33m[stage-5] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m2175
+[33m[your_program] [0m1508
 [33m[stage-5] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-5] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-5] [test-2] [0m[94mRunning test case: 2[0m
@@ -281,16 +281,16 @@ Debug = true
 [33m[stage-5] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-5] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-5] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-5] [test-3] [0m[33m[test.lox][0m 7 * 2 / 7 / 1
+[33m[stage-5] [test-3] [0m[33m[test.lox][0m 7 * 4 / 7 / 1
 [33m[stage-5] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m2
+[33m[your_program] [0m4
 [33m[stage-5] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-5] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-5] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-5] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-5] [test-4] [0m[33m[test.lox][0m (18 * 2 / (3 * 6))
+[33m[stage-5] [test-4] [0m[33m[test.lox][0m (18 * 4 / (3 * 6))
 [33m[stage-5] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m2
+[33m[your_program] [0m4
 [33m[stage-5] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-5] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-5] [0m[92mTest passed.[0m
@@ -298,9 +298,9 @@ Debug = true
 [33m[stage-4] [0m[94mRunning tests for Stage #4: dc1[0m
 [33m[stage-4] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-4] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-4] [test-1] [0m[33m[test.lox][0m -32
+[33m[stage-4] [test-1] [0m[33m[test.lox][0m -75
 [33m[stage-4] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m-32
+[33m[your_program] [0m-75
 [33m[stage-4] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-4] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-4] [test-2] [0m[94mRunning test case: 2[0m
@@ -319,7 +319,7 @@ Debug = true
 [33m[stage-4] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-4] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-4] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-4] [test-4] [0m[33m[test.lox][0m (!!95)
+[33m[stage-4] [test-4] [0m[33m[test.lox][0m (!!61)
 [33m[stage-4] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
 [33m[your_program] [0mtrue
 [33m[stage-4] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
@@ -336,23 +336,23 @@ Debug = true
 [33m[stage-3] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-3] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-3] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-3] [test-2] [0m[33m[test.lox][0m (61)
+[33m[stage-3] [test-2] [0m[33m[test.lox][0m (95)
 [33m[stage-3] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m61
+[33m[your_program] [0m95
 [33m[stage-3] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-3] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-3] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-3] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-3] [test-3] [0m[33m[test.lox][0m ("foo quz")
+[33m[stage-3] [test-3] [0m[33m[test.lox][0m ("world bar")
 [33m[stage-3] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mfoo quz
+[33m[your_program] [0mworld bar
 [33m[stage-3] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-3] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-3] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-3] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-3] [test-4] [0m[33m[test.lox][0m ((true))
+[33m[stage-3] [test-4] [0m[33m[test.lox][0m ((false))
 [33m[stage-3] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mtrue
+[33m[your_program] [0mfalse
 [33m[stage-3] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-3] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-3] [0m[92mTest passed.[0m
@@ -367,23 +367,23 @@ Debug = true
 [33m[stage-2] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-2] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-2] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-2] [test-2] [0m[33m[test.lox][0m 96.50
+[33m[stage-2] [test-2] [0m[33m[test.lox][0m 51.96
 [33m[stage-2] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m96.5
+[33m[your_program] [0m51.96
 [33m[stage-2] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-2] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-2] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-2] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-2] [test-3] [0m[33m[test.lox][0m "baz world"
+[33m[stage-2] [test-3] [0m[33m[test.lox][0m "quz hello"
 [33m[stage-2] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mbaz world
+[33m[your_program] [0mquz hello
 [33m[stage-2] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-2] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-2] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-2] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-2] [test-4] [0m[33m[test.lox][0m "24"
+[33m[stage-2] [test-4] [0m[33m[test.lox][0m "71"
 [33m[stage-2] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m24
+[33m[your_program] [0m71
 [33m[stage-2] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-2] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-2] [0m[92mTest passed.[0m

--- a/internal/test_helpers/fixtures/pass_parsing
+++ b/internal/test_helpers/fixtures/pass_parsing
@@ -111,9 +111,9 @@ Debug = true
 [33m[stage-7] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-7] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-7] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-7] [test-4] [0m[33m[test.lox][0m -(-99 + 91) * (10 * 69) / (52 + 20)
+[33m[stage-7] [test-4] [0m[33m[test.lox][0m (-99 + 91) * (10 * 69) / (52 + 20)
 [33m[stage-7] [test-4] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(/ (* (- (group (+ (- 99.0) 91.0))) (group (* 10.0 69.0))) (group (+ 52.0 20.0)))
+[33m[your_program] [0m(/ (* (group (+ (- 99.0) 91.0)) (group (* 10.0 69.0))) (group (+ 52.0 20.0)))
 [33m[stage-7] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-7] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-7] [0m[92mTest passed.[0m


### PR DESCRIPTION
Update tests so that we never generate `-0` accidentally. 
(Seems like a weird edge case not implemented at this stage by official jlox.)