### PR TITLE
Add test case of trailing zeroes for Scanning: Number literals #kj0

### DIFF
--- a/internal/stage13.go
+++ b/internal/stage13.go
@@ -21,6 +21,7 @@ func testNumbers(stageHarness *test_case_harness.TestCaseHarness) error {
 		TestCases: []testcases.TokenizeTestCase{
 			{FileContents: getRandIntAsString(), ExpectsError: false},
 			{FileContents: fmt.Sprintf("%d.%d", getRandInt(), getRandInt()), ExpectsError: false},
+			{FileContents: fmt.Sprintf("%d.0000", getRandInt()), ExpectsError: false},
 			{FileContents: shuffledString1, ExpectsError: false},
 			{FileContents: shuffledString2, ExpectsError: false},
 		},

--- a/internal/stage13.go
+++ b/internal/stage13.go
@@ -14,8 +14,7 @@ func testNumbers(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	logger := stageHarness.Logger
 
-	shuffledString1 := fmt.Sprintf(`"%s" = "%s" != (%d == %d)`, getRandString(), getRandString(), getRandInt(), getRandInt())
-	shuffledString2 := fmt.Sprintf(`(%d+%d) > %d != ("Success" != "Failure") != (%d >= %d)`, getRandInt(), getRandInt(), getRandInt(), getRandInt(), getRandInt())
+	shuffledString1 := fmt.Sprintf(`(%d+%d) > %d != ("Success" != "Failure") != (%d >= %d)`, getRandInt(), getRandInt(), getRandInt(), getRandInt(), getRandInt())
 
 	tokenizeTestCases := testcases.MultiTokenizeTestCase{
 		TestCases: []testcases.TokenizeTestCase{
@@ -23,7 +22,6 @@ func testNumbers(stageHarness *test_case_harness.TestCaseHarness) error {
 			{FileContents: fmt.Sprintf("%d.%d", getRandInt(), getRandInt()), ExpectsError: false},
 			{FileContents: fmt.Sprintf("%d.0000", getRandInt()), ExpectsError: false},
 			{FileContents: shuffledString1, ExpectsError: false},
-			{FileContents: shuffledString2, ExpectsError: false},
 		},
 	}
 	return tokenizeTestCases.RunAll(b, logger)

--- a/internal/test_helpers/fixtures/pass_scanning
+++ b/internal/test_helpers/fixtures/pass_scanning
@@ -241,8 +241,16 @@ Debug = true
 [33m[stage-13] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-13] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-13] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-13] [test-3] [0m[33m[test.lox][0m "bar" = "world" != (30 == 52)
+[33m[stage-13] [test-3] [0m[33m[test.lox][0m 19.0000
 [33m[stage-13] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
+[33m[your_program] [0mNUMBER 19.0000 19.0
+[33m[your_program] [0mEOF  null
+[33m[stage-13] [test-3] [0m[92m✓ 2 line(s) match on stdout[0m
+[33m[stage-13] [test-3] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-13] [test-4] [0m[94mRunning test case: 4[0m
+[33m[stage-13] [test-4] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-13] [test-4] [0m[33m[test.lox][0m "bar" = "world" != (30 == 52)
+[33m[stage-13] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0mSTRING "bar" bar
 [33m[your_program] [0mEQUAL = null
 [33m[your_program] [0mSTRING "world" world
@@ -253,12 +261,12 @@ Debug = true
 [33m[your_program] [0mNUMBER 52 52.0
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mEOF  null
-[33m[stage-13] [test-3] [0m[92m✓ 10 line(s) match on stdout[0m
-[33m[stage-13] [test-3] [0m[92m✓ Received exit code 0.[0m
-[33m[stage-13] [test-4] [0m[94mRunning test case: 4[0m
-[33m[stage-13] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-13] [test-4] [0m[33m[test.lox][0m (30+89) > 29 != ("Success" != "Failure") != (17 >= 54)
-[33m[stage-13] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
+[33m[stage-13] [test-4] [0m[92m✓ 10 line(s) match on stdout[0m
+[33m[stage-13] [test-4] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-13] [test-5] [0m[94mRunning test case: 5[0m
+[33m[stage-13] [test-5] [0m[94mWriting contents to ./test.lox:[0m
+[33m[stage-13] [test-5] [0m[33m[test.lox][0m (30+89) > 29 != ("Success" != "Failure") != (17 >= 54)
+[33m[stage-13] [test-5] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mNUMBER 30 30.0
 [33m[your_program] [0mPLUS + null
@@ -279,8 +287,8 @@ Debug = true
 [33m[your_program] [0mNUMBER 54 54.0
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mEOF  null
-[33m[stage-13] [test-4] [0m[92m✓ 20 line(s) match on stdout[0m
-[33m[stage-13] [test-4] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-13] [test-5] [0m[92m✓ 20 line(s) match on stdout[0m
+[33m[stage-13] [test-5] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-13] [0m[92mTest passed.[0m
 
 [33m[stage-12] [0m[94mRunning tests for Stage #12: ue7[0m
@@ -294,10 +302,10 @@ Debug = true
 [33m[stage-12] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-12] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-12] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-12] [test-2] [0m[33m[test.lox][0m "hello" "unterminated
+[33m[stage-12] [test-2] [0m[33m[test.lox][0m "baz" "unterminated
 [33m[stage-12] [test-2] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0m[line 1] Error: Unterminated string.
-[33m[your_program] [0mSTRING "hello" hello
+[33m[your_program] [0mSTRING "baz" baz
 [33m[your_program] [0mEOF  null
 [33m[stage-12] [test-2] [0m[92m✓ 1 line(s) match on stderr[0m
 [33m[stage-12] [test-2] [0m[92m✓ 2 line(s) match on stdout[0m
@@ -312,12 +320,12 @@ Debug = true
 [33m[stage-12] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-12] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-12] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-12] [test-4] [0m[33m[test.lox][0m ("hello"+"world") != "other_string"
+[33m[stage-12] [test-4] [0m[33m[test.lox][0m ("foo"+"baz") != "other_string"
 [33m[stage-12] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mSTRING "hello" hello
+[33m[your_program] [0mSTRING "foo" foo
 [33m[your_program] [0mPLUS + null
-[33m[your_program] [0mSTRING "world" world
+[33m[your_program] [0mSTRING "baz" baz
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mBANG_EQUAL != null
 [33m[your_program] [0mSTRING "other_string" other_string
@@ -340,11 +348,11 @@ Debug = true
 [33m[stage-11] [test-1] [0m[92m✓ Received exit code 65.[0m
 [33m[stage-11] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-11] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-11] [test-2] [0m[33m[test.lox][0m $% #
+[33m[stage-11] [test-2] [0m[33m[test.lox][0m <|TAB|>@%$
 [33m[stage-11] [test-2] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0m[line 1] Error: Unexpected character: $
+[33m[your_program] [0m[line 1] Error: Unexpected character: @
 [33m[your_program] [0m[line 1] Error: Unexpected character: %
-[33m[your_program] [0m[line 1] Error: Unexpected character: #
+[33m[your_program] [0m[line 1] Error: Unexpected character: $
 [33m[your_program] [0mEOF  null
 [33m[stage-11] [test-2] [0m[92m✓ 3 line(s) match on stderr[0m
 [33m[stage-11] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
@@ -379,12 +387,12 @@ Debug = true
 [33m[stage-11] [test-3] [0m[92m✓ Received exit code 65.[0m
 [33m[stage-11] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-11] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-11] [test-4] [0m[33m[test.lox][0m ({* @})
+[33m[stage-11] [test-4] [0m[33m[test.lox][0m ({, %})
 [33m[stage-11] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0m[line 1] Error: Unexpected character: @
+[33m[your_program] [0m[line 1] Error: Unexpected character: %
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mLEFT_BRACE { null
-[33m[your_program] [0mSTAR * null
+[33m[your_program] [0mCOMMA , null
 [33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mEOF  null
@@ -411,8 +419,9 @@ Debug = true
 [33m[stage-10] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-10] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-10] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-10] [test-3] [0m[33m[test.lox][0m {<|SPACE|>}
-[33m[stage-10] [test-3] [0m[33m[test.lox][0m ((-;<|TAB|>. ))
+[33m[stage-10] [test-3] [0m[33m[test.lox][0m {<|TAB|>
+[33m[stage-10] [test-3] [0m[33m[test.lox][0m }
+[33m[stage-10] [test-3] [0m[33m[test.lox][0m ((-;+,<|TAB|>))
 [33m[stage-10] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0mLEFT_BRACE { null
 [33m[your_program] [0mRIGHT_BRACE } null
@@ -420,31 +429,31 @@ Debug = true
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mMINUS - null
 [33m[your_program] [0mSEMICOLON ; null
-[33m[your_program] [0mDOT . null
+[33m[your_program] [0mPLUS + null
+[33m[your_program] [0mCOMMA , null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mEOF  null
-[33m[stage-10] [test-3] [0m[92m✓ 10 line(s) match on stdout[0m
+[33m[stage-10] [test-3] [0m[92m✓ 11 line(s) match on stdout[0m
 [33m[stage-10] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-10] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-10] [test-4] [0m[94mWriting contents to ./test.lox:[0m
 [33m[stage-10] [test-4] [0m[33m[test.lox][0m {
-[33m[stage-10] [test-4] [0m[33m[test.lox][0m <|TAB|>
-[33m[stage-10] [test-4] [0m[33m[test.lox][0m <|TAB|> }
-[33m[stage-10] [test-4] [0m[33m[test.lox][0m ((* ><>=))
+[33m[stage-10] [test-4] [0m[33m[test.lox][0m <|TAB|><|TAB|><|SPACE|>}
+[33m[stage-10] [test-4] [0m[33m[test.lox][0m ((* <
+[33m[stage-10] [test-4] [0m[33m[test.lox][0m >=))
 [33m[stage-10] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0mLEFT_BRACE { null
 [33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mSTAR * null
-[33m[your_program] [0mGREATER > null
 [33m[your_program] [0mLESS < null
 [33m[your_program] [0mGREATER_EQUAL >= null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mEOF  null
-[33m[stage-10] [test-4] [0m[92m✓ 11 line(s) match on stdout[0m
+[33m[stage-10] [test-4] [0m[92m✓ 10 line(s) match on stdout[0m
 [33m[stage-10] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-10] [0m[92mTest passed.[0m
 
@@ -474,14 +483,14 @@ Debug = true
 [33m[stage-9] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-9] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-9] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-9] [test-4] [0m[33m[test.lox][0m ({(-*+)})//Comment
+[33m[stage-9] [test-4] [0m[33m[test.lox][0m ({(.=,)})//Comment
 [33m[stage-9] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mLEFT_BRACE { null
 [33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mMINUS - null
-[33m[your_program] [0mSTAR * null
-[33m[your_program] [0mPLUS + null
+[33m[your_program] [0mDOT . null
+[33m[your_program] [0mEQUAL = null
+[33m[your_program] [0mCOMMA , null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mRIGHT_PAREN ) null
@@ -514,29 +523,28 @@ Debug = true
 [33m[stage-8] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-8] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-8] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-8] [test-3] [0m[33m[test.lox][0m ><>=>>=
+[33m[stage-8] [test-3] [0m[33m[test.lox][0m >=><=<=>=
 [33m[stage-8] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mGREATER > null
-[33m[your_program] [0mLESS < null
 [33m[your_program] [0mGREATER_EQUAL >= null
 [33m[your_program] [0mGREATER > null
+[33m[your_program] [0mLESS_EQUAL <= null
+[33m[your_program] [0mLESS_EQUAL <= null
 [33m[your_program] [0mGREATER_EQUAL >= null
 [33m[your_program] [0mEOF  null
 [33m[stage-8] [test-3] [0m[92m✓ 6 line(s) match on stdout[0m
 [33m[stage-8] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-8] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-8] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-8] [test-4] [0m[33m[test.lox][0m (){>===<}
+[33m[stage-8] [test-4] [0m[33m[test.lox][0m (){<=!=}
 [33m[stage-8] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mLEFT_BRACE { null
-[33m[your_program] [0mGREATER_EQUAL >= null
-[33m[your_program] [0mEQUAL_EQUAL == null
-[33m[your_program] [0mLESS < null
+[33m[your_program] [0mLESS_EQUAL <= null
+[33m[your_program] [0mBANG_EQUAL != null
 [33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mEOF  null
-[33m[stage-8] [test-4] [0m[92m✓ 8 line(s) match on stdout[0m
+[33m[stage-8] [test-4] [0m[92m✓ 7 line(s) match on stdout[0m
 [33m[stage-8] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-8] [0m[92mTest passed.[0m
 
@@ -577,20 +585,20 @@ Debug = true
 [33m[stage-7] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-7] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-7] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-7] [test-4] [0m[33m[test.lox][0m {(@!#==%)}
+[33m[stage-7] [test-4] [0m[33m[test.lox][0m {(!=%@==!)}
 [33m[stage-7] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0m[line 1] Error: Unexpected character: @
-[33m[your_program] [0m[line 1] Error: Unexpected character: #
 [33m[your_program] [0m[line 1] Error: Unexpected character: %
+[33m[your_program] [0m[line 1] Error: Unexpected character: @
 [33m[your_program] [0mLEFT_BRACE { null
 [33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mBANG ! null
+[33m[your_program] [0mBANG_EQUAL != null
 [33m[your_program] [0mEQUAL_EQUAL == null
+[33m[your_program] [0mBANG ! null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mEOF  null
-[33m[stage-7] [test-4] [0m[92m✓ 3 line(s) match on stderr[0m
-[33m[stage-7] [test-4] [0m[92m✓ 7 line(s) match on stdout[0m
+[33m[stage-7] [test-4] [0m[92m✓ 2 line(s) match on stderr[0m
+[33m[stage-7] [test-4] [0m[92m✓ 8 line(s) match on stdout[0m
 [33m[stage-7] [test-4] [0m[92m✓ Received exit code 65.[0m
 [33m[stage-7] [0m[92mTest passed.[0m
 
@@ -628,20 +636,20 @@ Debug = true
 [33m[stage-6] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-6] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-6] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-6] [test-4] [0m[33m[test.lox][0m ((%=@$==))
+[33m[stage-6] [test-4] [0m[33m[test.lox][0m ((=#$%@))
 [33m[stage-6] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
+[33m[your_program] [0m[line 1] Error: Unexpected character: #
+[33m[your_program] [0m[line 1] Error: Unexpected character: $
 [33m[your_program] [0m[line 1] Error: Unexpected character: %
 [33m[your_program] [0m[line 1] Error: Unexpected character: @
-[33m[your_program] [0m[line 1] Error: Unexpected character: $
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mEQUAL = null
-[33m[your_program] [0mEQUAL_EQUAL == null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mEOF  null
-[33m[stage-6] [test-4] [0m[92m✓ 3 line(s) match on stderr[0m
-[33m[stage-6] [test-4] [0m[92m✓ 7 line(s) match on stdout[0m
+[33m[stage-6] [test-4] [0m[92m✓ 4 line(s) match on stderr[0m
+[33m[stage-6] [test-4] [0m[92m✓ 6 line(s) match on stdout[0m
 [33m[stage-6] [test-4] [0m[92m✓ Received exit code 65.[0m
 [33m[stage-6] [0m[92mTest passed.[0m
 
@@ -670,35 +678,35 @@ Debug = true
 [33m[stage-5] [test-2] [0m[92m✓ Received exit code 65.[0m
 [33m[stage-5] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-5] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-5] [test-3] [0m[33m[test.lox][0m @%#$#
+[33m[stage-5] [test-3] [0m[33m[test.lox][0m %$@$@
 [33m[stage-5] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0m[line 1] Error: Unexpected character: @
 [33m[your_program] [0m[line 1] Error: Unexpected character: %
-[33m[your_program] [0m[line 1] Error: Unexpected character: #
 [33m[your_program] [0m[line 1] Error: Unexpected character: $
-[33m[your_program] [0m[line 1] Error: Unexpected character: #
+[33m[your_program] [0m[line 1] Error: Unexpected character: @
+[33m[your_program] [0m[line 1] Error: Unexpected character: $
+[33m[your_program] [0m[line 1] Error: Unexpected character: @
 [33m[your_program] [0mEOF  null
 [33m[stage-5] [test-3] [0m[92m✓ 5 line(s) match on stderr[0m
 [33m[stage-5] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-5] [test-3] [0m[92m✓ Received exit code 65.[0m
 [33m[stage-5] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-5] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-5] [test-4] [0m[33m[test.lox][0m {(-#@%$,.)}
+[33m[stage-5] [test-4] [0m[33m[test.lox][0m {(;-$*@%.)}
 [33m[stage-5] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0m[line 1] Error: Unexpected character: #
+[33m[your_program] [0m[line 1] Error: Unexpected character: $
 [33m[your_program] [0m[line 1] Error: Unexpected character: @
 [33m[your_program] [0m[line 1] Error: Unexpected character: %
-[33m[your_program] [0m[line 1] Error: Unexpected character: $
 [33m[your_program] [0mLEFT_BRACE { null
 [33m[your_program] [0mLEFT_PAREN ( null
+[33m[your_program] [0mSEMICOLON ; null
 [33m[your_program] [0mMINUS - null
-[33m[your_program] [0mCOMMA , null
+[33m[your_program] [0mSTAR * null
 [33m[your_program] [0mDOT . null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mEOF  null
-[33m[stage-5] [test-4] [0m[92m✓ 4 line(s) match on stderr[0m
-[33m[stage-5] [test-4] [0m[92m✓ 8 line(s) match on stdout[0m
+[33m[stage-5] [test-4] [0m[92m✓ 3 line(s) match on stderr[0m
+[33m[stage-5] [test-4] [0m[92m✓ 9 line(s) match on stdout[0m
 [33m[stage-5] [test-4] [0m[92m✓ Received exit code 65.[0m
 [33m[stage-5] [0m[92mTest passed.[0m
 
@@ -733,29 +741,29 @@ Debug = true
 [33m[stage-4] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-4] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-4] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-4] [test-3] [0m[33m[test.lox][0m ;-+-,;*
+[33m[stage-4] [test-3] [0m[33m[test.lox][0m -,+-;.*
 [33m[stage-4] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mSEMICOLON ; null
-[33m[your_program] [0mMINUS - null
-[33m[your_program] [0mPLUS + null
 [33m[your_program] [0mMINUS - null
 [33m[your_program] [0mCOMMA , null
+[33m[your_program] [0mPLUS + null
+[33m[your_program] [0mMINUS - null
 [33m[your_program] [0mSEMICOLON ; null
+[33m[your_program] [0mDOT . null
 [33m[your_program] [0mSTAR * null
 [33m[your_program] [0mEOF  null
 [33m[stage-4] [test-3] [0m[92m✓ 8 line(s) match on stdout[0m
 [33m[stage-4] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-4] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-4] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-4] [test-4] [0m[33m[test.lox][0m ({*;+-.})
+[33m[stage-4] [test-4] [0m[33m[test.lox][0m ({+,-;*})
 [33m[stage-4] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mLEFT_BRACE { null
-[33m[your_program] [0mSTAR * null
-[33m[your_program] [0mSEMICOLON ; null
 [33m[your_program] [0mPLUS + null
+[33m[your_program] [0mCOMMA , null
 [33m[your_program] [0mMINUS - null
-[33m[your_program] [0mDOT . null
+[33m[your_program] [0mSEMICOLON ; null
+[33m[your_program] [0mSTAR * null
 [33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mEOF  null
@@ -785,11 +793,11 @@ Debug = true
 [33m[stage-3] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-3] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-3] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-3] [test-3] [0m[33m[test.lox][0m {{}{}
+[33m[stage-3] [test-3] [0m[33m[test.lox][0m {{{{}
 [33m[stage-3] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0mLEFT_BRACE { null
 [33m[your_program] [0mLEFT_BRACE { null
-[33m[your_program] [0mRIGHT_BRACE } null
+[33m[your_program] [0mLEFT_BRACE { null
 [33m[your_program] [0mLEFT_BRACE { null
 [33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mEOF  null
@@ -797,15 +805,15 @@ Debug = true
 [33m[stage-3] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-3] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-3] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-3] [test-4] [0m[33m[test.lox][0m )}(}{)(
+[33m[stage-3] [test-4] [0m[33m[test.lox][0m }{){)(}
 [33m[stage-3] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mRIGHT_BRACE } null
-[33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mLEFT_BRACE { null
 [33m[your_program] [0mRIGHT_PAREN ) null
+[33m[your_program] [0mLEFT_BRACE { null
+[33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mLEFT_PAREN ( null
+[33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mEOF  null
 [33m[stage-3] [test-4] [0m[92m✓ 8 line(s) match on stdout[0m
 [33m[stage-3] [test-4] [0m[92m✓ Received exit code 0.[0m
@@ -831,27 +839,27 @@ Debug = true
 [33m[stage-2] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-2] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-2] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-2] [test-3] [0m[33m[test.lox][0m )))()
+[33m[stage-2] [test-3] [0m[33m[test.lox][0m )))((
 [33m[stage-2] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mRIGHT_PAREN ) null
+[33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mEOF  null
 [33m[stage-2] [test-3] [0m[92m✓ 6 line(s) match on stdout[0m
 [33m[stage-2] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-2] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-2] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-2] [test-4] [0m[33m[test.lox][0m ))(()()
+[33m[stage-2] [test-4] [0m[33m[test.lox][0m ())(()(
 [33m[stage-2] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
+[33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mEOF  null
 [33m[stage-2] [test-4] [0m[92m✓ 8 line(s) match on stdout[0m
 [33m[stage-2] [test-4] [0m[92m✓ Received exit code 0.[0m

--- a/internal/test_helpers/fixtures/pass_scanning
+++ b/internal/test_helpers/fixtures/pass_scanning
@@ -225,55 +225,39 @@ Debug = true
 [33m[stage-13] [0m[94mRunning tests for Stage #13: kj0[0m
 [33m[stage-13] [test-1] [0m[94mRunning test case: 1[0m
 [33m[stage-13] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-13] [test-1] [0m[33m[test.lox][0m 47
+[33m[stage-13] [test-1] [0m[33m[test.lox][0m 19
 [33m[stage-13] [test-1] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mNUMBER 47 47.0
+[33m[your_program] [0mNUMBER 19 19.0
 [33m[your_program] [0mEOF  null
 [33m[stage-13] [test-1] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[stage-13] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-13] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-13] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-13] [test-2] [0m[33m[test.lox][0m 83.88
+[33m[stage-13] [test-2] [0m[33m[test.lox][0m 81.11
 [33m[stage-13] [test-2] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mNUMBER 83.88 83.88
+[33m[your_program] [0mNUMBER 81.11 81.11
 [33m[your_program] [0mEOF  null
 [33m[stage-13] [test-2] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[stage-13] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-13] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-13] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-13] [test-3] [0m[33m[test.lox][0m 19.0000
+[33m[stage-13] [test-3] [0m[33m[test.lox][0m 95.0000
 [33m[stage-13] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mNUMBER 19.0000 19.0
+[33m[your_program] [0mNUMBER 95.0000 95.0
 [33m[your_program] [0mEOF  null
 [33m[stage-13] [test-3] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[stage-13] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-13] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-13] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-13] [test-4] [0m[33m[test.lox][0m "bar" = "world" != (30 == 52)
+[33m[stage-13] [test-4] [0m[33m[test.lox][0m (80+80) > 80 != ("Success" != "Failure") != (19 >= 82)
 [33m[stage-13] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mSTRING "bar" bar
-[33m[your_program] [0mEQUAL = null
-[33m[your_program] [0mSTRING "world" world
-[33m[your_program] [0mBANG_EQUAL != null
 [33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mNUMBER 30 30.0
-[33m[your_program] [0mEQUAL_EQUAL == null
-[33m[your_program] [0mNUMBER 52 52.0
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mEOF  null
-[33m[stage-13] [test-4] [0m[92m✓ 10 line(s) match on stdout[0m
-[33m[stage-13] [test-4] [0m[92m✓ Received exit code 0.[0m
-[33m[stage-13] [test-5] [0m[94mRunning test case: 5[0m
-[33m[stage-13] [test-5] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-13] [test-5] [0m[33m[test.lox][0m (30+89) > 29 != ("Success" != "Failure") != (17 >= 54)
-[33m[stage-13] [test-5] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mNUMBER 30 30.0
+[33m[your_program] [0mNUMBER 80 80.0
 [33m[your_program] [0mPLUS + null
-[33m[your_program] [0mNUMBER 89 89.0
+[33m[your_program] [0mNUMBER 80 80.0
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mGREATER > null
-[33m[your_program] [0mNUMBER 29 29.0
+[33m[your_program] [0mNUMBER 80 80.0
 [33m[your_program] [0mBANG_EQUAL != null
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mSTRING "Success" Success
@@ -282,13 +266,13 @@ Debug = true
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mBANG_EQUAL != null
 [33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mNUMBER 17 17.0
+[33m[your_program] [0mNUMBER 19 19.0
 [33m[your_program] [0mGREATER_EQUAL >= null
-[33m[your_program] [0mNUMBER 54 54.0
+[33m[your_program] [0mNUMBER 82 82.0
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mEOF  null
-[33m[stage-13] [test-5] [0m[92m✓ 20 line(s) match on stdout[0m
-[33m[stage-13] [test-5] [0m[92m✓ Received exit code 0.[0m
+[33m[stage-13] [test-4] [0m[92m✓ 20 line(s) match on stdout[0m
+[33m[stage-13] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-13] [0m[92mTest passed.[0m
 
 [33m[stage-12] [0m[94mRunning tests for Stage #12: ue7[0m
@@ -302,10 +286,10 @@ Debug = true
 [33m[stage-12] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-12] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-12] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-12] [test-2] [0m[33m[test.lox][0m "baz" "unterminated
+[33m[stage-12] [test-2] [0m[33m[test.lox][0m "bar" "unterminated
 [33m[stage-12] [test-2] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0m[line 1] Error: Unterminated string.
-[33m[your_program] [0mSTRING "baz" baz
+[33m[your_program] [0mSTRING "bar" bar
 [33m[your_program] [0mEOF  null
 [33m[stage-12] [test-2] [0m[92m✓ 1 line(s) match on stderr[0m
 [33m[stage-12] [test-2] [0m[92m✓ 2 line(s) match on stdout[0m
@@ -320,12 +304,12 @@ Debug = true
 [33m[stage-12] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-12] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-12] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-12] [test-4] [0m[33m[test.lox][0m ("foo"+"baz") != "other_string"
+[33m[stage-12] [test-4] [0m[33m[test.lox][0m ("hello"+"foo") != "other_string"
 [33m[stage-12] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mSTRING "foo" foo
+[33m[your_program] [0mSTRING "hello" hello
 [33m[your_program] [0mPLUS + null
-[33m[your_program] [0mSTRING "baz" baz
+[33m[your_program] [0mSTRING "foo" foo
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mBANG_EQUAL != null
 [33m[your_program] [0mSTRING "other_string" other_string
@@ -348,13 +332,14 @@ Debug = true
 [33m[stage-11] [test-1] [0m[92m✓ Received exit code 65.[0m
 [33m[stage-11] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-11] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-11] [test-2] [0m[33m[test.lox][0m <|TAB|>@%$
+[33m[stage-11] [test-2] [0m[33m[test.lox][0m #%@$
 [33m[stage-11] [test-2] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0m[line 1] Error: Unexpected character: @
+[33m[your_program] [0m[line 1] Error: Unexpected character: #
 [33m[your_program] [0m[line 1] Error: Unexpected character: %
+[33m[your_program] [0m[line 1] Error: Unexpected character: @
 [33m[your_program] [0m[line 1] Error: Unexpected character: $
 [33m[your_program] [0mEOF  null
-[33m[stage-11] [test-2] [0m[92m✓ 3 line(s) match on stderr[0m
+[33m[stage-11] [test-2] [0m[92m✓ 4 line(s) match on stderr[0m
 [33m[stage-11] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-11] [test-2] [0m[92m✓ Received exit code 65.[0m
 [33m[stage-11] [test-3] [0m[94mRunning test case: 3[0m
@@ -387,12 +372,12 @@ Debug = true
 [33m[stage-11] [test-3] [0m[92m✓ Received exit code 65.[0m
 [33m[stage-11] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-11] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-11] [test-4] [0m[33m[test.lox][0m ({, %})
+[33m[stage-11] [test-4] [0m[33m[test.lox][0m ({*<|TAB|>$})
 [33m[stage-11] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0m[line 1] Error: Unexpected character: %
+[33m[your_program] [0m[line 1] Error: Unexpected character: $
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mLEFT_BRACE { null
-[33m[your_program] [0mCOMMA , null
+[33m[your_program] [0mSTAR * null
 [33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mEOF  null
@@ -419,18 +404,19 @@ Debug = true
 [33m[stage-10] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-10] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-10] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-10] [test-3] [0m[33m[test.lox][0m {<|TAB|>
-[33m[stage-10] [test-3] [0m[33m[test.lox][0m }
-[33m[stage-10] [test-3] [0m[33m[test.lox][0m ((-;+,<|TAB|>))
+[33m[stage-10] [test-3] [0m[33m[test.lox][0m {
+[33m[stage-10] [test-3] [0m[33m[test.lox][0m <|TAB|>}
+[33m[stage-10] [test-3] [0m[33m[test.lox][0m ((,
+[33m[stage-10] [test-3] [0m[33m[test.lox][0m -.*))
 [33m[stage-10] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0mLEFT_BRACE { null
 [33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mMINUS - null
-[33m[your_program] [0mSEMICOLON ; null
-[33m[your_program] [0mPLUS + null
 [33m[your_program] [0mCOMMA , null
+[33m[your_program] [0mMINUS - null
+[33m[your_program] [0mDOT . null
+[33m[your_program] [0mSTAR * null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mEOF  null
@@ -438,22 +424,22 @@ Debug = true
 [33m[stage-10] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-10] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-10] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-10] [test-4] [0m[33m[test.lox][0m {
-[33m[stage-10] [test-4] [0m[33m[test.lox][0m <|TAB|><|TAB|><|SPACE|>}
-[33m[stage-10] [test-4] [0m[33m[test.lox][0m ((* <
-[33m[stage-10] [test-4] [0m[33m[test.lox][0m >=))
+[33m[stage-10] [test-4] [0m[33m[test.lox][0m {<|TAB|><|TAB|><|SPACE|>
+[33m[stage-10] [test-4] [0m[33m[test.lox][0m }
+[33m[stage-10] [test-4] [0m[33m[test.lox][0m ((<|TAB|>.>>=*))
 [33m[stage-10] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0mLEFT_BRACE { null
 [33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mSTAR * null
-[33m[your_program] [0mLESS < null
+[33m[your_program] [0mDOT . null
+[33m[your_program] [0mGREATER > null
 [33m[your_program] [0mGREATER_EQUAL >= null
+[33m[your_program] [0mSTAR * null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mEOF  null
-[33m[stage-10] [test-4] [0m[92m✓ 10 line(s) match on stdout[0m
+[33m[stage-10] [test-4] [0m[92m✓ 11 line(s) match on stdout[0m
 [33m[stage-10] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-10] [0m[92mTest passed.[0m
 
@@ -483,14 +469,14 @@ Debug = true
 [33m[stage-9] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-9] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-9] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-9] [test-4] [0m[33m[test.lox][0m ({(.=,)})//Comment
+[33m[stage-9] [test-4] [0m[33m[test.lox][0m ({(*>===)})//Comment
 [33m[stage-9] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mLEFT_BRACE { null
 [33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mDOT . null
-[33m[your_program] [0mEQUAL = null
-[33m[your_program] [0mCOMMA , null
+[33m[your_program] [0mSTAR * null
+[33m[your_program] [0mGREATER_EQUAL >= null
+[33m[your_program] [0mEQUAL_EQUAL == null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mRIGHT_PAREN ) null
@@ -523,28 +509,29 @@ Debug = true
 [33m[stage-8] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-8] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-8] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-8] [test-3] [0m[33m[test.lox][0m >=><=<=>=
+[33m[stage-8] [test-3] [0m[33m[test.lox][0m >=<=<<=>
 [33m[stage-8] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0mGREATER_EQUAL >= null
+[33m[your_program] [0mLESS_EQUAL <= null
+[33m[your_program] [0mLESS < null
+[33m[your_program] [0mLESS_EQUAL <= null
 [33m[your_program] [0mGREATER > null
-[33m[your_program] [0mLESS_EQUAL <= null
-[33m[your_program] [0mLESS_EQUAL <= null
-[33m[your_program] [0mGREATER_EQUAL >= null
 [33m[your_program] [0mEOF  null
 [33m[stage-8] [test-3] [0m[92m✓ 6 line(s) match on stdout[0m
 [33m[stage-8] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-8] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-8] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-8] [test-4] [0m[33m[test.lox][0m (){<=!=}
+[33m[stage-8] [test-4] [0m[33m[test.lox][0m (){!====}
 [33m[stage-8] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mLEFT_BRACE { null
-[33m[your_program] [0mLESS_EQUAL <= null
 [33m[your_program] [0mBANG_EQUAL != null
+[33m[your_program] [0mEQUAL_EQUAL == null
+[33m[your_program] [0mEQUAL = null
 [33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mEOF  null
-[33m[stage-8] [test-4] [0m[92m✓ 7 line(s) match on stdout[0m
+[33m[stage-8] [test-4] [0m[92m✓ 8 line(s) match on stdout[0m
 [33m[stage-8] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-8] [0m[92mTest passed.[0m
 
@@ -585,15 +572,15 @@ Debug = true
 [33m[stage-7] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-7] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-7] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-7] [test-4] [0m[33m[test.lox][0m {(!=%@==!)}
+[33m[stage-7] [test-4] [0m[33m[test.lox][0m {(!=@$===)}
 [33m[stage-7] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0m[line 1] Error: Unexpected character: %
 [33m[your_program] [0m[line 1] Error: Unexpected character: @
+[33m[your_program] [0m[line 1] Error: Unexpected character: $
 [33m[your_program] [0mLEFT_BRACE { null
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mBANG_EQUAL != null
 [33m[your_program] [0mEQUAL_EQUAL == null
-[33m[your_program] [0mBANG ! null
+[33m[your_program] [0mEQUAL = null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mEOF  null
@@ -636,20 +623,20 @@ Debug = true
 [33m[stage-6] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-6] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-6] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-6] [test-4] [0m[33m[test.lox][0m ((=#$%@))
+[33m[stage-6] [test-4] [0m[33m[test.lox][0m ((===$@%))
 [33m[stage-6] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0m[line 1] Error: Unexpected character: #
 [33m[your_program] [0m[line 1] Error: Unexpected character: $
-[33m[your_program] [0m[line 1] Error: Unexpected character: %
 [33m[your_program] [0m[line 1] Error: Unexpected character: @
+[33m[your_program] [0m[line 1] Error: Unexpected character: %
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mLEFT_PAREN ( null
+[33m[your_program] [0mEQUAL_EQUAL == null
 [33m[your_program] [0mEQUAL = null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mEOF  null
-[33m[stage-6] [test-4] [0m[92m✓ 4 line(s) match on stderr[0m
-[33m[stage-6] [test-4] [0m[92m✓ 6 line(s) match on stdout[0m
+[33m[stage-6] [test-4] [0m[92m✓ 3 line(s) match on stderr[0m
+[33m[stage-6] [test-4] [0m[92m✓ 7 line(s) match on stdout[0m
 [33m[stage-6] [test-4] [0m[92m✓ Received exit code 65.[0m
 [33m[stage-6] [0m[92mTest passed.[0m
 
@@ -678,35 +665,35 @@ Debug = true
 [33m[stage-5] [test-2] [0m[92m✓ Received exit code 65.[0m
 [33m[stage-5] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-5] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-5] [test-3] [0m[33m[test.lox][0m %$@$@
+[33m[stage-5] [test-3] [0m[33m[test.lox][0m %%@$#
 [33m[stage-5] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0m[line 1] Error: Unexpected character: %
-[33m[your_program] [0m[line 1] Error: Unexpected character: $
+[33m[your_program] [0m[line 1] Error: Unexpected character: %
 [33m[your_program] [0m[line 1] Error: Unexpected character: @
 [33m[your_program] [0m[line 1] Error: Unexpected character: $
-[33m[your_program] [0m[line 1] Error: Unexpected character: @
+[33m[your_program] [0m[line 1] Error: Unexpected character: #
 [33m[your_program] [0mEOF  null
 [33m[stage-5] [test-3] [0m[92m✓ 5 line(s) match on stderr[0m
 [33m[stage-5] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-5] [test-3] [0m[92m✓ Received exit code 65.[0m
 [33m[stage-5] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-5] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-5] [test-4] [0m[33m[test.lox][0m {(;-$*@%.)}
+[33m[stage-5] [test-4] [0m[33m[test.lox][0m {(#*-@+;.)}
 [33m[stage-5] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0m[line 1] Error: Unexpected character: $
+[33m[your_program] [0m[line 1] Error: Unexpected character: #
 [33m[your_program] [0m[line 1] Error: Unexpected character: @
-[33m[your_program] [0m[line 1] Error: Unexpected character: %
 [33m[your_program] [0mLEFT_BRACE { null
 [33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mSEMICOLON ; null
-[33m[your_program] [0mMINUS - null
 [33m[your_program] [0mSTAR * null
+[33m[your_program] [0mMINUS - null
+[33m[your_program] [0mPLUS + null
+[33m[your_program] [0mSEMICOLON ; null
 [33m[your_program] [0mDOT . null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mEOF  null
-[33m[stage-5] [test-4] [0m[92m✓ 3 line(s) match on stderr[0m
-[33m[stage-5] [test-4] [0m[92m✓ 9 line(s) match on stdout[0m
+[33m[stage-5] [test-4] [0m[92m✓ 2 line(s) match on stderr[0m
+[33m[stage-5] [test-4] [0m[92m✓ 10 line(s) match on stdout[0m
 [33m[stage-5] [test-4] [0m[92m✓ Received exit code 65.[0m
 [33m[stage-5] [0m[92mTest passed.[0m
 
@@ -741,28 +728,28 @@ Debug = true
 [33m[stage-4] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-4] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-4] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-4] [test-3] [0m[33m[test.lox][0m -,+-;.*
+[33m[stage-4] [test-3] [0m[33m[test.lox][0m .-,+,;*
 [33m[stage-4] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
+[33m[your_program] [0mDOT . null
 [33m[your_program] [0mMINUS - null
 [33m[your_program] [0mCOMMA , null
 [33m[your_program] [0mPLUS + null
-[33m[your_program] [0mMINUS - null
+[33m[your_program] [0mCOMMA , null
 [33m[your_program] [0mSEMICOLON ; null
-[33m[your_program] [0mDOT . null
 [33m[your_program] [0mSTAR * null
 [33m[your_program] [0mEOF  null
 [33m[stage-4] [test-3] [0m[92m✓ 8 line(s) match on stdout[0m
 [33m[stage-4] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-4] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-4] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-4] [test-4] [0m[33m[test.lox][0m ({+,-;*})
+[33m[stage-4] [test-4] [0m[33m[test.lox][0m ({+-,.*})
 [33m[stage-4] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mLEFT_BRACE { null
 [33m[your_program] [0mPLUS + null
-[33m[your_program] [0mCOMMA , null
 [33m[your_program] [0mMINUS - null
-[33m[your_program] [0mSEMICOLON ; null
+[33m[your_program] [0mCOMMA , null
+[33m[your_program] [0mDOT . null
 [33m[your_program] [0mSTAR * null
 [33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mRIGHT_PAREN ) null
@@ -793,10 +780,10 @@ Debug = true
 [33m[stage-3] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-3] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-3] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-3] [test-3] [0m[33m[test.lox][0m {{{{}
+[33m[stage-3] [test-3] [0m[33m[test.lox][0m }}{{}
 [33m[stage-3] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mLEFT_BRACE { null
-[33m[your_program] [0mLEFT_BRACE { null
+[33m[your_program] [0mRIGHT_BRACE } null
+[33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mLEFT_BRACE { null
 [33m[your_program] [0mLEFT_BRACE { null
 [33m[your_program] [0mRIGHT_BRACE } null
@@ -805,15 +792,15 @@ Debug = true
 [33m[stage-3] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-3] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-3] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-3] [test-4] [0m[33m[test.lox][0m }{){)(}
+[33m[stage-3] [test-4] [0m[33m[test.lox][0m (}{){})
 [33m[stage-3] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mRIGHT_BRACE } null
-[33m[your_program] [0mLEFT_BRACE { null
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mLEFT_BRACE { null
-[33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mRIGHT_BRACE } null
+[33m[your_program] [0mLEFT_BRACE { null
+[33m[your_program] [0mRIGHT_PAREN ) null
+[33m[your_program] [0mLEFT_BRACE { null
+[33m[your_program] [0mRIGHT_BRACE } null
+[33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mEOF  null
 [33m[stage-3] [test-4] [0m[92m✓ 8 line(s) match on stdout[0m
 [33m[stage-3] [test-4] [0m[92m✓ Received exit code 0.[0m
@@ -839,27 +826,27 @@ Debug = true
 [33m[stage-2] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-2] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-2] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-2] [test-3] [0m[33m[test.lox][0m )))((
+[33m[stage-2] [test-3] [0m[33m[test.lox][0m (()))
 [33m[stage-2] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mLEFT_PAREN ( null
+[33m[your_program] [0mRIGHT_PAREN ) null
+[33m[your_program] [0mRIGHT_PAREN ) null
+[33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mEOF  null
 [33m[stage-2] [test-3] [0m[92m✓ 6 line(s) match on stdout[0m
 [33m[stage-2] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-2] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-2] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-2] [test-4] [0m[33m[test.lox][0m ())(()(
+[33m[stage-2] [test-4] [0m[33m[test.lox][0m )(()())
 [33m[stage-2] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mLEFT_PAREN ( null
+[33m[your_program] [0mRIGHT_PAREN ) null
+[33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mEOF  null
 [33m[stage-2] [test-4] [0m[92m✓ 8 line(s) match on stdout[0m
 [33m[stage-2] [test-4] [0m[92m✓ Received exit code 0.[0m


### PR DESCRIPTION
This PR adds a new test case to handle number lexmemes with trailing zeroes during scanning. It ensures that trailing zeroes are correctly processed and that number formatting does not lead to incorrect behavior.

Thanks @jfvillablanca for highlighting this! [[Forum #1671](https://forum.codecrafters.io/t/kj0-test-is-not-reproducible-in-number-literal-stage-of-interpreter-challenge/1671/3)]