### PR TITLE
Harden test case in #kj0 Scanning: Number literals

### DIFF
--- a/internal/stage12.go
+++ b/internal/stage12.go
@@ -15,7 +15,7 @@ func testStrings(stageHarness *test_case_harness.TestCaseHarness) error {
 
 	logger := stageHarness.Logger
 
-	string1 := random.RandomElementFromArray(QUOTED_STRINGS) + " " + "\"unterminated"
+	string1 := random.RandomElementFromArray(QUOTED_STRINGS) + " " + random.RandomElementFromArray(SINGLE_CHAR_OPERATORS) + " " + "\"unterminated"
 	string2 := `"foo 	bar 123 // hello world!"`
 	shuffledString2 := "(" + strings.Join(random.RandomElementsFromArray(QUOTED_STRINGS, 2), "+") + `) != "other_string"`
 

--- a/internal/test_helpers/fixtures/pass_scanning
+++ b/internal/test_helpers/fixtures/pass_scanning
@@ -286,13 +286,14 @@ Debug = true
 [33m[stage-12] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-12] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-12] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-12] [test-2.lox] [0m"bar" "unterminated
+[33m[stage-12] [test-2.lox] [0m"bar" ; "unterminated
 [33m[stage-12] [test-2] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0m[line 1] Error: Unterminated string.
 [33m[your_program] [0mSTRING "bar" bar
+[33m[your_program] [0mSEMICOLON ; null
 [33m[your_program] [0mEOF  null
 [33m[stage-12] [test-2] [0m[92m✓ 1 line(s) match on stderr[0m
-[33m[stage-12] [test-2] [0m[92m✓ 2 line(s) match on stdout[0m
+[33m[stage-12] [test-2] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[stage-12] [test-2] [0m[92m✓ Received exit code 65.[0m
 [33m[stage-12] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-12] [test-3] [0m[94mWriting contents to ./test.lox:[0m
@@ -304,12 +305,12 @@ Debug = true
 [33m[stage-12] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-12] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-12] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-12] [test-4.lox] [0m("hello"+"bar") != "other_string"
+[33m[stage-12] [test-4.lox] [0m("hello"+"foo") != "other_string"
 [33m[stage-12] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mSTRING "hello" hello
 [33m[your_program] [0mPLUS + null
-[33m[your_program] [0mSTRING "bar" bar
+[33m[your_program] [0mSTRING "foo" foo
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mBANG_EQUAL != null
 [33m[your_program] [0mSTRING "other_string" other_string
@@ -333,12 +334,14 @@ Debug = true
 [33m[stage-11] [test-1] [0m[92m✓ Received exit code 65.[0m
 [33m[stage-11] [test-2] [0m[94mRunning test case: 2[0m
 [33m[stage-11] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-11] [test-2.lox] [0m
-[33m[stage-11] [test-2.lox] [0m<|TAB|> @
+[33m[stage-11] [test-2.lox] [0m@
+[33m[stage-11] [test-2.lox] [0m%#
 [33m[stage-11] [test-2] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0m[line 2] Error: Unexpected character: @
+[33m[your_program] [0m[line 1] Error: Unexpected character: @
+[33m[your_program] [0m[line 2] Error: Unexpected character: %
+[33m[your_program] [0m[line 2] Error: Unexpected character: #
 [33m[your_program] [0mEOF  null
-[33m[stage-11] [test-2] [0m[92m✓ 1 line(s) match on stderr[0m
+[33m[stage-11] [test-2] [0m[92m✓ 3 line(s) match on stderr[0m
 [33m[stage-11] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-11] [test-2] [0m[92m✓ Received exit code 65.[0m
 [33m[stage-11] [test-3] [0m[94mRunning test case: 3[0m
@@ -371,12 +374,12 @@ Debug = true
 [33m[stage-11] [test-3] [0m[92m✓ Received exit code 65.[0m
 [33m[stage-11] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-11] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-11] [test-4.lox] [0m({; $})
+[33m[stage-11] [test-4.lox] [0m({+ #})
 [33m[stage-11] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0m[line 1] Error: Unexpected character: $
+[33m[your_program] [0m[line 1] Error: Unexpected character: #
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mLEFT_BRACE { null
-[33m[your_program] [0mSEMICOLON ; null
+[33m[your_program] [0mPLUS + null
 [33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mEOF  null
@@ -403,43 +406,41 @@ Debug = true
 [33m[stage-10] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-10] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-10] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-10] [test-3.lox] [0m{<|TAB|>
+[33m[stage-10] [test-3.lox] [0m{<|SPACE|>
 [33m[stage-10] [test-3.lox] [0m}
-[33m[stage-10] [test-3.lox] [0m((
-[33m[stage-10] [test-3.lox] [0m;*.+))
+[33m[stage-10] [test-3.lox] [0m((*
+[33m[stage-10] [test-3.lox] [0m<|SPACE|>-<|TAB|>))
 [33m[stage-10] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0mLEFT_BRACE { null
 [33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mSEMICOLON ; null
 [33m[your_program] [0mSTAR * null
-[33m[your_program] [0mDOT . null
-[33m[your_program] [0mPLUS + null
+[33m[your_program] [0mMINUS - null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mEOF  null
-[33m[stage-10] [test-3] [0m[92m✓ 11 line(s) match on stdout[0m
+[33m[stage-10] [test-3] [0m[92m✓ 9 line(s) match on stdout[0m
 [33m[stage-10] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-10] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-10] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-10] [test-4.lox] [0m{<|TAB|>
-[33m[stage-10] [test-4.lox] [0m<|SPACE|><|SPACE|><|TAB|>}
-[33m[stage-10] [test-4.lox] [0m((
-[33m[stage-10] [test-4.lox] [0m<=<>-))
+[33m[stage-10] [test-4.lox] [0m{<|SPACE|>
+[33m[stage-10] [test-4.lox] [0m
+[33m[stage-10] [test-4.lox] [0m<|TAB|><|TAB|>}
+[33m[stage-10] [test-4.lox] [0m((<|SPACE|>,-<=
+[33m[stage-10] [test-4.lox] [0m))
 [33m[stage-10] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0mLEFT_BRACE { null
 [33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mLESS_EQUAL <= null
-[33m[your_program] [0mLESS < null
-[33m[your_program] [0mGREATER > null
+[33m[your_program] [0mCOMMA , null
 [33m[your_program] [0mMINUS - null
+[33m[your_program] [0mLESS_EQUAL <= null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mEOF  null
-[33m[stage-10] [test-4] [0m[92m✓ 11 line(s) match on stdout[0m
+[33m[stage-10] [test-4] [0m[92m✓ 10 line(s) match on stdout[0m
 [33m[stage-10] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-10] [0m[92mTest passed.[0m
 
@@ -469,14 +470,14 @@ Debug = true
 [33m[stage-9] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-9] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-9] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-9] [test-4.lox] [0m({(!+<)})[33m//Comment[0m
+[33m[stage-9] [test-4.lox] [0m({(<=;.)})[33m//Comment[0m
 [33m[stage-9] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mLEFT_BRACE { null
 [33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mBANG ! null
-[33m[your_program] [0mPLUS + null
-[33m[your_program] [0mLESS < null
+[33m[your_program] [0mLESS_EQUAL <= null
+[33m[your_program] [0mSEMICOLON ; null
+[33m[your_program] [0mDOT . null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mRIGHT_PAREN ) null
@@ -509,26 +510,26 @@ Debug = true
 [33m[stage-8] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-8] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-8] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-8] [test-3.lox] [0m>=<<=<<=
+[33m[stage-8] [test-3.lox] [0m>=><<=<
 [33m[stage-8] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0mGREATER_EQUAL >= null
+[33m[your_program] [0mGREATER > null
 [33m[your_program] [0mLESS < null
 [33m[your_program] [0mLESS_EQUAL <= null
 [33m[your_program] [0mLESS < null
-[33m[your_program] [0mLESS_EQUAL <= null
 [33m[your_program] [0mEOF  null
 [33m[stage-8] [test-3] [0m[92m✓ 6 line(s) match on stdout[0m
 [33m[stage-8] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-8] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-8] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-8] [test-4.lox] [0m(){==>!}
+[33m[stage-8] [test-4.lox] [0m(){>====}
 [33m[stage-8] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mLEFT_BRACE { null
+[33m[your_program] [0mGREATER_EQUAL >= null
 [33m[your_program] [0mEQUAL_EQUAL == null
-[33m[your_program] [0mGREATER > null
-[33m[your_program] [0mBANG ! null
+[33m[your_program] [0mEQUAL = null
 [33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mEOF  null
 [33m[stage-8] [test-4] [0m[92m✓ 8 line(s) match on stdout[0m
@@ -572,15 +573,15 @@ Debug = true
 [33m[stage-7] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-7] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-7] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-7] [test-4.lox] [0m{(==#!$!=)}
+[33m[stage-7] [test-4.lox] [0m{(==!=$!%)}
 [33m[stage-7] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0m[line 1] Error: Unexpected character: #
 [33m[your_program] [0m[line 1] Error: Unexpected character: $
+[33m[your_program] [0m[line 1] Error: Unexpected character: %
 [33m[your_program] [0mLEFT_BRACE { null
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mEQUAL_EQUAL == null
-[33m[your_program] [0mBANG ! null
 [33m[your_program] [0mBANG_EQUAL != null
+[33m[your_program] [0mBANG ! null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mEOF  null
@@ -623,20 +624,20 @@ Debug = true
 [33m[stage-6] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-6] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-6] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-6] [test-4.lox] [0m((%$@=#))
+[33m[stage-6] [test-4.lox] [0m((#===$%))
 [33m[stage-6] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0m[line 1] Error: Unexpected character: %
-[33m[your_program] [0m[line 1] Error: Unexpected character: $
-[33m[your_program] [0m[line 1] Error: Unexpected character: @
 [33m[your_program] [0m[line 1] Error: Unexpected character: #
+[33m[your_program] [0m[line 1] Error: Unexpected character: $
+[33m[your_program] [0m[line 1] Error: Unexpected character: %
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mLEFT_PAREN ( null
+[33m[your_program] [0mEQUAL_EQUAL == null
 [33m[your_program] [0mEQUAL = null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mEOF  null
-[33m[stage-6] [test-4] [0m[92m✓ 4 line(s) match on stderr[0m
-[33m[stage-6] [test-4] [0m[92m✓ 6 line(s) match on stdout[0m
+[33m[stage-6] [test-4] [0m[92m✓ 3 line(s) match on stderr[0m
+[33m[stage-6] [test-4] [0m[92m✓ 7 line(s) match on stdout[0m
 [33m[stage-6] [test-4] [0m[92m✓ Received exit code 65.[0m
 [33m[stage-6] [0m[92mTest passed.[0m
 
@@ -665,35 +666,35 @@ Debug = true
 [33m[stage-5] [test-2] [0m[92m✓ Received exit code 65.[0m
 [33m[stage-5] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-5] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-5] [test-3.lox] [0m#@$$#
+[33m[stage-5] [test-3.lox] [0m@#$#@
 [33m[stage-5] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
+[33m[your_program] [0m[line 1] Error: Unexpected character: @
+[33m[your_program] [0m[line 1] Error: Unexpected character: #
+[33m[your_program] [0m[line 1] Error: Unexpected character: $
 [33m[your_program] [0m[line 1] Error: Unexpected character: #
 [33m[your_program] [0m[line 1] Error: Unexpected character: @
-[33m[your_program] [0m[line 1] Error: Unexpected character: $
-[33m[your_program] [0m[line 1] Error: Unexpected character: $
-[33m[your_program] [0m[line 1] Error: Unexpected character: #
 [33m[your_program] [0mEOF  null
 [33m[stage-5] [test-3] [0m[92m✓ 5 line(s) match on stderr[0m
 [33m[stage-5] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[stage-5] [test-3] [0m[92m✓ Received exit code 65.[0m
 [33m[stage-5] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-5] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-5] [test-4.lox] [0m{(+*-,#;.)}
+[33m[stage-5] [test-4.lox] [0m{(+$#.,-@)}
 [33m[stage-5] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
+[33m[your_program] [0m[line 1] Error: Unexpected character: $
 [33m[your_program] [0m[line 1] Error: Unexpected character: #
+[33m[your_program] [0m[line 1] Error: Unexpected character: @
 [33m[your_program] [0mLEFT_BRACE { null
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mPLUS + null
-[33m[your_program] [0mSTAR * null
-[33m[your_program] [0mMINUS - null
-[33m[your_program] [0mCOMMA , null
-[33m[your_program] [0mSEMICOLON ; null
 [33m[your_program] [0mDOT . null
+[33m[your_program] [0mCOMMA , null
+[33m[your_program] [0mMINUS - null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mEOF  null
-[33m[stage-5] [test-4] [0m[92m✓ 1 line(s) match on stderr[0m
-[33m[stage-5] [test-4] [0m[92m✓ 11 line(s) match on stdout[0m
+[33m[stage-5] [test-4] [0m[92m✓ 3 line(s) match on stderr[0m
+[33m[stage-5] [test-4] [0m[92m✓ 9 line(s) match on stdout[0m
 [33m[stage-5] [test-4] [0m[92m✓ Received exit code 65.[0m
 [33m[stage-5] [0m[92mTest passed.[0m
 
@@ -728,29 +729,29 @@ Debug = true
 [33m[stage-4] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-4] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-4] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-4] [test-3.lox] [0m*..,*-+
+[33m[stage-4] [test-3.lox] [0m-;+*+;.
 [33m[stage-4] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mSTAR * null
-[33m[your_program] [0mDOT . null
-[33m[your_program] [0mDOT . null
-[33m[your_program] [0mCOMMA , null
-[33m[your_program] [0mSTAR * null
 [33m[your_program] [0mMINUS - null
+[33m[your_program] [0mSEMICOLON ; null
 [33m[your_program] [0mPLUS + null
+[33m[your_program] [0mSTAR * null
+[33m[your_program] [0mPLUS + null
+[33m[your_program] [0mSEMICOLON ; null
+[33m[your_program] [0mDOT . null
 [33m[your_program] [0mEOF  null
 [33m[stage-4] [test-3] [0m[92m✓ 8 line(s) match on stdout[0m
 [33m[stage-4] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-4] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-4] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-4] [test-4.lox] [0m({*;+-,})
+[33m[stage-4] [test-4.lox] [0m({,*+.;})
 [33m[stage-4] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mLEFT_BRACE { null
-[33m[your_program] [0mSTAR * null
-[33m[your_program] [0mSEMICOLON ; null
-[33m[your_program] [0mPLUS + null
-[33m[your_program] [0mMINUS - null
 [33m[your_program] [0mCOMMA , null
+[33m[your_program] [0mSTAR * null
+[33m[your_program] [0mPLUS + null
+[33m[your_program] [0mDOT . null
+[33m[your_program] [0mSEMICOLON ; null
 [33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mEOF  null
@@ -780,27 +781,27 @@ Debug = true
 [33m[stage-3] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-3] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-3] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-3] [test-3.lox] [0m{{{}}
+[33m[stage-3] [test-3.lox] [0m{}{}{
 [33m[stage-3] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0mLEFT_BRACE { null
-[33m[your_program] [0mLEFT_BRACE { null
+[33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mLEFT_BRACE { null
 [33m[your_program] [0mRIGHT_BRACE } null
-[33m[your_program] [0mRIGHT_BRACE } null
+[33m[your_program] [0mLEFT_BRACE { null
 [33m[your_program] [0mEOF  null
 [33m[stage-3] [test-3] [0m[92m✓ 6 line(s) match on stdout[0m
 [33m[stage-3] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-3] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-3] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-3] [test-4.lox] [0m(}{)(})
+[33m[stage-3] [test-4.lox] [0m(()})}{
 [33m[stage-3] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
 [33m[your_program] [0mLEFT_PAREN ( null
+[33m[your_program] [0mLEFT_PAREN ( null
+[33m[your_program] [0mRIGHT_PAREN ) null
+[33m[your_program] [0mRIGHT_BRACE } null
+[33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mRIGHT_BRACE } null
 [33m[your_program] [0mLEFT_BRACE { null
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mRIGHT_BRACE } null
-[33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mEOF  null
 [33m[stage-3] [test-4] [0m[92m✓ 8 line(s) match on stdout[0m
 [33m[stage-3] [test-4] [0m[92m✓ Received exit code 0.[0m
@@ -826,27 +827,27 @@ Debug = true
 [33m[stage-2] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-2] [test-3] [0m[94mRunning test case: 3[0m
 [33m[stage-2] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-2] [test-3.lox] [0m()(()
+[33m[stage-2] [test-3.lox] [0m)(()(
 [33m[stage-2] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mRIGHT_PAREN ) null
+[33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mEOF  null
 [33m[stage-2] [test-3] [0m[92m✓ 6 line(s) match on stdout[0m
 [33m[stage-2] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[stage-2] [test-4] [0m[94mRunning test case: 4[0m
 [33m[stage-2] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[stage-2] [test-4.lox] [0m)())(((
+[33m[stage-2] [test-4.lox] [0m())((()
 [33m[stage-2] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mLEFT_PAREN ( null
 [33m[your_program] [0mLEFT_PAREN ( null
+[33m[your_program] [0mRIGHT_PAREN ) null
 [33m[your_program] [0mEOF  null
 [33m[stage-2] [test-4] [0m[92m✓ 8 line(s) match on stdout[0m
 [33m[stage-2] [test-4] [0m[92m✓ Received exit code 0.[0m


### PR DESCRIPTION
Context:

https://backend.codecrafters.io/admin/course_stage_feedback_submissions/9f3a0c9a-66c8-49f1-adc6-1d6ca1d57204/edit

Fixture now:

<img width="590" alt="image" src="https://github.com/user-attachments/assets/c1bfa58b-22b5-4374-be38-c32e556ac025" />

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated tokenization test cases with revised input strings, operators, and expected outputs.
  - Adjusted error messages and token sequences in test fixtures to match changes in test inputs.
  - Refined whitespace, punctuation, and operator usage in test scenarios for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->