### PR TITLE
Avoid edge case-y test in equality/assignment stage

### DIFF
--- a/internal/stage6.go
+++ b/internal/stage6.go
@@ -18,7 +18,7 @@ func testEquality(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	shuffledString1 := "((" + strings.Join(random.RandomElementsFromArray(slices.Concat(LEXICAL_ERRORS, EQUALS), 5), "") + "))"
 	tokenizeTestCases := testcases.MultiTokenizeTestCase{
-		FileContents: []string{"=", "===", "({=}){=====}", shuffledString1},
+		FileContents: []string{"=", "==", "({=}){==}", shuffledString1},
 	}
 	return tokenizeTestCases.RunAll(b, logger)
 }

--- a/internal/test_helpers/fixtures/pass_scanning
+++ b/internal/test_helpers/fixtures/pass_scanning
@@ -615,16 +615,15 @@ Debug = true
 [33m[stage-6] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-6] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-6] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-6] [test-2] [0m[33m[test.lox][0m ===
+[33m[stage-6] [test-2] [0m[33m[test.lox][0m ==
 [33m[stage-6] [test-2] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0mEQUAL_EQUAL == null
-[33m[your_program] [0mEQUAL = null
 [33m[your_program] [0mEOF  null
-[33m[stage-6] [test-2] [0m[92m✓ 3 line(s) match on stdout[0m
+[33m[stage-6] [test-2] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[stage-6] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-6] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-6] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-6] [test-3] [0m[33m[test.lox][0m ({=}){=====}
+[33m[stage-6] [test-3] [0m[33m[test.lox][0m ({=}){==}
 [33m[stage-6] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mLEFT_BRACE { null
@@ -633,11 +632,9 @@ Debug = true
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mLEFT_BRACE { null
 [33m[your_program] [0mEQUAL_EQUAL == null
-[33m[your_program] [0mEQUAL_EQUAL == null
-[33m[your_program] [0mEQUAL = null
 [33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mEOF  null
-[33m[stage-6] [test-3] [0m[92m✓ 11 line(s) match on stdout[0m
+[33m[stage-6] [test-3] [0m[92m✓ 9 line(s) match on stdout[0m
 [33m[stage-6] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-6] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-6] [test-4] [0m[94mWriting contents to ./test.lox:[0m


### PR DESCRIPTION
This stage has a lower completion rate than most, and most users seem to trip up on this test case: 
 
<img width="1108" alt="Screenshot 2024-08-23 at 17 44 19" src="https://github.com/user-attachments/assets/cce4f557-724d-41c6-9fe0-00cdadf6cd72">

<img width="1112" alt="Screenshot 2024-08-23 at 17 44 15" src="https://github.com/user-attachments/assets/54fe386f-f220-4ab1-a716-3bdb4324efb8">

<img width="1120" alt="Screenshot 2024-08-23 at 17 44 23" src="https://github.com/user-attachments/assets/ac49b246-d507-4273-bd8d-6c02ca3c5058">

This feels a bit edge case-y, so let's avoid and use simpler tests.