### PR TITLE
Refactor greet function to remove global variable

### DIFF
--- a/internal/test_helpers/fixtures/pass_functions
+++ b/internal/test_helpers/fixtures/pass_functions
@@ -297,11 +297,9 @@ Debug = true
 [33m[stage-4] [test-1.lox] [0m[33m// another function[0m
 [33m[stage-4] [test-1.lox] [0m[33m// and uses it to greet two different people with[0m
 [33m[stage-4] [test-1.lox] [0m[33m// two different greetings[0m
-[33m[stage-4] [test-1.lox] [0mvar globalGreeting = "Hello";
-[33m[stage-4] [test-1.lox] [0m
 [33m[stage-4] [test-1.lox] [0mfun makeGreeter() {
 [33m[stage-4] [test-1.lox] [0m  fun greet(name) {
-[33m[stage-4] [test-1.lox] [0m    print globalGreeting + " " + name;
+[33m[stage-4] [test-1.lox] [0m    print "Hello " + name;
 [33m[stage-4] [test-1.lox] [0m  }
 [33m[stage-4] [test-1.lox] [0m  return greet;
 [33m[stage-4] [test-1.lox] [0m}

--- a/internal/test_helpers/fixtures/pass_functions_final
+++ b/internal/test_helpers/fixtures/pass_functions_final
@@ -297,11 +297,9 @@ Debug = true
 [33m[stage-4] [test-1.lox] [0m[33m// another function[0m
 [33m[stage-4] [test-1.lox] [0m[33m// and uses it to greet two different people with[0m
 [33m[stage-4] [test-1.lox] [0m[33m// two different greetings[0m
-[33m[stage-4] [test-1.lox] [0mvar globalGreeting = "Hello";
-[33m[stage-4] [test-1.lox] [0m
 [33m[stage-4] [test-1.lox] [0mfun makeGreeter() {
 [33m[stage-4] [test-1.lox] [0m  fun greet(name) {
-[33m[stage-4] [test-1.lox] [0m    print globalGreeting + " " + name;
+[33m[stage-4] [test-1.lox] [0m    print "Hello " + name;
 [33m[stage-4] [test-1.lox] [0m  }
 [33m[stage-4] [test-1.lox] [0m  return greet;
 [33m[stage-4] [test-1.lox] [0m}

--- a/test_programs/f6/1.lox
+++ b/test_programs/f6/1.lox
@@ -5,11 +5,9 @@ expected_error_type: none
 // another function
 // and uses it to greet two different people with
 // two different greetings
-var globalGreeting = "Hello";
-
 fun makeGreeter() {
   fun greet(name) {
-    print globalGreeting + " " + name;
+    print "Hello " + name;
   }
   return greet;
 }


### PR DESCRIPTION
Eliminate the globalGreeting variable and simplify the greet function to directly print the greeting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified greeting logic in test fixtures by removing reliance on a global variable and using a direct greeting string within functions. No changes to public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->