### PR TITLE
Add multiline testcase to  #ue7 Scanning: String literals

### DIFF
--- a/internal/lox/api/scanner_api.go
+++ b/internal/lox/api/scanner_api.go
@@ -26,7 +26,9 @@ func ScanTokens(source string) ([]string, []string, int, error) {
 		} else if reflect.TypeOf(literal).Kind() == reflect.Float64 {
 			literal = lox.FormatFloat(literal.(float64))
 		}
-		tokenLines = append(tokenLines, fmt.Sprintf("%s %s %s", lox.GetTokenName(token.Type), token.Lexeme, literal))
+		tokenLine := fmt.Sprintf("%s %s %s", lox.GetTokenName(token.Type), token.Lexeme, literal)
+		// Handle potential multiline strings
+		tokenLines = append(tokenLines, strings.Split(tokenLine, "\n")...)
 	}
 
 	exitCode := 0

--- a/internal/stage12.go
+++ b/internal/stage12.go
@@ -16,7 +16,7 @@ func testStrings(stageHarness *test_case_harness.TestCaseHarness) error {
 	logger := stageHarness.Logger
 
 	string1 := random.RandomElementFromArray(QUOTED_STRINGS) + " " + "\"unterminated"
-	string2 := `"foo 	bar 123 // hello world!"`
+	string2 := `"foo bar    // This is a multiline string` + LF + `	123  // Second line in the same string"`
 	shuffledString2 := "(" + strings.Join(random.RandomElementsFromArray(QUOTED_STRINGS, 2), "+") + `) != "other_string"`
 
 	tokenizeTestCases := testcases.MultiTestCase{

--- a/internal/stage12.go
+++ b/internal/stage12.go
@@ -16,7 +16,7 @@ func testStrings(stageHarness *test_case_harness.TestCaseHarness) error {
 	logger := stageHarness.Logger
 
 	string1 := random.RandomElementFromArray(QUOTED_STRINGS) + " " + "\"unterminated"
-	string2 := `"foo bar    // This is a multiline string` + LF + `	123  // Second line in the same string"`
+	string2 := `"Multiline string` + LF + `with two lines"`
 	shuffledString2 := "(" + strings.Join(random.RandomElementsFromArray(QUOTED_STRINGS, 2), "+") + `) != "other_string"`
 
 	tokenizeTestCases := testcases.MultiTestCase{

--- a/internal/test_helpers/fixtures/pass_scanning
+++ b/internal/test_helpers/fixtures/pass_scanning
@@ -296,11 +296,14 @@ Debug = true
 [33m[stage-12] [test-2] [0m[92m✓ Received exit code 65.[0m
 [33m[stage-12] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-12] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-12] [test-3.lox] [0m"foo <|TAB|>bar 123 // hello world!"
+[33m[stage-12] [test-3.lox] [0m"foo bar    // This is a multiline string
+[33m[stage-12] [test-3.lox] [0m<|TAB|>123  // Second line in the same string"
 [33m[stage-12] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mSTRING "foo 	bar 123 // hello world!" foo 	bar 123 // hello world!
+[33m[your_program] [0mSTRING "foo bar    // This is a multiline string
+[33m[your_program] [0m	123  // Second line in the same string" foo bar    // This is a multiline string
+[33m[your_program] [0m	123  // Second line in the same string
 [33m[your_program] [0mEOF  null
-[33m[stage-12] [test-3] [0m[92m✓ 2 line(s) match on stdout[0m
+[33m[stage-12] [test-3] [0m[92m✓ 4 line(s) match on stdout[0m
 [33m[stage-12] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-12] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-12] [test-4] [0m[94mWriting contents to ./test.lox:[0m

--- a/internal/test_helpers/fixtures/pass_scanning
+++ b/internal/test_helpers/fixtures/pass_scanning
@@ -296,12 +296,12 @@ Debug = true
 [33m[stage-12] [test-2] [0m[92m✓ Received exit code 65.[0m
 [33m[stage-12] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-12] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-12] [test-3.lox] [0m"foo bar    // This is a multiline string
-[33m[stage-12] [test-3.lox] [0m<|TAB|>123  // Second line in the same string"
+[33m[stage-12] [test-3.lox] [0m"Multiline string
+[33m[stage-12] [test-3.lox] [0mwith two lines"
 [33m[stage-12] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mSTRING "foo bar    // This is a multiline string
-[33m[your_program] [0m	123  // Second line in the same string" foo bar    // This is a multiline string
-[33m[your_program] [0m	123  // Second line in the same string
+[33m[your_program] [0mSTRING "Multiline string
+[33m[your_program] [0mwith two lines" Multiline string
+[33m[your_program] [0mwith two lines
 [33m[your_program] [0mEOF  null
 [33m[stage-12] [test-3] [0m[92m✓ 4 line(s) match on stdout[0m
 [33m[stage-12] [test-3] [0m[92m✓ Received exit code 0.[0m


### PR DESCRIPTION
Fixture:

<img width="589" alt="image" src="https://github.com/user-attachments/assets/3c2197cd-150e-4760-ab81-5b01b53b2871" />

---

- [ ] **TODO:** edit instructions to match the tester

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced token processing to correctly handle multiline string inputs, ensuring that outputs reflect multiple line content.

- **Tests**
  - Updated test cases and input files to verify the improved handling and accurate display of multiline string data, resulting in increased output line count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->