### PR TITLE
Improve error message when extra line is found in stdout

### DIFF
--- a/internal/assertions/stdout_assertion.go
+++ b/internal/assertions/stdout_assertion.go
@@ -40,7 +40,7 @@ func (a StdoutAssertion) Run(result executable.ExecutableResult, logger *logger.
 	if len(stdout) > len(a.ExpectedLines) {
 		logAllSuccessLogs(successLogs, logger)
 		logger.Errorf("! %s", stdout[len(a.ExpectedLines)])
-		return fmt.Errorf("Expected nothing after the last stdout line of %q, but found extra line: %q", a.ExpectedLines[len(a.ExpectedLines)-1], stdout[len(a.ExpectedLines)])
+		return fmt.Errorf("Expected nothing after last stdout line %q, but found extra line: %q", a.ExpectedLines[len(a.ExpectedLines)-1], stdout[len(a.ExpectedLines)])
 	}
 
 	// If all lines match, we don't want to print all the lines again

--- a/internal/assertions/stdout_assertion.go
+++ b/internal/assertions/stdout_assertion.go
@@ -40,7 +40,7 @@ func (a StdoutAssertion) Run(result executable.ExecutableResult, logger *logger.
 	if len(stdout) > len(a.ExpectedLines) {
 		logAllSuccessLogs(successLogs, logger)
 		logger.Errorf("! %s", stdout[len(a.ExpectedLines)])
-		return fmt.Errorf("Expected last stdout line to be %q, but found extra line: %q", a.ExpectedLines[len(a.ExpectedLines)-1], stdout[len(a.ExpectedLines)])
+		return fmt.Errorf("Expected nothing after the last stdout line of %q, but found extra line: %q", a.ExpectedLines[len(a.ExpectedLines)-1], stdout[len(a.ExpectedLines)])
 	}
 
 	// If all lines match, we don't want to print all the lines again

--- a/internal/test_helpers/fixtures/pass_statements
+++ b/internal/test_helpers/fixtures/pass_statements
@@ -572,14 +572,14 @@ Debug = true
 [33m[stage-1] [test-4.lox] [0m  print foo;
 [33m[stage-1] [test-4.lox] [0m  print baz;
 [33m[stage-1] [test-4.lox] [0m}
-[33m[stage-1] [test-4.lox] [0mprint baz;
+[33m[stage-1] [test-4.lox] [0mprint foo;
 [33m[stage-1] [test-4.lox] [0m
 [33m[stage-1] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
 [33m[your_program] [0mmodified foo
 [33m[your_program] [0minner baz
 [33m[your_program] [0mmodified foo
 [33m[your_program] [0mouter baz
-[33m[your_program] [0mUndefined variable 'baz'.
+[33m[your_program] [0mUndefined variable 'foo'.
 [33m[your_program] [0m[line 17]
 [33m[stage-1] [test-4] [0m[92m✓ 4 line(s) match on stdout[0m
 [33m[stage-1] [test-4] [0m[92m✓ Received exit code 70.[0m

--- a/internal/test_helpers/fixtures/pass_statements_final
+++ b/internal/test_helpers/fixtures/pass_statements_final
@@ -572,14 +572,14 @@ Debug = true
 [33m[stage-1] [test-4.lox] [0m  print foo;
 [33m[stage-1] [test-4.lox] [0m  print baz;
 [33m[stage-1] [test-4.lox] [0m}
-[33m[stage-1] [test-4.lox] [0mprint baz;
+[33m[stage-1] [test-4.lox] [0mprint foo;
 [33m[stage-1] [test-4.lox] [0m
 [33m[stage-1] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
 [33m[your_program] [0mmodified foo
 [33m[your_program] [0minner baz
 [33m[your_program] [0mmodified foo
 [33m[your_program] [0mouter baz
-[33m[your_program] [0mUndefined variable 'baz'.
+[33m[your_program] [0mUndefined variable 'foo'.
 [33m[your_program] [0m[line 17]
 [33m[stage-1] [test-4] [0m[92m✓ 4 line(s) match on stdout[0m
 [33m[stage-1] [test-4] [0m[92m✓ Received exit code 70.[0m

--- a/test_programs/s10/4.lox
+++ b/test_programs/s10/4.lox
@@ -17,4 +17,4 @@ expected_error_type: runtime
   print <<RANDOM_STRING_1>>;
   print <<RANDOM_STRING_2>>;
 }
-print <<RANDOM_STRING_2>>;
+print <<RANDOM_STRING_1>>;


### PR DESCRIPTION
Context:

https://forum.codecrafters.io/t/interpreter-fb4-test-is-bugged/7332

<img width="903" alt="image" src="https://github.com/user-attachments/assets/da48bb97-66c8-4012-a2cb-93a460f597f6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the clarity of error messages related to output validation. Users will now see a message that clearly indicates when extra output lines appear beyond the expected output, making it easier to identify and troubleshoot output discrepancies.

- **Changes**
  - Updated test output to reflect the variable `foo` instead of `baz`, altering the error message accordingly.
  - Modified program output to print `RANDOM_STRING_1` instead of `RANDOM_STRING_2`, affecting the final output after execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->