### PR TITLE
Revert OOM testing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.2
 
 require (
-	github.com/codecrafters-io/tester-utils v0.4.12-0.20260106130009-acd01d7c4239
+	github.com/codecrafters-io/tester-utils v0.4.12
 	github.com/fatih/color v1.18.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/codecrafters-io/tester-utils v0.4.12-0.20260106130009-acd01d7c4239 h1:S3GuEBKUSu9EbxgBj3sXsJee+pwBgB5cHJWQIZJF38Y=
 github.com/codecrafters-io/tester-utils v0.4.12-0.20260106130009-acd01d7c4239/go.mod h1:uhbl+sCQIv2Hg4QUZuKQarVR5cuhDbpVKId8KUF2cX8=
+github.com/codecrafters-io/tester-utils v0.4.12 h1:ijW1Uak7JxsuyuVPrlK5/hmn1aZZKYcTbiIfS3wwt3k=
+github.com/codecrafters-io/tester-utils v0.4.12/go.mod h1:HkK8e9dga12hpVJJXv6S21kMeSZeobkoEFov1d1WVsY=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/internal/test_helpers/fixtures/pass_classes
+++ b/internal/test_helpers/fixtures/pass_classes
@@ -3,60 +3,60 @@ Debug = true
 [33m[tester::#VF4] [0m[94mRunning tests for Stage #VF4 (vf4)[0m
 [33m[tester::#VF4] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#VF4] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#VF4] [test-1.lox] [0m[33m// Class declaration with empty body[0m
-[33m[tester::#VF4] [test-1.lox] [0mclass Spaceship {}
-[33m[tester::#VF4] [test-1.lox] [0mprint Spaceship;
+[33m[tester::#VF4] [test-1.lox] [0m[0m[33m// Class declaration with empty body[0m[0m
+[33m[tester::#VF4] [test-1.lox] [0m[0mclass Spaceship {}[0m
+[33m[tester::#VF4] [test-1.lox] [0m[0mprint Spaceship;[0m
 [33m[tester::#VF4] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mSpaceship
+[33m[your_program] [0m[0mSpaceship[0m
 [33m[tester::#VF4] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#VF4] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#VF4] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#VF4] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#VF4] [test-2.lox] [0m[33m// Multiple class declarations with empty body[0m
-[33m[tester::#VF4] [test-2.lox] [0mclass Robot {}
-[33m[tester::#VF4] [test-2.lox] [0mclass Wizard {}
-[33m[tester::#VF4] [test-2.lox] [0mprint Robot;
-[33m[tester::#VF4] [test-2.lox] [0mprint Wizard;
-[33m[tester::#VF4] [test-2.lox] [0mprint "Both classes successfully printed";
+[33m[tester::#VF4] [test-2.lox] [0m[0m[33m// Multiple class declarations with empty body[0m[0m
+[33m[tester::#VF4] [test-2.lox] [0m[0mclass Robot {}[0m
+[33m[tester::#VF4] [test-2.lox] [0m[0mclass Wizard {}[0m
+[33m[tester::#VF4] [test-2.lox] [0m[0mprint Robot;[0m
+[33m[tester::#VF4] [test-2.lox] [0m[0mprint Wizard;[0m
+[33m[tester::#VF4] [test-2.lox] [0m[0mprint "Both classes successfully printed";[0m
 [33m[tester::#VF4] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mRobot
-[33m[your_program] [0mWizard
-[33m[your_program] [0mBoth classes successfully printed
+[33m[your_program] [0m[0mRobot[0m
+[33m[your_program] [0m[0mWizard[0m
+[33m[your_program] [0m[0mBoth classes successfully printed[0m
 [33m[tester::#VF4] [test-2] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#VF4] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#VF4] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#VF4] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#VF4] [test-3.lox] [0m{
-[33m[tester::#VF4] [test-3.lox] [0m  [33m// Class declaration inside blocks should work[0m
-[33m[tester::#VF4] [test-3.lox] [0m  class Dinosaur {}
-[33m[tester::#VF4] [test-3.lox] [0m  print "Inside block: Dinosaur exists";
-[33m[tester::#VF4] [test-3.lox] [0m  print Dinosaur;
-[33m[tester::#VF4] [test-3.lox] [0m}
-[33m[tester::#VF4] [test-3.lox] [0mprint "Accessing out-of-scope class:";
-[33m[tester::#VF4] [test-3.lox] [0mprint Dinosaur;  [33m// expect runtime error[0m
+[33m[tester::#VF4] [test-3.lox] [0m[0m{[0m
+[33m[tester::#VF4] [test-3.lox] [0m[0m  [33m// Class declaration inside blocks should work[0m[0m
+[33m[tester::#VF4] [test-3.lox] [0m[0m  class Dinosaur {}[0m
+[33m[tester::#VF4] [test-3.lox] [0m[0m  print "Inside block: Dinosaur exists";[0m
+[33m[tester::#VF4] [test-3.lox] [0m[0m  print Dinosaur;[0m
+[33m[tester::#VF4] [test-3.lox] [0m[0m}[0m
+[33m[tester::#VF4] [test-3.lox] [0m[0mprint "Accessing out-of-scope class:";[0m
+[33m[tester::#VF4] [test-3.lox] [0m[0mprint Dinosaur;  [33m// expect runtime error[0m[0m
 [33m[tester::#VF4] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mInside block: Dinosaur exists
-[33m[your_program] [0mDinosaur
-[33m[your_program] [0mAccessing out-of-scope class:
-[33m[your_program] [0mUndefined variable 'Dinosaur'.
-[33m[your_program] [0m[line 8]
+[33m[your_program] [0m[0mInside block: Dinosaur exists[0m
+[33m[your_program] [0m[0mDinosaur[0m
+[33m[your_program] [0m[0mAccessing out-of-scope class:[0m
+[33m[your_program] [0m[0mUndefined variable 'Dinosaur'.[0m
+[33m[your_program] [0m[0m[line 8][0m
 [33m[tester::#VF4] [test-3] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#VF4] [test-3] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#VF4] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#VF4] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#VF4] [test-4.lox] [0m[33m// Class declaration inside function should work[0m
-[33m[tester::#VF4] [test-4.lox] [0mfun foo() {
-[33m[tester::#VF4] [test-4.lox] [0m  class Superhero {}
-[33m[tester::#VF4] [test-4.lox] [0m  print "Class declared inside function";
-[33m[tester::#VF4] [test-4.lox] [0m  print Superhero;
-[33m[tester::#VF4] [test-4.lox] [0m}
-[33m[tester::#VF4] [test-4.lox] [0m
-[33m[tester::#VF4] [test-4.lox] [0mfoo();
-[33m[tester::#VF4] [test-4.lox] [0mprint "Function called successfully";
+[33m[tester::#VF4] [test-4.lox] [0m[0m[33m// Class declaration inside function should work[0m[0m
+[33m[tester::#VF4] [test-4.lox] [0m[0mfun foo() {[0m
+[33m[tester::#VF4] [test-4.lox] [0m[0m  class Superhero {}[0m
+[33m[tester::#VF4] [test-4.lox] [0m[0m  print "Class declared inside function";[0m
+[33m[tester::#VF4] [test-4.lox] [0m[0m  print Superhero;[0m
+[33m[tester::#VF4] [test-4.lox] [0m[0m}[0m
+[33m[tester::#VF4] [test-4.lox] [0m[0m[0m
+[33m[tester::#VF4] [test-4.lox] [0m[0mfoo();[0m
+[33m[tester::#VF4] [test-4.lox] [0m[0mprint "Function called successfully";[0m
 [33m[tester::#VF4] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mClass declared inside function
-[33m[your_program] [0mSuperhero
-[33m[your_program] [0mFunction called successfully
+[33m[your_program] [0m[0mClass declared inside function[0m
+[33m[your_program] [0m[0mSuperhero[0m
+[33m[your_program] [0m[0mFunction called successfully[0m
 [33m[tester::#VF4] [test-4] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#VF4] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#VF4] [0m[92mTest passed.[0m
@@ -64,83 +64,83 @@ Debug = true
 [33m[tester::#YK8] [0m[94mRunning tests for Stage #YK8 (yk8)[0m
 [33m[tester::#YK8] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#YK8] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YK8] [test-1.lox] [0m[33m// Class instantiation[0m
-[33m[tester::#YK8] [test-1.lox] [0mclass Spaceship {}
-[33m[tester::#YK8] [test-1.lox] [0mvar falcon = Spaceship();
-[33m[tester::#YK8] [test-1.lox] [0mprint falcon;
+[33m[tester::#YK8] [test-1.lox] [0m[0m[33m// Class instantiation[0m[0m
+[33m[tester::#YK8] [test-1.lox] [0m[0mclass Spaceship {}[0m
+[33m[tester::#YK8] [test-1.lox] [0m[0mvar falcon = Spaceship();[0m
+[33m[tester::#YK8] [test-1.lox] [0m[0mprint falcon;[0m
 [33m[tester::#YK8] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mSpaceship instance
+[33m[your_program] [0m[0mSpaceship instance[0m
 [33m[tester::#YK8] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#YK8] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#YK8] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#YK8] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YK8] [test-2.lox] [0m[33m// Instantiating multiple instances of a class[0m
-[33m[tester::#YK8] [test-2.lox] [0m[33m// should work[0m
-[33m[tester::#YK8] [test-2.lox] [0mclass Robot {}
-[33m[tester::#YK8] [test-2.lox] [0mvar r1 = Robot();
-[33m[tester::#YK8] [test-2.lox] [0mvar r2 = Robot();
-[33m[tester::#YK8] [test-2.lox] [0m
-[33m[tester::#YK8] [test-2.lox] [0mprint "Created multiple robots:";
-[33m[tester::#YK8] [test-2.lox] [0mprint r1;
-[33m[tester::#YK8] [test-2.lox] [0mprint r2;
+[33m[tester::#YK8] [test-2.lox] [0m[0m[33m// Instantiating multiple instances of a class[0m[0m
+[33m[tester::#YK8] [test-2.lox] [0m[0m[33m// should work[0m[0m
+[33m[tester::#YK8] [test-2.lox] [0m[0mclass Robot {}[0m
+[33m[tester::#YK8] [test-2.lox] [0m[0mvar r1 = Robot();[0m
+[33m[tester::#YK8] [test-2.lox] [0m[0mvar r2 = Robot();[0m
+[33m[tester::#YK8] [test-2.lox] [0m[0m[0m
+[33m[tester::#YK8] [test-2.lox] [0m[0mprint "Created multiple robots:";[0m
+[33m[tester::#YK8] [test-2.lox] [0m[0mprint r1;[0m
+[33m[tester::#YK8] [test-2.lox] [0m[0mprint r2;[0m
 [33m[tester::#YK8] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mCreated multiple robots:
-[33m[your_program] [0mRobot instance
-[33m[your_program] [0mRobot instance
+[33m[your_program] [0m[0mCreated multiple robots:[0m
+[33m[your_program] [0m[0mRobot instance[0m
+[33m[your_program] [0m[0mRobot instance[0m
 [33m[tester::#YK8] [test-2] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#YK8] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#YK8] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#YK8] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YK8] [test-3.lox] [0mclass Wizard {}
-[33m[tester::#YK8] [test-3.lox] [0mclass Dragon {}
-[33m[tester::#YK8] [test-3.lox] [0m
-[33m[tester::#YK8] [test-3.lox] [0m[33m// Instantiating classes in a function should work[0m
-[33m[tester::#YK8] [test-3.lox] [0mfun createCharacters() {
-[33m[tester::#YK8] [test-3.lox] [0m  var merlin = Wizard();
-[33m[tester::#YK8] [test-3.lox] [0m  var smaug = Dragon();
-[33m[tester::#YK8] [test-3.lox] [0m  print "Characters created in fantasy world:";
-[33m[tester::#YK8] [test-3.lox] [0m  print merlin;
-[33m[tester::#YK8] [test-3.lox] [0m  print smaug;
-[33m[tester::#YK8] [test-3.lox] [0m  return merlin;
-[33m[tester::#YK8] [test-3.lox] [0m}
-[33m[tester::#YK8] [test-3.lox] [0m
-[33m[tester::#YK8] [test-3.lox] [0mvar mainCharacter = createCharacters();
-[33m[tester::#YK8] [test-3.lox] [0m[33m// An instance of a class should be truthy[0m
-[33m[tester::#YK8] [test-3.lox] [0mif (mainCharacter) {
-[33m[tester::#YK8] [test-3.lox] [0m  print "The main character is:";
-[33m[tester::#YK8] [test-3.lox] [0m  print mainCharacter;
-[33m[tester::#YK8] [test-3.lox] [0m} else {
-[33m[tester::#YK8] [test-3.lox] [0m  print "Failed to create a main character.";
-[33m[tester::#YK8] [test-3.lox] [0m}
+[33m[tester::#YK8] [test-3.lox] [0m[0mclass Wizard {}[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0mclass Dragon {}[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0m[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0m[33m// Instantiating classes in a function should work[0m[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0mfun createCharacters() {[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0m  var merlin = Wizard();[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0m  var smaug = Dragon();[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0m  print "Characters created in fantasy world:";[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0m  print merlin;[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0m  print smaug;[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0m  return merlin;[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0m}[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0m[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0mvar mainCharacter = createCharacters();[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0m[33m// An instance of a class should be truthy[0m[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0mif (mainCharacter) {[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0m  print "The main character is:";[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0m  print mainCharacter;[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0m} else {[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0m  print "Failed to create a main character.";[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0m}[0m
 [33m[tester::#YK8] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mCharacters created in fantasy world:
-[33m[your_program] [0mWizard instance
-[33m[your_program] [0mDragon instance
-[33m[your_program] [0mThe main character is:
-[33m[your_program] [0mWizard instance
+[33m[your_program] [0m[0mCharacters created in fantasy world:[0m
+[33m[your_program] [0m[0mWizard instance[0m
+[33m[your_program] [0m[0mDragon instance[0m
+[33m[your_program] [0m[0mThe main character is:[0m
+[33m[your_program] [0m[0mWizard instance[0m
 [33m[tester::#YK8] [test-3] [0m[92m✓ 5 line(s) match on stdout[0m
 [33m[tester::#YK8] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#YK8] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#YK8] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YK8] [test-4.lox] [0mclass Superhero {}
-[33m[tester::#YK8] [test-4.lox] [0m
-[33m[tester::#YK8] [test-4.lox] [0mvar count = 0;
-[33m[tester::#YK8] [test-4.lox] [0mwhile (count < 3) {
-[33m[tester::#YK8] [test-4.lox] [0m  var hero = Superhero();
-[33m[tester::#YK8] [test-4.lox] [0m  print "Hero created:";
-[33m[tester::#YK8] [test-4.lox] [0m  print hero;
-[33m[tester::#YK8] [test-4.lox] [0m  count = count + 1;
-[33m[tester::#YK8] [test-4.lox] [0m}
-[33m[tester::#YK8] [test-4.lox] [0m
-[33m[tester::#YK8] [test-4.lox] [0mprint "All heroes created!";
+[33m[tester::#YK8] [test-4.lox] [0m[0mclass Superhero {}[0m
+[33m[tester::#YK8] [test-4.lox] [0m[0m[0m
+[33m[tester::#YK8] [test-4.lox] [0m[0mvar count = 0;[0m
+[33m[tester::#YK8] [test-4.lox] [0m[0mwhile (count < 3) {[0m
+[33m[tester::#YK8] [test-4.lox] [0m[0m  var hero = Superhero();[0m
+[33m[tester::#YK8] [test-4.lox] [0m[0m  print "Hero created:";[0m
+[33m[tester::#YK8] [test-4.lox] [0m[0m  print hero;[0m
+[33m[tester::#YK8] [test-4.lox] [0m[0m  count = count + 1;[0m
+[33m[tester::#YK8] [test-4.lox] [0m[0m}[0m
+[33m[tester::#YK8] [test-4.lox] [0m[0m[0m
+[33m[tester::#YK8] [test-4.lox] [0m[0mprint "All heroes created!";[0m
 [33m[tester::#YK8] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mHero created:
-[33m[your_program] [0mSuperhero instance
-[33m[your_program] [0mHero created:
-[33m[your_program] [0mSuperhero instance
-[33m[your_program] [0mHero created:
-[33m[your_program] [0mSuperhero instance
-[33m[your_program] [0mAll heroes created!
+[33m[your_program] [0m[0mHero created:[0m
+[33m[your_program] [0m[0mSuperhero instance[0m
+[33m[your_program] [0m[0mHero created:[0m
+[33m[your_program] [0m[0mSuperhero instance[0m
+[33m[your_program] [0m[0mHero created:[0m
+[33m[your_program] [0m[0mSuperhero instance[0m
+[33m[your_program] [0m[0mAll heroes created![0m
 [33m[tester::#YK8] [test-4] [0m[92m✓ 7 line(s) match on stdout[0m
 [33m[tester::#YK8] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#YK8] [0m[92mTest passed.[0m
@@ -148,94 +148,94 @@ Debug = true
 [33m[tester::#YF3] [0m[94mRunning tests for Stage #YF3 (yf3)[0m
 [33m[tester::#YF3] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#YF3] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YF3] [test-1.lox] [0mclass Spaceship {}
-[33m[tester::#YF3] [test-1.lox] [0mvar falcon = Spaceship();
-[33m[tester::#YF3] [test-1.lox] [0m
-[33m[tester::#YF3] [test-1.lox] [0m[33m// Setting properties on an instance should work[0m
-[33m[tester::#YF3] [test-1.lox] [0mfalcon.name = "Millennium Falcon";
-[33m[tester::#YF3] [test-1.lox] [0mfalcon.speed = 75.5;
-[33m[tester::#YF3] [test-1.lox] [0m
-[33m[tester::#YF3] [test-1.lox] [0m[33m// Getting properties on an instance should work[0m
-[33m[tester::#YF3] [test-1.lox] [0mprint "Ship details:";
-[33m[tester::#YF3] [test-1.lox] [0mprint falcon.name;
-[33m[tester::#YF3] [test-1.lox] [0mprint falcon.speed;
+[33m[tester::#YF3] [test-1.lox] [0m[0mclass Spaceship {}[0m
+[33m[tester::#YF3] [test-1.lox] [0m[0mvar falcon = Spaceship();[0m
+[33m[tester::#YF3] [test-1.lox] [0m[0m[0m
+[33m[tester::#YF3] [test-1.lox] [0m[0m[33m// Setting properties on an instance should work[0m[0m
+[33m[tester::#YF3] [test-1.lox] [0m[0mfalcon.name = "Millennium Falcon";[0m
+[33m[tester::#YF3] [test-1.lox] [0m[0mfalcon.speed = 75.5;[0m
+[33m[tester::#YF3] [test-1.lox] [0m[0m[0m
+[33m[tester::#YF3] [test-1.lox] [0m[0m[33m// Getting properties on an instance should work[0m[0m
+[33m[tester::#YF3] [test-1.lox] [0m[0mprint "Ship details:";[0m
+[33m[tester::#YF3] [test-1.lox] [0m[0mprint falcon.name;[0m
+[33m[tester::#YF3] [test-1.lox] [0m[0mprint falcon.speed;[0m
 [33m[tester::#YF3] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mShip details:
-[33m[your_program] [0mMillennium Falcon
-[33m[your_program] [0m75.5
+[33m[your_program] [0m[0mShip details:[0m
+[33m[your_program] [0m[0mMillennium Falcon[0m
+[33m[your_program] [0m[0m75.5[0m
 [33m[tester::#YF3] [test-1] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#YF3] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#YF3] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#YF3] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YF3] [test-2.lox] [0mclass Robot {}
-[33m[tester::#YF3] [test-2.lox] [0mvar r2d2 = Robot();
-[33m[tester::#YF3] [test-2.lox] [0m
-[33m[tester::#YF3] [test-2.lox] [0m[33m// Setting properties on an instance should work[0m
-[33m[tester::#YF3] [test-2.lox] [0mr2d2.model = "Astromech";
-[33m[tester::#YF3] [test-2.lox] [0mr2d2.operational = false;
-[33m[tester::#YF3] [test-2.lox] [0m
-[33m[tester::#YF3] [test-2.lox] [0m[33m// Getting properties on an instance should work[0m
-[33m[tester::#YF3] [test-2.lox] [0mif (r2d2.operational) {
-[33m[tester::#YF3] [test-2.lox] [0m  print r2d2.model;
-[33m[tester::#YF3] [test-2.lox] [0m  r2d2.mission = "Navigate hyperspace";
-[33m[tester::#YF3] [test-2.lox] [0m  print r2d2.mission;
-[33m[tester::#YF3] [test-2.lox] [0m}
+[33m[tester::#YF3] [test-2.lox] [0m[0mclass Robot {}[0m
+[33m[tester::#YF3] [test-2.lox] [0m[0mvar r2d2 = Robot();[0m
+[33m[tester::#YF3] [test-2.lox] [0m[0m[0m
+[33m[tester::#YF3] [test-2.lox] [0m[0m[33m// Setting properties on an instance should work[0m[0m
+[33m[tester::#YF3] [test-2.lox] [0m[0mr2d2.model = "Astromech";[0m
+[33m[tester::#YF3] [test-2.lox] [0m[0mr2d2.operational = false;[0m
+[33m[tester::#YF3] [test-2.lox] [0m[0m[0m
+[33m[tester::#YF3] [test-2.lox] [0m[0m[33m// Getting properties on an instance should work[0m[0m
+[33m[tester::#YF3] [test-2.lox] [0m[0mif (r2d2.operational) {[0m
+[33m[tester::#YF3] [test-2.lox] [0m[0m  print r2d2.model;[0m
+[33m[tester::#YF3] [test-2.lox] [0m[0m  r2d2.mission = "Navigate hyperspace";[0m
+[33m[tester::#YF3] [test-2.lox] [0m[0m  print r2d2.mission;[0m
+[33m[tester::#YF3] [test-2.lox] [0m[0m}[0m
 [33m[tester::#YF3] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
 [33m[tester::#YF3] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#YF3] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#YF3] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#YF3] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YF3] [test-3.lox] [0mclass Superhero {}
-[33m[tester::#YF3] [test-3.lox] [0mvar batman = Superhero();
-[33m[tester::#YF3] [test-3.lox] [0mvar superman = Superhero();
-[33m[tester::#YF3] [test-3.lox] [0m
-[33m[tester::#YF3] [test-3.lox] [0m[33m// Setting properties on an instance should work[0m
-[33m[tester::#YF3] [test-3.lox] [0mbatman.name = "Batman";
-[33m[tester::#YF3] [test-3.lox] [0mbatman.called = 80;
-[33m[tester::#YF3] [test-3.lox] [0m
-[33m[tester::#YF3] [test-3.lox] [0m[33m// Setting properties on an instance should work[0m
-[33m[tester::#YF3] [test-3.lox] [0msuperman.name = "Superman";
-[33m[tester::#YF3] [test-3.lox] [0msuperman.called = 16;
-[33m[tester::#YF3] [test-3.lox] [0m
-[33m[tester::#YF3] [test-3.lox] [0m[33m// Getting properties on an instance should work[0m
-[33m[tester::#YF3] [test-3.lox] [0mprint "Times " + superman.name + " was called: ";
-[33m[tester::#YF3] [test-3.lox] [0mprint superman.called;
-[33m[tester::#YF3] [test-3.lox] [0mprint "Times " + batman.name + " was called: ";
-[33m[tester::#YF3] [test-3.lox] [0mprint batman.called;
+[33m[tester::#YF3] [test-3.lox] [0m[0mclass Superhero {}[0m
+[33m[tester::#YF3] [test-3.lox] [0m[0mvar batman = Superhero();[0m
+[33m[tester::#YF3] [test-3.lox] [0m[0mvar superman = Superhero();[0m
+[33m[tester::#YF3] [test-3.lox] [0m[0m[0m
+[33m[tester::#YF3] [test-3.lox] [0m[0m[33m// Setting properties on an instance should work[0m[0m
+[33m[tester::#YF3] [test-3.lox] [0m[0mbatman.name = "Batman";[0m
+[33m[tester::#YF3] [test-3.lox] [0m[0mbatman.called = 80;[0m
+[33m[tester::#YF3] [test-3.lox] [0m[0m[0m
+[33m[tester::#YF3] [test-3.lox] [0m[0m[33m// Setting properties on an instance should work[0m[0m
+[33m[tester::#YF3] [test-3.lox] [0m[0msuperman.name = "Superman";[0m
+[33m[tester::#YF3] [test-3.lox] [0m[0msuperman.called = 16;[0m
+[33m[tester::#YF3] [test-3.lox] [0m[0m[0m
+[33m[tester::#YF3] [test-3.lox] [0m[0m[33m// Getting properties on an instance should work[0m[0m
+[33m[tester::#YF3] [test-3.lox] [0m[0mprint "Times " + superman.name + " was called: ";[0m
+[33m[tester::#YF3] [test-3.lox] [0m[0mprint superman.called;[0m
+[33m[tester::#YF3] [test-3.lox] [0m[0mprint "Times " + batman.name + " was called: ";[0m
+[33m[tester::#YF3] [test-3.lox] [0m[0mprint batman.called;[0m
 [33m[tester::#YF3] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mTimes Superman was called: 
-[33m[your_program] [0m16
-[33m[your_program] [0mTimes Batman was called: 
-[33m[your_program] [0m80
+[33m[your_program] [0m[0mTimes Superman was called: [0m
+[33m[your_program] [0m[0m16[0m
+[33m[your_program] [0m[0mTimes Batman was called: [0m
+[33m[your_program] [0m[0m80[0m
 [33m[tester::#YF3] [test-3] [0m[92m✓ 4 line(s) match on stdout[0m
 [33m[tester::#YF3] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#YF3] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#YF3] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YF3] [test-4.lox] [0mclass Wizard {}
-[33m[tester::#YF3] [test-4.lox] [0mvar gandalf = Wizard();
-[33m[tester::#YF3] [test-4.lox] [0m
-[33m[tester::#YF3] [test-4.lox] [0mgandalf.color = "Grey";
-[33m[tester::#YF3] [test-4.lox] [0mgandalf.power = nil;
-[33m[tester::#YF3] [test-4.lox] [0mprint gandalf.color;
-[33m[tester::#YF3] [test-4.lox] [0m
-[33m[tester::#YF3] [test-4.lox] [0m[33m// functions should be able to accept class[0m
-[33m[tester::#YF3] [test-4.lox] [0m[33m// instances and get or set properties on them[0m
-[33m[tester::#YF3] [test-4.lox] [0mfun promote(wizard) {
-[33m[tester::#YF3] [test-4.lox] [0m  wizard.color = "White";
-[33m[tester::#YF3] [test-4.lox] [0m  if (false) {
-[33m[tester::#YF3] [test-4.lox] [0m    wizard.power = 100;
-[33m[tester::#YF3] [test-4.lox] [0m  } else {
-[33m[tester::#YF3] [test-4.lox] [0m    wizard.power = 0;
-[33m[tester::#YF3] [test-4.lox] [0m  }
-[33m[tester::#YF3] [test-4.lox] [0m}
-[33m[tester::#YF3] [test-4.lox] [0m
-[33m[tester::#YF3] [test-4.lox] [0mpromote(gandalf);
-[33m[tester::#YF3] [test-4.lox] [0mprint gandalf.color;
-[33m[tester::#YF3] [test-4.lox] [0mprint gandalf.power;
+[33m[tester::#YF3] [test-4.lox] [0m[0mclass Wizard {}[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0mvar gandalf = Wizard();[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0m[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0mgandalf.color = "Grey";[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0mgandalf.power = nil;[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0mprint gandalf.color;[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0m[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0m[33m// functions should be able to accept class[0m[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0m[33m// instances and get or set properties on them[0m[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0mfun promote(wizard) {[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0m  wizard.color = "White";[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0m  if (false) {[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0m    wizard.power = 100;[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0m  } else {[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0m    wizard.power = 0;[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0m}[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0m[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0mpromote(gandalf);[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0mprint gandalf.color;[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0mprint gandalf.power;[0m
 [33m[tester::#YF3] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mGrey
-[33m[your_program] [0mWhite
-[33m[your_program] [0m0
+[33m[your_program] [0m[0mGrey[0m
+[33m[your_program] [0m[0mWhite[0m
+[33m[your_program] [0m[0m0[0m
 [33m[tester::#YF3] [test-4] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#YF3] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#YF3] [0m[92mTest passed.[0m
@@ -243,114 +243,114 @@ Debug = true
 [33m[tester::#QR2] [0m[94mRunning tests for Stage #QR2 (qr2)[0m
 [33m[tester::#QR2] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#QR2] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#QR2] [test-1.lox] [0mclass Robot {
-[33m[tester::#QR2] [test-1.lox] [0m  beep() {
-[33m[tester::#QR2] [test-1.lox] [0m    print "Beep boop!";
-[33m[tester::#QR2] [test-1.lox] [0m  }
-[33m[tester::#QR2] [test-1.lox] [0m}
-[33m[tester::#QR2] [test-1.lox] [0m
-[33m[tester::#QR2] [test-1.lox] [0mvar r2d2 = Robot();
-[33m[tester::#QR2] [test-1.lox] [0m[33m// Calling a method on an instance should work[0m
-[33m[tester::#QR2] [test-1.lox] [0mr2d2.beep();
-[33m[tester::#QR2] [test-1.lox] [0m
-[33m[tester::#QR2] [test-1.lox] [0m[33m// Calling a method on a class instance should work[0m
-[33m[tester::#QR2] [test-1.lox] [0mRobot().beep();
+[33m[tester::#QR2] [test-1.lox] [0m[0mclass Robot {[0m
+[33m[tester::#QR2] [test-1.lox] [0m[0m  beep() {[0m
+[33m[tester::#QR2] [test-1.lox] [0m[0m    print "Beep boop!";[0m
+[33m[tester::#QR2] [test-1.lox] [0m[0m  }[0m
+[33m[tester::#QR2] [test-1.lox] [0m[0m}[0m
+[33m[tester::#QR2] [test-1.lox] [0m[0m[0m
+[33m[tester::#QR2] [test-1.lox] [0m[0mvar r2d2 = Robot();[0m
+[33m[tester::#QR2] [test-1.lox] [0m[0m[33m// Calling a method on an instance should work[0m[0m
+[33m[tester::#QR2] [test-1.lox] [0m[0mr2d2.beep();[0m
+[33m[tester::#QR2] [test-1.lox] [0m[0m[0m
+[33m[tester::#QR2] [test-1.lox] [0m[0m[33m// Calling a method on a class instance should work[0m[0m
+[33m[tester::#QR2] [test-1.lox] [0m[0mRobot().beep();[0m
 [33m[tester::#QR2] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mBeep boop!
-[33m[your_program] [0mBeep boop!
+[33m[your_program] [0m[0mBeep boop![0m
+[33m[your_program] [0m[0mBeep boop![0m
 [33m[tester::#QR2] [test-1] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#QR2] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#QR2] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#QR2] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#QR2] [test-2.lox] [0m{
-[33m[tester::#QR2] [test-2.lox] [0m  class Foo {
-[33m[tester::#QR2] [test-2.lox] [0m    returnSelf() {
-[33m[tester::#QR2] [test-2.lox] [0m      [33m// Should be able to return the class itself[0m
-[33m[tester::#QR2] [test-2.lox] [0m      return Foo;
-[33m[tester::#QR2] [test-2.lox] [0m    }
-[33m[tester::#QR2] [test-2.lox] [0m  }
-[33m[tester::#QR2] [test-2.lox] [0m
-[33m[tester::#QR2] [test-2.lox] [0m  [33m// Calling a method on an instance should work[0m
-[33m[tester::#QR2] [test-2.lox] [0m  print Foo().returnSelf();
-[33m[tester::#QR2] [test-2.lox] [0m}
+[33m[tester::#QR2] [test-2.lox] [0m[0m{[0m
+[33m[tester::#QR2] [test-2.lox] [0m[0m  class Foo {[0m
+[33m[tester::#QR2] [test-2.lox] [0m[0m    returnSelf() {[0m
+[33m[tester::#QR2] [test-2.lox] [0m[0m      [33m// Should be able to return the class itself[0m[0m
+[33m[tester::#QR2] [test-2.lox] [0m[0m      return Foo;[0m
+[33m[tester::#QR2] [test-2.lox] [0m[0m    }[0m
+[33m[tester::#QR2] [test-2.lox] [0m[0m  }[0m
+[33m[tester::#QR2] [test-2.lox] [0m[0m[0m
+[33m[tester::#QR2] [test-2.lox] [0m[0m  [33m// Calling a method on an instance should work[0m[0m
+[33m[tester::#QR2] [test-2.lox] [0m[0m  print Foo().returnSelf();[0m
+[33m[tester::#QR2] [test-2.lox] [0m[0m}[0m
 [33m[tester::#QR2] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mFoo
+[33m[your_program] [0m[0mFoo[0m
 [33m[tester::#QR2] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#QR2] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#QR2] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#QR2] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#QR2] [test-3.lox] [0mclass Wizard {
-[33m[tester::#QR2] [test-3.lox] [0m  castSpell(spell) {
-[33m[tester::#QR2] [test-3.lox] [0m    [33m// Methods should be able to accept a parameter[0m
-[33m[tester::#QR2] [test-3.lox] [0m    print "Casting a magical spell: " + spell;
-[33m[tester::#QR2] [test-3.lox] [0m  }
-[33m[tester::#QR2] [test-3.lox] [0m}
-[33m[tester::#QR2] [test-3.lox] [0m
-[33m[tester::#QR2] [test-3.lox] [0mclass Dragon {
-[33m[tester::#QR2] [test-3.lox] [0m  [33m// Methods should be able to accept multiple[0m
-[33m[tester::#QR2] [test-3.lox] [0m  [33m// parameters[0m
-[33m[tester::#QR2] [test-3.lox] [0m  breatheFire(fire, intensity) {
-[33m[tester::#QR2] [test-3.lox] [0m    print "Breathing " + fire + " with intensity: "
-[33m[tester::#QR2] [test-3.lox] [0m    + intensity;
-[33m[tester::#QR2] [test-3.lox] [0m  }
-[33m[tester::#QR2] [test-3.lox] [0m}
-[33m[tester::#QR2] [test-3.lox] [0m
-[33m[tester::#QR2] [test-3.lox] [0mvar merlin = Wizard();
-[33m[tester::#QR2] [test-3.lox] [0mvar smaug = Dragon();
-[33m[tester::#QR2] [test-3.lox] [0m
-[33m[tester::#QR2] [test-3.lox] [0mif (false) {
-[33m[tester::#QR2] [test-3.lox] [0m  var action = merlin.castSpell;
-[33m[tester::#QR2] [test-3.lox] [0m  action("Fireball");
-[33m[tester::#QR2] [test-3.lox] [0m} else {
-[33m[tester::#QR2] [test-3.lox] [0m  var action = smaug.breatheFire;
-[33m[tester::#QR2] [test-3.lox] [0m  action("Fire", "100");
-[33m[tester::#QR2] [test-3.lox] [0m}
+[33m[tester::#QR2] [test-3.lox] [0m[0mclass Wizard {[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m  castSpell(spell) {[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m    [33m// Methods should be able to accept a parameter[0m[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m    print "Casting a magical spell: " + spell;[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m  }[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m}[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0mclass Dragon {[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m  [33m// Methods should be able to accept multiple[0m[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m  [33m// parameters[0m[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m  breatheFire(fire, intensity) {[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m    print "Breathing " + fire + " with intensity: "[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m    + intensity;[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m  }[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m}[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0mvar merlin = Wizard();[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0mvar smaug = Dragon();[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0mif (false) {[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m  var action = merlin.castSpell;[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m  action("Fireball");[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m} else {[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m  var action = smaug.breatheFire;[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m  action("Fire", "100");[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m}[0m
 [33m[tester::#QR2] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mBreathing Fire with intensity: 100
+[33m[your_program] [0m[0mBreathing Fire with intensity: 100[0m
 [33m[tester::#QR2] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#QR2] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#QR2] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#QR2] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#QR2] [test-4.lox] [0mclass Superhero {
-[33m[tester::#QR2] [test-4.lox] [0m  [33m// Methods should be able to accept a parameter[0m
-[33m[tester::#QR2] [test-4.lox] [0m  useSpecialPower(hero) {
-[33m[tester::#QR2] [test-4.lox] [0m    print "Using power: " + hero.specialPower;
-[33m[tester::#QR2] [test-4.lox] [0m  }
-[33m[tester::#QR2] [test-4.lox] [0m
-[33m[tester::#QR2] [test-4.lox] [0m  [33m// Methods should be able to accept a parameter[0m
-[33m[tester::#QR2] [test-4.lox] [0m  [33m// of any type[0m
-[33m[tester::#QR2] [test-4.lox] [0m  hasSpecialPower(hero) {
-[33m[tester::#QR2] [test-4.lox] [0m    return hero.specialPower;
-[33m[tester::#QR2] [test-4.lox] [0m  }
-[33m[tester::#QR2] [test-4.lox] [0m
-[33m[tester::#QR2] [test-4.lox] [0m  [33m// Methods should be able to accept class[0m
-[33m[tester::#QR2] [test-4.lox] [0m  [33m// instances as parameters and then update their[0m
-[33m[tester::#QR2] [test-4.lox] [0m  [33m// properties[0m
-[33m[tester::#QR2] [test-4.lox] [0m  giveSpecialPower(hero, power) {
-[33m[tester::#QR2] [test-4.lox] [0m    hero.specialPower = power;
-[33m[tester::#QR2] [test-4.lox] [0m  }
-[33m[tester::#QR2] [test-4.lox] [0m}
-[33m[tester::#QR2] [test-4.lox] [0m
-[33m[tester::#QR2] [test-4.lox] [0mfun performHeroics(hero, superheroClass) {
-[33m[tester::#QR2] [test-4.lox] [0m  if (superheroClass.hasSpecialPower(hero)) {
-[33m[tester::#QR2] [test-4.lox] [0m    superheroClass.useSpecialPower(hero);
-[33m[tester::#QR2] [test-4.lox] [0m  } else {
-[33m[tester::#QR2] [test-4.lox] [0m    print "No special power available";
-[33m[tester::#QR2] [test-4.lox] [0m  }
-[33m[tester::#QR2] [test-4.lox] [0m}
-[33m[tester::#QR2] [test-4.lox] [0m
-[33m[tester::#QR2] [test-4.lox] [0mvar superman = Superhero();
-[33m[tester::#QR2] [test-4.lox] [0mvar heroClass = Superhero();
-[33m[tester::#QR2] [test-4.lox] [0m
-[33m[tester::#QR2] [test-4.lox] [0mif (false) {
-[33m[tester::#QR2] [test-4.lox] [0m  heroClass.giveSpecialPower(superman, "Flight");
-[33m[tester::#QR2] [test-4.lox] [0m} else {
-[33m[tester::#QR2] [test-4.lox] [0m  heroClass.giveSpecialPower(superman, "Strength");
-[33m[tester::#QR2] [test-4.lox] [0m}
-[33m[tester::#QR2] [test-4.lox] [0m
-[33m[tester::#QR2] [test-4.lox] [0mperformHeroics(superman, heroClass);
+[33m[tester::#QR2] [test-4.lox] [0m[0mclass Superhero {[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m  [33m// Methods should be able to accept a parameter[0m[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m  useSpecialPower(hero) {[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m    print "Using power: " + hero.specialPower;[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m  [33m// Methods should be able to accept a parameter[0m[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m  [33m// of any type[0m[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m  hasSpecialPower(hero) {[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m    return hero.specialPower;[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m  [33m// Methods should be able to accept class[0m[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m  [33m// instances as parameters and then update their[0m[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m  [33m// properties[0m[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m  giveSpecialPower(hero, power) {[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m    hero.specialPower = power;[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m}[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0mfun performHeroics(hero, superheroClass) {[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m  if (superheroClass.hasSpecialPower(hero)) {[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m    superheroClass.useSpecialPower(hero);[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m  } else {[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m    print "No special power available";[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m}[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0mvar superman = Superhero();[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0mvar heroClass = Superhero();[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0mif (false) {[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m  heroClass.giveSpecialPower(superman, "Flight");[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m} else {[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m  heroClass.giveSpecialPower(superman, "Strength");[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m}[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0mperformHeroics(superman, heroClass);[0m
 [33m[tester::#QR2] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mUsing power: Strength
+[33m[your_program] [0m[0mUsing power: Strength[0m
 [33m[tester::#QR2] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#QR2] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#QR2] [0m[92mTest passed.[0m
@@ -358,92 +358,92 @@ Debug = true
 [33m[tester::#YD7] [0m[94mRunning tests for Stage #YD7 (yd7)[0m
 [33m[tester::#YD7] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#YD7] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YD7] [test-1.lox] [0mclass Spaceship {
-[33m[tester::#YD7] [test-1.lox] [0m  identify() {
-[33m[tester::#YD7] [test-1.lox] [0m    [33m// this should be bound to the instance[0m
-[33m[tester::#YD7] [test-1.lox] [0m    print this;
-[33m[tester::#YD7] [test-1.lox] [0m  }
-[33m[tester::#YD7] [test-1.lox] [0m}
-[33m[tester::#YD7] [test-1.lox] [0m
-[33m[tester::#YD7] [test-1.lox] [0m[33m// Calling a method on a class instance should work[0m
-[33m[tester::#YD7] [test-1.lox] [0mSpaceship().identify();
+[33m[tester::#YD7] [test-1.lox] [0m[0mclass Spaceship {[0m
+[33m[tester::#YD7] [test-1.lox] [0m[0m  identify() {[0m
+[33m[tester::#YD7] [test-1.lox] [0m[0m    [33m// this should be bound to the instance[0m[0m
+[33m[tester::#YD7] [test-1.lox] [0m[0m    print this;[0m
+[33m[tester::#YD7] [test-1.lox] [0m[0m  }[0m
+[33m[tester::#YD7] [test-1.lox] [0m[0m}[0m
+[33m[tester::#YD7] [test-1.lox] [0m[0m[0m
+[33m[tester::#YD7] [test-1.lox] [0m[0m[33m// Calling a method on a class instance should work[0m[0m
+[33m[tester::#YD7] [test-1.lox] [0m[0mSpaceship().identify();[0m
 [33m[tester::#YD7] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mSpaceship instance
+[33m[your_program] [0m[0mSpaceship instance[0m
 [33m[tester::#YD7] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#YD7] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#YD7] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#YD7] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YD7] [test-2.lox] [0mclass Calculator {
-[33m[tester::#YD7] [test-2.lox] [0m  add(a, b) {
-[33m[tester::#YD7] [test-2.lox] [0m    [33m// this should be bound to the instance[0m
-[33m[tester::#YD7] [test-2.lox] [0m    return a + b + this.memory;
-[33m[tester::#YD7] [test-2.lox] [0m  }
-[33m[tester::#YD7] [test-2.lox] [0m}
-[33m[tester::#YD7] [test-2.lox] [0m
-[33m[tester::#YD7] [test-2.lox] [0mvar calc = Calculator();
-[33m[tester::#YD7] [test-2.lox] [0m[33m// Instance properties should be accessible using[0m
-[33m[tester::#YD7] [test-2.lox] [0m[33m// the this keyword[0m
-[33m[tester::#YD7] [test-2.lox] [0mcalc.memory = 88;
-[33m[tester::#YD7] [test-2.lox] [0mprint calc.add(54, 1);
+[33m[tester::#YD7] [test-2.lox] [0m[0mclass Calculator {[0m
+[33m[tester::#YD7] [test-2.lox] [0m[0m  add(a, b) {[0m
+[33m[tester::#YD7] [test-2.lox] [0m[0m    [33m// this should be bound to the instance[0m[0m
+[33m[tester::#YD7] [test-2.lox] [0m[0m    return a + b + this.memory;[0m
+[33m[tester::#YD7] [test-2.lox] [0m[0m  }[0m
+[33m[tester::#YD7] [test-2.lox] [0m[0m}[0m
+[33m[tester::#YD7] [test-2.lox] [0m[0m[0m
+[33m[tester::#YD7] [test-2.lox] [0m[0mvar calc = Calculator();[0m
+[33m[tester::#YD7] [test-2.lox] [0m[0m[33m// Instance properties should be accessible using[0m[0m
+[33m[tester::#YD7] [test-2.lox] [0m[0m[33m// the this keyword[0m[0m
+[33m[tester::#YD7] [test-2.lox] [0m[0mcalc.memory = 88;[0m
+[33m[tester::#YD7] [test-2.lox] [0m[0mprint calc.add(54, 1);[0m
 [33m[tester::#YD7] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m143
+[33m[your_program] [0m[0m143[0m
 [33m[tester::#YD7] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#YD7] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#YD7] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#YD7] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YD7] [test-3.lox] [0mclass Animal {
-[33m[tester::#YD7] [test-3.lox] [0m  makeSound() {
-[33m[tester::#YD7] [test-3.lox] [0m    print this.sound;
-[33m[tester::#YD7] [test-3.lox] [0m  }
-[33m[tester::#YD7] [test-3.lox] [0m
-[33m[tester::#YD7] [test-3.lox] [0m  identify() {
-[33m[tester::#YD7] [test-3.lox] [0m    print this.species;
-[33m[tester::#YD7] [test-3.lox] [0m  }
-[33m[tester::#YD7] [test-3.lox] [0m}
-[33m[tester::#YD7] [test-3.lox] [0m
-[33m[tester::#YD7] [test-3.lox] [0mvar dog = Animal();
-[33m[tester::#YD7] [test-3.lox] [0mdog.sound = "Woof";
-[33m[tester::#YD7] [test-3.lox] [0mdog.species = "Dog";
-[33m[tester::#YD7] [test-3.lox] [0m
-[33m[tester::#YD7] [test-3.lox] [0mvar cat = Animal();
-[33m[tester::#YD7] [test-3.lox] [0mcat.sound = "Meow";
-[33m[tester::#YD7] [test-3.lox] [0mcat.species = "Cat";
-[33m[tester::#YD7] [test-3.lox] [0m
-[33m[tester::#YD7] [test-3.lox] [0m[33m// The this keyword should be bound to the[0m
-[33m[tester::#YD7] [test-3.lox] [0m[33m// class instance that the method is called on[0m
-[33m[tester::#YD7] [test-3.lox] [0mcat.makeSound = dog.makeSound;
-[33m[tester::#YD7] [test-3.lox] [0mdog.identify = cat.identify;
-[33m[tester::#YD7] [test-3.lox] [0m
-[33m[tester::#YD7] [test-3.lox] [0mcat.makeSound(); [33m// expect: Woof[0m
-[33m[tester::#YD7] [test-3.lox] [0mdog.identify(); [33m// expect: Cat[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0mclass Animal {[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0m  makeSound() {[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0m    print this.sound;[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0m  }[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0m[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0m  identify() {[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0m    print this.species;[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0m  }[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0m}[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0m[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0mvar dog = Animal();[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0mdog.sound = "Woof";[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0mdog.species = "Dog";[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0m[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0mvar cat = Animal();[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0mcat.sound = "Meow";[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0mcat.species = "Cat";[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0m[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0m[33m// The this keyword should be bound to the[0m[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0m[33m// class instance that the method is called on[0m[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0mcat.makeSound = dog.makeSound;[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0mdog.identify = cat.identify;[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0m[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0mcat.makeSound(); [33m// expect: Woof[0m[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0mdog.identify(); [33m// expect: Cat[0m[0m
 [33m[tester::#YD7] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mWoof
-[33m[your_program] [0mCat
+[33m[your_program] [0m[0mWoof[0m
+[33m[your_program] [0m[0mCat[0m
 [33m[tester::#YD7] [test-3] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#YD7] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#YD7] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#YD7] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YD7] [test-4.lox] [0mclass Wizard {
-[33m[tester::#YD7] [test-4.lox] [0m  getSpellCaster() {
-[33m[tester::#YD7] [test-4.lox] [0m    fun castSpell() {
-[33m[tester::#YD7] [test-4.lox] [0m      print this;
-[33m[tester::#YD7] [test-4.lox] [0m      print "Casting spell as " + this.name;
-[33m[tester::#YD7] [test-4.lox] [0m    }
-[33m[tester::#YD7] [test-4.lox] [0m
-[33m[tester::#YD7] [test-4.lox] [0m    [33m// Functions are first-class objects in Lox[0m
-[33m[tester::#YD7] [test-4.lox] [0m    return castSpell;
-[33m[tester::#YD7] [test-4.lox] [0m  }
-[33m[tester::#YD7] [test-4.lox] [0m}
-[33m[tester::#YD7] [test-4.lox] [0m
-[33m[tester::#YD7] [test-4.lox] [0mvar wizard = Wizard();
-[33m[tester::#YD7] [test-4.lox] [0mwizard.name = "Merlin";
-[33m[tester::#YD7] [test-4.lox] [0m
-[33m[tester::#YD7] [test-4.lox] [0m[33m// Calling an instance method that returns a[0m
-[33m[tester::#YD7] [test-4.lox] [0m[33m// function should work[0m
-[33m[tester::#YD7] [test-4.lox] [0mwizard.getSpellCaster()();
+[33m[tester::#YD7] [test-4.lox] [0m[0mclass Wizard {[0m
+[33m[tester::#YD7] [test-4.lox] [0m[0m  getSpellCaster() {[0m
+[33m[tester::#YD7] [test-4.lox] [0m[0m    fun castSpell() {[0m
+[33m[tester::#YD7] [test-4.lox] [0m[0m      print this;[0m
+[33m[tester::#YD7] [test-4.lox] [0m[0m      print "Casting spell as " + this.name;[0m
+[33m[tester::#YD7] [test-4.lox] [0m[0m    }[0m
+[33m[tester::#YD7] [test-4.lox] [0m[0m[0m
+[33m[tester::#YD7] [test-4.lox] [0m[0m    [33m// Functions are first-class objects in Lox[0m[0m
+[33m[tester::#YD7] [test-4.lox] [0m[0m    return castSpell;[0m
+[33m[tester::#YD7] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#YD7] [test-4.lox] [0m[0m}[0m
+[33m[tester::#YD7] [test-4.lox] [0m[0m[0m
+[33m[tester::#YD7] [test-4.lox] [0m[0mvar wizard = Wizard();[0m
+[33m[tester::#YD7] [test-4.lox] [0m[0mwizard.name = "Merlin";[0m
+[33m[tester::#YD7] [test-4.lox] [0m[0m[0m
+[33m[tester::#YD7] [test-4.lox] [0m[0m[33m// Calling an instance method that returns a[0m[0m
+[33m[tester::#YD7] [test-4.lox] [0m[0m[33m// function should work[0m[0m
+[33m[tester::#YD7] [test-4.lox] [0m[0mwizard.getSpellCaster()();[0m
 [33m[tester::#YD7] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mWizard instance
-[33m[your_program] [0mCasting spell as Merlin
+[33m[your_program] [0m[0mWizard instance[0m
+[33m[your_program] [0m[0mCasting spell as Merlin[0m
 [33m[tester::#YD7] [test-4] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#YD7] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#YD7] [0m[92mTest passed.[0m
@@ -451,59 +451,59 @@ Debug = true
 [33m[tester::#DG2] [0m[94mRunning tests for Stage #DG2 (dg2)[0m
 [33m[tester::#DG2] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#DG2] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#DG2] [test-1.lox] [0m[33m// The this keyword used outside of a class[0m
-[33m[tester::#DG2] [test-1.lox] [0m[33m// should be a compile error[0m
-[33m[tester::#DG2] [test-1.lox] [0mprint this;
+[33m[tester::#DG2] [test-1.lox] [0m[0m[33m// The this keyword used outside of a class[0m[0m
+[33m[tester::#DG2] [test-1.lox] [0m[0m[33m// should be a compile error[0m[0m
+[33m[tester::#DG2] [test-1.lox] [0m[0mprint this;[0m
 [33m[tester::#DG2] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 3] Error at 'this': Can't use 'this' outside of a class.
+[33m[your_program] [0m[0m[line 3] Error at 'this': Can't use 'this' outside of a class.[0m
 [33m[tester::#DG2] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#DG2] [test-1] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#DG2] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#DG2] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#DG2] [test-2.lox] [0m[33m// using this outside of a class shouldn't work[0m
-[33m[tester::#DG2] [test-2.lox] [0mfun notAMethod() {
-[33m[tester::#DG2] [test-2.lox] [0m  print this; [33m// expect compile error[0m
-[33m[tester::#DG2] [test-2.lox] [0m}
+[33m[tester::#DG2] [test-2.lox] [0m[0m[33m// using this outside of a class shouldn't work[0m[0m
+[33m[tester::#DG2] [test-2.lox] [0m[0mfun notAMethod() {[0m
+[33m[tester::#DG2] [test-2.lox] [0m[0m  print this; [33m// expect compile error[0m[0m
+[33m[tester::#DG2] [test-2.lox] [0m[0m}[0m
 [33m[tester::#DG2] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 3] Error at 'this': Can't use 'this' outside of a class.
+[33m[your_program] [0m[0m[line 3] Error at 'this': Can't use 'this' outside of a class.[0m
 [33m[tester::#DG2] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#DG2] [test-2] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#DG2] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#DG2] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#DG2] [test-3.lox] [0mclass Person {
-[33m[tester::#DG2] [test-3.lox] [0m  sayName() {
-[33m[tester::#DG2] [test-3.lox] [0m    [33m// this is not a callable object[0m
-[33m[tester::#DG2] [test-3.lox] [0m    print this(); [33m// expect runtime error[0m
-[33m[tester::#DG2] [test-3.lox] [0m  }
-[33m[tester::#DG2] [test-3.lox] [0m}
-[33m[tester::#DG2] [test-3.lox] [0mPerson().sayName();
+[33m[tester::#DG2] [test-3.lox] [0m[0mclass Person {[0m
+[33m[tester::#DG2] [test-3.lox] [0m[0m  sayName() {[0m
+[33m[tester::#DG2] [test-3.lox] [0m[0m    [33m// this is not a callable object[0m[0m
+[33m[tester::#DG2] [test-3.lox] [0m[0m    print this(); [33m// expect runtime error[0m[0m
+[33m[tester::#DG2] [test-3.lox] [0m[0m  }[0m
+[33m[tester::#DG2] [test-3.lox] [0m[0m}[0m
+[33m[tester::#DG2] [test-3.lox] [0m[0mPerson().sayName();[0m
 [33m[tester::#DG2] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mCan only call functions and classes.
-[33m[your_program] [0m[line 4]
+[33m[your_program] [0m[0mCan only call functions and classes.[0m
+[33m[your_program] [0m[0m[line 4][0m
 [33m[tester::#DG2] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#DG2] [test-3] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#DG2] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#DG2] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#DG2] [test-4.lox] [0mclass Confused {
-[33m[tester::#DG2] [test-4.lox] [0m  method() {
-[33m[tester::#DG2] [test-4.lox] [0m    fun inner(instance) {
-[33m[tester::#DG2] [test-4.lox] [0m      [33m// this is a local variable[0m
-[33m[tester::#DG2] [test-4.lox] [0m      var feeling = "confused";
-[33m[tester::#DG2] [test-4.lox] [0m      [33m// Unless explicitly set, feeling can't be[0m
-[33m[tester::#DG2] [test-4.lox] [0m      [33m// accessed using this keyword[0m
-[33m[tester::#DG2] [test-4.lox] [0m      print this.feeling; [33m// expect runtime error[0m
-[33m[tester::#DG2] [test-4.lox] [0m    }
-[33m[tester::#DG2] [test-4.lox] [0m    return inner;
-[33m[tester::#DG2] [test-4.lox] [0m  }
-[33m[tester::#DG2] [test-4.lox] [0m}
-[33m[tester::#DG2] [test-4.lox] [0m
-[33m[tester::#DG2] [test-4.lox] [0mvar instance = Confused();
-[33m[tester::#DG2] [test-4.lox] [0mvar m = instance.method();
-[33m[tester::#DG2] [test-4.lox] [0m[33m// calling the function returned should work[0m
-[33m[tester::#DG2] [test-4.lox] [0mm(instance);
+[33m[tester::#DG2] [test-4.lox] [0m[0mclass Confused {[0m
+[33m[tester::#DG2] [test-4.lox] [0m[0m  method() {[0m
+[33m[tester::#DG2] [test-4.lox] [0m[0m    fun inner(instance) {[0m
+[33m[tester::#DG2] [test-4.lox] [0m[0m      [33m// this is a local variable[0m[0m
+[33m[tester::#DG2] [test-4.lox] [0m[0m      var feeling = "confused";[0m
+[33m[tester::#DG2] [test-4.lox] [0m[0m      [33m// Unless explicitly set, feeling can't be[0m[0m
+[33m[tester::#DG2] [test-4.lox] [0m[0m      [33m// accessed using this keyword[0m[0m
+[33m[tester::#DG2] [test-4.lox] [0m[0m      print this.feeling; [33m// expect runtime error[0m[0m
+[33m[tester::#DG2] [test-4.lox] [0m[0m    }[0m
+[33m[tester::#DG2] [test-4.lox] [0m[0m    return inner;[0m
+[33m[tester::#DG2] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#DG2] [test-4.lox] [0m[0m}[0m
+[33m[tester::#DG2] [test-4.lox] [0m[0m[0m
+[33m[tester::#DG2] [test-4.lox] [0m[0mvar instance = Confused();[0m
+[33m[tester::#DG2] [test-4.lox] [0m[0mvar m = instance.method();[0m
+[33m[tester::#DG2] [test-4.lox] [0m[0m[33m// calling the function returned should work[0m[0m
+[33m[tester::#DG2] [test-4.lox] [0m[0mm(instance);[0m
 [33m[tester::#DG2] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mUndefined property 'feeling'.
-[33m[your_program] [0m[line 8]
+[33m[your_program] [0m[0mUndefined property 'feeling'.[0m
+[33m[your_program] [0m[0m[line 8][0m
 [33m[tester::#DG2] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#DG2] [test-4] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#DG2] [0m[92mTest passed.[0m
@@ -511,97 +511,97 @@ Debug = true
 [33m[tester::#OU5] [0m[94mRunning tests for Stage #OU5 (ou5)[0m
 [33m[tester::#OU5] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#OU5] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#OU5] [test-1.lox] [0mclass Default {
-[33m[tester::#OU5] [test-1.lox] [0m  [33m// this is the constructor[0m
-[33m[tester::#OU5] [test-1.lox] [0m  init() {
-[33m[tester::#OU5] [test-1.lox] [0m    [33m// it should be able to set[0m
-[33m[tester::#OU5] [test-1.lox] [0m    [33m// properties on the instance[0m
-[33m[tester::#OU5] [test-1.lox] [0m    this.x = "baz";
-[33m[tester::#OU5] [test-1.lox] [0m    this.y = 59;
-[33m[tester::#OU5] [test-1.lox] [0m  }
-[33m[tester::#OU5] [test-1.lox] [0m}
-[33m[tester::#OU5] [test-1.lox] [0m
-[33m[tester::#OU5] [test-1.lox] [0m[33m// the constructor should be called[0m
-[33m[tester::#OU5] [test-1.lox] [0m[33m// automatically  when the class is being[0m
-[33m[tester::#OU5] [test-1.lox] [0m[33m// instantiated[0m
-[33m[tester::#OU5] [test-1.lox] [0mprint Default().x;
-[33m[tester::#OU5] [test-1.lox] [0mprint Default().y;
+[33m[tester::#OU5] [test-1.lox] [0m[0mclass Default {[0m
+[33m[tester::#OU5] [test-1.lox] [0m[0m  [33m// this is the constructor[0m[0m
+[33m[tester::#OU5] [test-1.lox] [0m[0m  init() {[0m
+[33m[tester::#OU5] [test-1.lox] [0m[0m    [33m// it should be able to set[0m[0m
+[33m[tester::#OU5] [test-1.lox] [0m[0m    [33m// properties on the instance[0m[0m
+[33m[tester::#OU5] [test-1.lox] [0m[0m    this.x = "baz";[0m
+[33m[tester::#OU5] [test-1.lox] [0m[0m    this.y = 59;[0m
+[33m[tester::#OU5] [test-1.lox] [0m[0m  }[0m
+[33m[tester::#OU5] [test-1.lox] [0m[0m}[0m
+[33m[tester::#OU5] [test-1.lox] [0m[0m[0m
+[33m[tester::#OU5] [test-1.lox] [0m[0m[33m// the constructor should be called[0m[0m
+[33m[tester::#OU5] [test-1.lox] [0m[0m[33m// automatically  when the class is being[0m[0m
+[33m[tester::#OU5] [test-1.lox] [0m[0m[33m// instantiated[0m[0m
+[33m[tester::#OU5] [test-1.lox] [0m[0mprint Default().x;[0m
+[33m[tester::#OU5] [test-1.lox] [0m[0mprint Default().y;[0m
 [33m[tester::#OU5] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mbaz
-[33m[your_program] [0m59
+[33m[your_program] [0m[0mbaz[0m
+[33m[your_program] [0m[0m59[0m
 [33m[tester::#OU5] [test-1] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#OU5] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#OU5] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#OU5] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#OU5] [test-2.lox] [0mclass Robot {
-[33m[tester::#OU5] [test-2.lox] [0m  [33m// constructors should be able to accept[0m
-[33m[tester::#OU5] [test-2.lox] [0m  [33m// one or more parameters[0m
-[33m[tester::#OU5] [test-2.lox] [0m  init(model, function) {
-[33m[tester::#OU5] [test-2.lox] [0m    this.model = model;
-[33m[tester::#OU5] [test-2.lox] [0m    this.function = function;
-[33m[tester::#OU5] [test-2.lox] [0m  }
-[33m[tester::#OU5] [test-2.lox] [0m}
-[33m[tester::#OU5] [test-2.lox] [0mprint Robot("R2-D2", "Astromech").model;
+[33m[tester::#OU5] [test-2.lox] [0m[0mclass Robot {[0m
+[33m[tester::#OU5] [test-2.lox] [0m[0m  [33m// constructors should be able to accept[0m[0m
+[33m[tester::#OU5] [test-2.lox] [0m[0m  [33m// one or more parameters[0m[0m
+[33m[tester::#OU5] [test-2.lox] [0m[0m  init(model, function) {[0m
+[33m[tester::#OU5] [test-2.lox] [0m[0m    this.model = model;[0m
+[33m[tester::#OU5] [test-2.lox] [0m[0m    this.function = function;[0m
+[33m[tester::#OU5] [test-2.lox] [0m[0m  }[0m
+[33m[tester::#OU5] [test-2.lox] [0m[0m}[0m
+[33m[tester::#OU5] [test-2.lox] [0m[0mprint Robot("R2-D2", "Astromech").model;[0m
 [33m[tester::#OU5] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mR2-D2
+[33m[your_program] [0m[0mR2-D2[0m
 [33m[tester::#OU5] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#OU5] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#OU5] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#OU5] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#OU5] [test-3.lox] [0mclass Counter {
-[33m[tester::#OU5] [test-3.lox] [0m  init(startValue) {
-[33m[tester::#OU5] [test-3.lox] [0m    if (startValue < 0) {
-[33m[tester::#OU5] [test-3.lox] [0m      print "startValue can't be negative";
-[33m[tester::#OU5] [test-3.lox] [0m      this.count = 0;
-[33m[tester::#OU5] [test-3.lox] [0m    } else {
-[33m[tester::#OU5] [test-3.lox] [0m      this.count = startValue;
-[33m[tester::#OU5] [test-3.lox] [0m    }
-[33m[tester::#OU5] [test-3.lox] [0m  }
-[33m[tester::#OU5] [test-3.lox] [0m}
-[33m[tester::#OU5] [test-3.lox] [0m
-[33m[tester::#OU5] [test-3.lox] [0m[33m// constructor is called automatically here[0m
-[33m[tester::#OU5] [test-3.lox] [0mvar instance = Counter(-11);
-[33m[tester::#OU5] [test-3.lox] [0mprint instance.count;
-[33m[tester::#OU5] [test-3.lox] [0m
-[33m[tester::#OU5] [test-3.lox] [0m[33m// it should be possible to call the constructor[0m
-[33m[tester::#OU5] [test-3.lox] [0m[33m// on a class instance as well[0m
-[33m[tester::#OU5] [test-3.lox] [0mprint instance.init(11).count;
+[33m[tester::#OU5] [test-3.lox] [0m[0mclass Counter {[0m
+[33m[tester::#OU5] [test-3.lox] [0m[0m  init(startValue) {[0m
+[33m[tester::#OU5] [test-3.lox] [0m[0m    if (startValue < 0) {[0m
+[33m[tester::#OU5] [test-3.lox] [0m[0m      print "startValue can't be negative";[0m
+[33m[tester::#OU5] [test-3.lox] [0m[0m      this.count = 0;[0m
+[33m[tester::#OU5] [test-3.lox] [0m[0m    } else {[0m
+[33m[tester::#OU5] [test-3.lox] [0m[0m      this.count = startValue;[0m
+[33m[tester::#OU5] [test-3.lox] [0m[0m    }[0m
+[33m[tester::#OU5] [test-3.lox] [0m[0m  }[0m
+[33m[tester::#OU5] [test-3.lox] [0m[0m}[0m
+[33m[tester::#OU5] [test-3.lox] [0m[0m[0m
+[33m[tester::#OU5] [test-3.lox] [0m[0m[33m// constructor is called automatically here[0m[0m
+[33m[tester::#OU5] [test-3.lox] [0m[0mvar instance = Counter(-11);[0m
+[33m[tester::#OU5] [test-3.lox] [0m[0mprint instance.count;[0m
+[33m[tester::#OU5] [test-3.lox] [0m[0m[0m
+[33m[tester::#OU5] [test-3.lox] [0m[0m[33m// it should be possible to call the constructor[0m[0m
+[33m[tester::#OU5] [test-3.lox] [0m[0m[33m// on a class instance as well[0m[0m
+[33m[tester::#OU5] [test-3.lox] [0m[0mprint instance.init(11).count;[0m
 [33m[tester::#OU5] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mstartValue can't be negative
-[33m[your_program] [0m0
-[33m[your_program] [0m11
+[33m[your_program] [0m[0mstartValue can't be negative[0m
+[33m[your_program] [0m[0m0[0m
+[33m[your_program] [0m[0m11[0m
 [33m[tester::#OU5] [test-3] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#OU5] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#OU5] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#OU5] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#OU5] [test-4.lox] [0mclass Vehicle {
-[33m[tester::#OU5] [test-4.lox] [0m  init(type) {
-[33m[tester::#OU5] [test-4.lox] [0m    this.type = type;
-[33m[tester::#OU5] [test-4.lox] [0m  }
-[33m[tester::#OU5] [test-4.lox] [0m}
-[33m[tester::#OU5] [test-4.lox] [0m
-[33m[tester::#OU5] [test-4.lox] [0mclass Car {
-[33m[tester::#OU5] [test-4.lox] [0m  init(make, model) {
-[33m[tester::#OU5] [test-4.lox] [0m    this.make = make;
-[33m[tester::#OU5] [test-4.lox] [0m    this.model = model;
-[33m[tester::#OU5] [test-4.lox] [0m    this.wheels = "four";
-[33m[tester::#OU5] [test-4.lox] [0m  }
-[33m[tester::#OU5] [test-4.lox] [0m
-[33m[tester::#OU5] [test-4.lox] [0m  describe() {
-[33m[tester::#OU5] [test-4.lox] [0m    [33m// expression across multiple lines should work[0m
-[33m[tester::#OU5] [test-4.lox] [0m    print this.make + " " + this.model +
-[33m[tester::#OU5] [test-4.lox] [0m    " with " + this.wheels + " wheels";
-[33m[tester::#OU5] [test-4.lox] [0m  }
-[33m[tester::#OU5] [test-4.lox] [0m}
-[33m[tester::#OU5] [test-4.lox] [0m
-[33m[tester::#OU5] [test-4.lox] [0mvar vehicle = Vehicle("Generic");
-[33m[tester::#OU5] [test-4.lox] [0mprint "Generic " + vehicle.type;
-[33m[tester::#OU5] [test-4.lox] [0m
-[33m[tester::#OU5] [test-4.lox] [0mvar myCar = Car("Toyota", "Corolla");
-[33m[tester::#OU5] [test-4.lox] [0mmyCar.describe();
+[33m[tester::#OU5] [test-4.lox] [0m[0mclass Vehicle {[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0m  init(type) {[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0m    this.type = type;[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0m}[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0m[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0mclass Car {[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0m  init(make, model) {[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0m    this.make = make;[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0m    this.model = model;[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0m    this.wheels = "four";[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0m[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0m  describe() {[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0m    [33m// expression across multiple lines should work[0m[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0m    print this.make + " " + this.model +[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0m    " with " + this.wheels + " wheels";[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0m}[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0m[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0mvar vehicle = Vehicle("Generic");[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0mprint "Generic " + vehicle.type;[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0m[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0mvar myCar = Car("Toyota", "Corolla");[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0mmyCar.describe();[0m
 [33m[tester::#OU5] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mGeneric Generic
-[33m[your_program] [0mToyota Corolla with four wheels
+[33m[your_program] [0m[0mGeneric Generic[0m
+[33m[your_program] [0m[0mToyota Corolla with four wheels[0m
 [33m[tester::#OU5] [test-4] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#OU5] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#OU5] [0m[92mTest passed.[0m
@@ -609,66 +609,66 @@ Debug = true
 [33m[tester::#EB9] [0m[94mRunning tests for Stage #EB9 (eb9)[0m
 [33m[tester::#EB9] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#EB9] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#EB9] [test-1.lox] [0mclass Person {
-[33m[tester::#EB9] [test-1.lox] [0m  init() {
-[33m[tester::#EB9] [test-1.lox] [0m    print "hello";
-[33m[tester::#EB9] [test-1.lox] [0m    [33m// constructor should return nothing[0m
-[33m[tester::#EB9] [test-1.lox] [0m    return;
-[33m[tester::#EB9] [test-1.lox] [0m  }
-[33m[tester::#EB9] [test-1.lox] [0m}
-[33m[tester::#EB9] [test-1.lox] [0m
-[33m[tester::#EB9] [test-1.lox] [0mPerson();
+[33m[tester::#EB9] [test-1.lox] [0m[0mclass Person {[0m
+[33m[tester::#EB9] [test-1.lox] [0m[0m  init() {[0m
+[33m[tester::#EB9] [test-1.lox] [0m[0m    print "hello";[0m
+[33m[tester::#EB9] [test-1.lox] [0m[0m    [33m// constructor should return nothing[0m[0m
+[33m[tester::#EB9] [test-1.lox] [0m[0m    return;[0m
+[33m[tester::#EB9] [test-1.lox] [0m[0m  }[0m
+[33m[tester::#EB9] [test-1.lox] [0m[0m}[0m
+[33m[tester::#EB9] [test-1.lox] [0m[0m[0m
+[33m[tester::#EB9] [test-1.lox] [0m[0mPerson();[0m
 [33m[tester::#EB9] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mhello
+[33m[your_program] [0m[0mhello[0m
 [33m[tester::#EB9] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#EB9] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#EB9] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#EB9] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#EB9] [test-2.lox] [0mclass ThingDefault {
-[33m[tester::#EB9] [test-2.lox] [0m  init() {
-[33m[tester::#EB9] [test-2.lox] [0m    this.x = "foo";
-[33m[tester::#EB9] [test-2.lox] [0m    this.y = 42;
-[33m[tester::#EB9] [test-2.lox] [0m    [33m// constructor should not return the instance[0m
-[33m[tester::#EB9] [test-2.lox] [0m    return this; [33m// expect compile error[0m
-[33m[tester::#EB9] [test-2.lox] [0m  }
-[33m[tester::#EB9] [test-2.lox] [0m}
-[33m[tester::#EB9] [test-2.lox] [0mvar out = ThingDefault();
-[33m[tester::#EB9] [test-2.lox] [0mprint out;
+[33m[tester::#EB9] [test-2.lox] [0m[0mclass ThingDefault {[0m
+[33m[tester::#EB9] [test-2.lox] [0m[0m  init() {[0m
+[33m[tester::#EB9] [test-2.lox] [0m[0m    this.x = "foo";[0m
+[33m[tester::#EB9] [test-2.lox] [0m[0m    this.y = 42;[0m
+[33m[tester::#EB9] [test-2.lox] [0m[0m    [33m// constructor should not return the instance[0m[0m
+[33m[tester::#EB9] [test-2.lox] [0m[0m    return this; [33m// expect compile error[0m[0m
+[33m[tester::#EB9] [test-2.lox] [0m[0m  }[0m
+[33m[tester::#EB9] [test-2.lox] [0m[0m}[0m
+[33m[tester::#EB9] [test-2.lox] [0m[0mvar out = ThingDefault();[0m
+[33m[tester::#EB9] [test-2.lox] [0m[0mprint out;[0m
 [33m[tester::#EB9] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 6] Error at 'return': Can't return a value from an initializer.
+[33m[your_program] [0m[0m[line 6] Error at 'return': Can't return a value from an initializer.[0m
 [33m[tester::#EB9] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#EB9] [test-2] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#EB9] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#EB9] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#EB9] [test-3.lox] [0mclass Foo {
-[33m[tester::#EB9] [test-3.lox] [0m  init() {
-[33m[tester::#EB9] [test-3.lox] [0m    [33m// constructor should not return anything[0m
-[33m[tester::#EB9] [test-3.lox] [0m    return "something"; [33m// expect compile error[0m
-[33m[tester::#EB9] [test-3.lox] [0m  }
-[33m[tester::#EB9] [test-3.lox] [0m}
-[33m[tester::#EB9] [test-3.lox] [0m
-[33m[tester::#EB9] [test-3.lox] [0mFoo();
+[33m[tester::#EB9] [test-3.lox] [0m[0mclass Foo {[0m
+[33m[tester::#EB9] [test-3.lox] [0m[0m  init() {[0m
+[33m[tester::#EB9] [test-3.lox] [0m[0m    [33m// constructor should not return anything[0m[0m
+[33m[tester::#EB9] [test-3.lox] [0m[0m    return "something"; [33m// expect compile error[0m[0m
+[33m[tester::#EB9] [test-3.lox] [0m[0m  }[0m
+[33m[tester::#EB9] [test-3.lox] [0m[0m}[0m
+[33m[tester::#EB9] [test-3.lox] [0m[0m[0m
+[33m[tester::#EB9] [test-3.lox] [0m[0mFoo();[0m
 [33m[tester::#EB9] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 4] Error at 'return': Can't return a value from an initializer.
+[33m[your_program] [0m[0m[line 4] Error at 'return': Can't return a value from an initializer.[0m
 [33m[tester::#EB9] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#EB9] [test-3] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#EB9] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#EB9] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#EB9] [test-4.lox] [0mclass Foo {
-[33m[tester::#EB9] [test-4.lox] [0m  init() {
-[33m[tester::#EB9] [test-4.lox] [0m    [33m// just calling the callback should've worked[0m
-[33m[tester::#EB9] [test-4.lox] [0m    [33m// but returning it is not allowed[0m
-[33m[tester::#EB9] [test-4.lox] [0m    return this.callback(); [33m// expect compile error[0m
-[33m[tester::#EB9] [test-4.lox] [0m  }
-[33m[tester::#EB9] [test-4.lox] [0m
-[33m[tester::#EB9] [test-4.lox] [0m  callback() {
-[33m[tester::#EB9] [test-4.lox] [0m    return "callback";
-[33m[tester::#EB9] [test-4.lox] [0m  }
-[33m[tester::#EB9] [test-4.lox] [0m}
-[33m[tester::#EB9] [test-4.lox] [0m
-[33m[tester::#EB9] [test-4.lox] [0mFoo();
+[33m[tester::#EB9] [test-4.lox] [0m[0mclass Foo {[0m
+[33m[tester::#EB9] [test-4.lox] [0m[0m  init() {[0m
+[33m[tester::#EB9] [test-4.lox] [0m[0m    [33m// just calling the callback should've worked[0m[0m
+[33m[tester::#EB9] [test-4.lox] [0m[0m    [33m// but returning it is not allowed[0m[0m
+[33m[tester::#EB9] [test-4.lox] [0m[0m    return this.callback(); [33m// expect compile error[0m[0m
+[33m[tester::#EB9] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#EB9] [test-4.lox] [0m[0m[0m
+[33m[tester::#EB9] [test-4.lox] [0m[0m  callback() {[0m
+[33m[tester::#EB9] [test-4.lox] [0m[0m    return "callback";[0m
+[33m[tester::#EB9] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#EB9] [test-4.lox] [0m[0m}[0m
+[33m[tester::#EB9] [test-4.lox] [0m[0m[0m
+[33m[tester::#EB9] [test-4.lox] [0m[0mFoo();[0m
 [33m[tester::#EB9] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 5] Error at 'return': Can't return a value from an initializer.
+[33m[your_program] [0m[0m[line 5] Error at 'return': Can't return a value from an initializer.[0m
 [33m[tester::#EB9] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#EB9] [test-4] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#EB9] [0m[92mTest passed.[0m

--- a/internal/test_helpers/fixtures/pass_classes_final
+++ b/internal/test_helpers/fixtures/pass_classes_final
@@ -3,60 +3,60 @@ Debug = true
 [33m[tester::#VF4] [0m[94mRunning tests for Stage #VF4 (vf4)[0m
 [33m[tester::#VF4] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#VF4] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#VF4] [test-1.lox] [0m[33m// Class declaration with empty body[0m
-[33m[tester::#VF4] [test-1.lox] [0mclass Spaceship {}
-[33m[tester::#VF4] [test-1.lox] [0mprint Spaceship;
+[33m[tester::#VF4] [test-1.lox] [0m[0m[33m// Class declaration with empty body[0m[0m
+[33m[tester::#VF4] [test-1.lox] [0m[0mclass Spaceship {}[0m
+[33m[tester::#VF4] [test-1.lox] [0m[0mprint Spaceship;[0m
 [33m[tester::#VF4] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mSpaceship
+[33m[your_program] [0m[0mSpaceship[0m
 [33m[tester::#VF4] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#VF4] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#VF4] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#VF4] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#VF4] [test-2.lox] [0m[33m// Multiple class declarations with empty body[0m
-[33m[tester::#VF4] [test-2.lox] [0mclass Robot {}
-[33m[tester::#VF4] [test-2.lox] [0mclass Wizard {}
-[33m[tester::#VF4] [test-2.lox] [0mprint Robot;
-[33m[tester::#VF4] [test-2.lox] [0mprint Wizard;
-[33m[tester::#VF4] [test-2.lox] [0mprint "Both classes successfully printed";
+[33m[tester::#VF4] [test-2.lox] [0m[0m[33m// Multiple class declarations with empty body[0m[0m
+[33m[tester::#VF4] [test-2.lox] [0m[0mclass Robot {}[0m
+[33m[tester::#VF4] [test-2.lox] [0m[0mclass Wizard {}[0m
+[33m[tester::#VF4] [test-2.lox] [0m[0mprint Robot;[0m
+[33m[tester::#VF4] [test-2.lox] [0m[0mprint Wizard;[0m
+[33m[tester::#VF4] [test-2.lox] [0m[0mprint "Both classes successfully printed";[0m
 [33m[tester::#VF4] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mRobot
-[33m[your_program] [0mWizard
-[33m[your_program] [0mBoth classes successfully printed
+[33m[your_program] [0m[0mRobot[0m
+[33m[your_program] [0m[0mWizard[0m
+[33m[your_program] [0m[0mBoth classes successfully printed[0m
 [33m[tester::#VF4] [test-2] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#VF4] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#VF4] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#VF4] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#VF4] [test-3.lox] [0m{
-[33m[tester::#VF4] [test-3.lox] [0m  [33m// Class declaration inside blocks should work[0m
-[33m[tester::#VF4] [test-3.lox] [0m  class Dinosaur {}
-[33m[tester::#VF4] [test-3.lox] [0m  print "Inside block: Dinosaur exists";
-[33m[tester::#VF4] [test-3.lox] [0m  print Dinosaur;
-[33m[tester::#VF4] [test-3.lox] [0m}
-[33m[tester::#VF4] [test-3.lox] [0mprint "Accessing out-of-scope class:";
-[33m[tester::#VF4] [test-3.lox] [0mprint Dinosaur;  [33m// expect runtime error[0m
+[33m[tester::#VF4] [test-3.lox] [0m[0m{[0m
+[33m[tester::#VF4] [test-3.lox] [0m[0m  [33m// Class declaration inside blocks should work[0m[0m
+[33m[tester::#VF4] [test-3.lox] [0m[0m  class Dinosaur {}[0m
+[33m[tester::#VF4] [test-3.lox] [0m[0m  print "Inside block: Dinosaur exists";[0m
+[33m[tester::#VF4] [test-3.lox] [0m[0m  print Dinosaur;[0m
+[33m[tester::#VF4] [test-3.lox] [0m[0m}[0m
+[33m[tester::#VF4] [test-3.lox] [0m[0mprint "Accessing out-of-scope class:";[0m
+[33m[tester::#VF4] [test-3.lox] [0m[0mprint Dinosaur;  [33m// expect runtime error[0m[0m
 [33m[tester::#VF4] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mInside block: Dinosaur exists
-[33m[your_program] [0mDinosaur
-[33m[your_program] [0mAccessing out-of-scope class:
-[33m[your_program] [0mUndefined variable 'Dinosaur'.
-[33m[your_program] [0m[line 8]
+[33m[your_program] [0m[0mInside block: Dinosaur exists[0m
+[33m[your_program] [0m[0mDinosaur[0m
+[33m[your_program] [0m[0mAccessing out-of-scope class:[0m
+[33m[your_program] [0m[0mUndefined variable 'Dinosaur'.[0m
+[33m[your_program] [0m[0m[line 8][0m
 [33m[tester::#VF4] [test-3] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#VF4] [test-3] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#VF4] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#VF4] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#VF4] [test-4.lox] [0m[33m// Class declaration inside function should work[0m
-[33m[tester::#VF4] [test-4.lox] [0mfun foo() {
-[33m[tester::#VF4] [test-4.lox] [0m  class Superhero {}
-[33m[tester::#VF4] [test-4.lox] [0m  print "Class declared inside function";
-[33m[tester::#VF4] [test-4.lox] [0m  print Superhero;
-[33m[tester::#VF4] [test-4.lox] [0m}
-[33m[tester::#VF4] [test-4.lox] [0m
-[33m[tester::#VF4] [test-4.lox] [0mfoo();
-[33m[tester::#VF4] [test-4.lox] [0mprint "Function called successfully";
+[33m[tester::#VF4] [test-4.lox] [0m[0m[33m// Class declaration inside function should work[0m[0m
+[33m[tester::#VF4] [test-4.lox] [0m[0mfun foo() {[0m
+[33m[tester::#VF4] [test-4.lox] [0m[0m  class Superhero {}[0m
+[33m[tester::#VF4] [test-4.lox] [0m[0m  print "Class declared inside function";[0m
+[33m[tester::#VF4] [test-4.lox] [0m[0m  print Superhero;[0m
+[33m[tester::#VF4] [test-4.lox] [0m[0m}[0m
+[33m[tester::#VF4] [test-4.lox] [0m[0m[0m
+[33m[tester::#VF4] [test-4.lox] [0m[0mfoo();[0m
+[33m[tester::#VF4] [test-4.lox] [0m[0mprint "Function called successfully";[0m
 [33m[tester::#VF4] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mClass declared inside function
-[33m[your_program] [0mSuperhero
-[33m[your_program] [0mFunction called successfully
+[33m[your_program] [0m[0mClass declared inside function[0m
+[33m[your_program] [0m[0mSuperhero[0m
+[33m[your_program] [0m[0mFunction called successfully[0m
 [33m[tester::#VF4] [test-4] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#VF4] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#VF4] [0m[92mTest passed.[0m
@@ -64,83 +64,83 @@ Debug = true
 [33m[tester::#YK8] [0m[94mRunning tests for Stage #YK8 (yk8)[0m
 [33m[tester::#YK8] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#YK8] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YK8] [test-1.lox] [0m[33m// Class instantiation[0m
-[33m[tester::#YK8] [test-1.lox] [0mclass Spaceship {}
-[33m[tester::#YK8] [test-1.lox] [0mvar falcon = Spaceship();
-[33m[tester::#YK8] [test-1.lox] [0mprint falcon;
+[33m[tester::#YK8] [test-1.lox] [0m[0m[33m// Class instantiation[0m[0m
+[33m[tester::#YK8] [test-1.lox] [0m[0mclass Spaceship {}[0m
+[33m[tester::#YK8] [test-1.lox] [0m[0mvar falcon = Spaceship();[0m
+[33m[tester::#YK8] [test-1.lox] [0m[0mprint falcon;[0m
 [33m[tester::#YK8] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mSpaceship instance
+[33m[your_program] [0m[0mSpaceship instance[0m
 [33m[tester::#YK8] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#YK8] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#YK8] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#YK8] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YK8] [test-2.lox] [0m[33m// Instantiating multiple instances of a class[0m
-[33m[tester::#YK8] [test-2.lox] [0m[33m// should work[0m
-[33m[tester::#YK8] [test-2.lox] [0mclass Robot {}
-[33m[tester::#YK8] [test-2.lox] [0mvar r1 = Robot();
-[33m[tester::#YK8] [test-2.lox] [0mvar r2 = Robot();
-[33m[tester::#YK8] [test-2.lox] [0m
-[33m[tester::#YK8] [test-2.lox] [0mprint "Created multiple robots:";
-[33m[tester::#YK8] [test-2.lox] [0mprint r1;
-[33m[tester::#YK8] [test-2.lox] [0mprint r2;
+[33m[tester::#YK8] [test-2.lox] [0m[0m[33m// Instantiating multiple instances of a class[0m[0m
+[33m[tester::#YK8] [test-2.lox] [0m[0m[33m// should work[0m[0m
+[33m[tester::#YK8] [test-2.lox] [0m[0mclass Robot {}[0m
+[33m[tester::#YK8] [test-2.lox] [0m[0mvar r1 = Robot();[0m
+[33m[tester::#YK8] [test-2.lox] [0m[0mvar r2 = Robot();[0m
+[33m[tester::#YK8] [test-2.lox] [0m[0m[0m
+[33m[tester::#YK8] [test-2.lox] [0m[0mprint "Created multiple robots:";[0m
+[33m[tester::#YK8] [test-2.lox] [0m[0mprint r1;[0m
+[33m[tester::#YK8] [test-2.lox] [0m[0mprint r2;[0m
 [33m[tester::#YK8] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mCreated multiple robots:
-[33m[your_program] [0mRobot instance
-[33m[your_program] [0mRobot instance
+[33m[your_program] [0m[0mCreated multiple robots:[0m
+[33m[your_program] [0m[0mRobot instance[0m
+[33m[your_program] [0m[0mRobot instance[0m
 [33m[tester::#YK8] [test-2] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#YK8] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#YK8] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#YK8] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YK8] [test-3.lox] [0mclass Wizard {}
-[33m[tester::#YK8] [test-3.lox] [0mclass Dragon {}
-[33m[tester::#YK8] [test-3.lox] [0m
-[33m[tester::#YK8] [test-3.lox] [0m[33m// Instantiating classes in a function should work[0m
-[33m[tester::#YK8] [test-3.lox] [0mfun createCharacters() {
-[33m[tester::#YK8] [test-3.lox] [0m  var merlin = Wizard();
-[33m[tester::#YK8] [test-3.lox] [0m  var smaug = Dragon();
-[33m[tester::#YK8] [test-3.lox] [0m  print "Characters created in fantasy world:";
-[33m[tester::#YK8] [test-3.lox] [0m  print merlin;
-[33m[tester::#YK8] [test-3.lox] [0m  print smaug;
-[33m[tester::#YK8] [test-3.lox] [0m  return merlin;
-[33m[tester::#YK8] [test-3.lox] [0m}
-[33m[tester::#YK8] [test-3.lox] [0m
-[33m[tester::#YK8] [test-3.lox] [0mvar mainCharacter = createCharacters();
-[33m[tester::#YK8] [test-3.lox] [0m[33m// An instance of a class should be truthy[0m
-[33m[tester::#YK8] [test-3.lox] [0mif (mainCharacter) {
-[33m[tester::#YK8] [test-3.lox] [0m  print "The main character is:";
-[33m[tester::#YK8] [test-3.lox] [0m  print mainCharacter;
-[33m[tester::#YK8] [test-3.lox] [0m} else {
-[33m[tester::#YK8] [test-3.lox] [0m  print "Failed to create a main character.";
-[33m[tester::#YK8] [test-3.lox] [0m}
+[33m[tester::#YK8] [test-3.lox] [0m[0mclass Wizard {}[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0mclass Dragon {}[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0m[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0m[33m// Instantiating classes in a function should work[0m[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0mfun createCharacters() {[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0m  var merlin = Wizard();[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0m  var smaug = Dragon();[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0m  print "Characters created in fantasy world:";[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0m  print merlin;[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0m  print smaug;[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0m  return merlin;[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0m}[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0m[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0mvar mainCharacter = createCharacters();[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0m[33m// An instance of a class should be truthy[0m[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0mif (mainCharacter) {[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0m  print "The main character is:";[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0m  print mainCharacter;[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0m} else {[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0m  print "Failed to create a main character.";[0m
+[33m[tester::#YK8] [test-3.lox] [0m[0m}[0m
 [33m[tester::#YK8] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mCharacters created in fantasy world:
-[33m[your_program] [0mWizard instance
-[33m[your_program] [0mDragon instance
-[33m[your_program] [0mThe main character is:
-[33m[your_program] [0mWizard instance
+[33m[your_program] [0m[0mCharacters created in fantasy world:[0m
+[33m[your_program] [0m[0mWizard instance[0m
+[33m[your_program] [0m[0mDragon instance[0m
+[33m[your_program] [0m[0mThe main character is:[0m
+[33m[your_program] [0m[0mWizard instance[0m
 [33m[tester::#YK8] [test-3] [0m[92m✓ 5 line(s) match on stdout[0m
 [33m[tester::#YK8] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#YK8] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#YK8] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YK8] [test-4.lox] [0mclass Superhero {}
-[33m[tester::#YK8] [test-4.lox] [0m
-[33m[tester::#YK8] [test-4.lox] [0mvar count = 0;
-[33m[tester::#YK8] [test-4.lox] [0mwhile (count < 3) {
-[33m[tester::#YK8] [test-4.lox] [0m  var hero = Superhero();
-[33m[tester::#YK8] [test-4.lox] [0m  print "Hero created:";
-[33m[tester::#YK8] [test-4.lox] [0m  print hero;
-[33m[tester::#YK8] [test-4.lox] [0m  count = count + 1;
-[33m[tester::#YK8] [test-4.lox] [0m}
-[33m[tester::#YK8] [test-4.lox] [0m
-[33m[tester::#YK8] [test-4.lox] [0mprint "All heroes created!";
+[33m[tester::#YK8] [test-4.lox] [0m[0mclass Superhero {}[0m
+[33m[tester::#YK8] [test-4.lox] [0m[0m[0m
+[33m[tester::#YK8] [test-4.lox] [0m[0mvar count = 0;[0m
+[33m[tester::#YK8] [test-4.lox] [0m[0mwhile (count < 3) {[0m
+[33m[tester::#YK8] [test-4.lox] [0m[0m  var hero = Superhero();[0m
+[33m[tester::#YK8] [test-4.lox] [0m[0m  print "Hero created:";[0m
+[33m[tester::#YK8] [test-4.lox] [0m[0m  print hero;[0m
+[33m[tester::#YK8] [test-4.lox] [0m[0m  count = count + 1;[0m
+[33m[tester::#YK8] [test-4.lox] [0m[0m}[0m
+[33m[tester::#YK8] [test-4.lox] [0m[0m[0m
+[33m[tester::#YK8] [test-4.lox] [0m[0mprint "All heroes created!";[0m
 [33m[tester::#YK8] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mHero created:
-[33m[your_program] [0mSuperhero instance
-[33m[your_program] [0mHero created:
-[33m[your_program] [0mSuperhero instance
-[33m[your_program] [0mHero created:
-[33m[your_program] [0mSuperhero instance
-[33m[your_program] [0mAll heroes created!
+[33m[your_program] [0m[0mHero created:[0m
+[33m[your_program] [0m[0mSuperhero instance[0m
+[33m[your_program] [0m[0mHero created:[0m
+[33m[your_program] [0m[0mSuperhero instance[0m
+[33m[your_program] [0m[0mHero created:[0m
+[33m[your_program] [0m[0mSuperhero instance[0m
+[33m[your_program] [0m[0mAll heroes created![0m
 [33m[tester::#YK8] [test-4] [0m[92m✓ 7 line(s) match on stdout[0m
 [33m[tester::#YK8] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#YK8] [0m[92mTest passed.[0m
@@ -148,94 +148,94 @@ Debug = true
 [33m[tester::#YF3] [0m[94mRunning tests for Stage #YF3 (yf3)[0m
 [33m[tester::#YF3] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#YF3] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YF3] [test-1.lox] [0mclass Spaceship {}
-[33m[tester::#YF3] [test-1.lox] [0mvar falcon = Spaceship();
-[33m[tester::#YF3] [test-1.lox] [0m
-[33m[tester::#YF3] [test-1.lox] [0m[33m// Setting properties on an instance should work[0m
-[33m[tester::#YF3] [test-1.lox] [0mfalcon.name = "Millennium Falcon";
-[33m[tester::#YF3] [test-1.lox] [0mfalcon.speed = 75.5;
-[33m[tester::#YF3] [test-1.lox] [0m
-[33m[tester::#YF3] [test-1.lox] [0m[33m// Getting properties on an instance should work[0m
-[33m[tester::#YF3] [test-1.lox] [0mprint "Ship details:";
-[33m[tester::#YF3] [test-1.lox] [0mprint falcon.name;
-[33m[tester::#YF3] [test-1.lox] [0mprint falcon.speed;
+[33m[tester::#YF3] [test-1.lox] [0m[0mclass Spaceship {}[0m
+[33m[tester::#YF3] [test-1.lox] [0m[0mvar falcon = Spaceship();[0m
+[33m[tester::#YF3] [test-1.lox] [0m[0m[0m
+[33m[tester::#YF3] [test-1.lox] [0m[0m[33m// Setting properties on an instance should work[0m[0m
+[33m[tester::#YF3] [test-1.lox] [0m[0mfalcon.name = "Millennium Falcon";[0m
+[33m[tester::#YF3] [test-1.lox] [0m[0mfalcon.speed = 75.5;[0m
+[33m[tester::#YF3] [test-1.lox] [0m[0m[0m
+[33m[tester::#YF3] [test-1.lox] [0m[0m[33m// Getting properties on an instance should work[0m[0m
+[33m[tester::#YF3] [test-1.lox] [0m[0mprint "Ship details:";[0m
+[33m[tester::#YF3] [test-1.lox] [0m[0mprint falcon.name;[0m
+[33m[tester::#YF3] [test-1.lox] [0m[0mprint falcon.speed;[0m
 [33m[tester::#YF3] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mShip details:
-[33m[your_program] [0mMillennium Falcon
-[33m[your_program] [0m75.5
+[33m[your_program] [0m[0mShip details:[0m
+[33m[your_program] [0m[0mMillennium Falcon[0m
+[33m[your_program] [0m[0m75.5[0m
 [33m[tester::#YF3] [test-1] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#YF3] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#YF3] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#YF3] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YF3] [test-2.lox] [0mclass Robot {}
-[33m[tester::#YF3] [test-2.lox] [0mvar r2d2 = Robot();
-[33m[tester::#YF3] [test-2.lox] [0m
-[33m[tester::#YF3] [test-2.lox] [0m[33m// Setting properties on an instance should work[0m
-[33m[tester::#YF3] [test-2.lox] [0mr2d2.model = "Astromech";
-[33m[tester::#YF3] [test-2.lox] [0mr2d2.operational = false;
-[33m[tester::#YF3] [test-2.lox] [0m
-[33m[tester::#YF3] [test-2.lox] [0m[33m// Getting properties on an instance should work[0m
-[33m[tester::#YF3] [test-2.lox] [0mif (r2d2.operational) {
-[33m[tester::#YF3] [test-2.lox] [0m  print r2d2.model;
-[33m[tester::#YF3] [test-2.lox] [0m  r2d2.mission = "Navigate hyperspace";
-[33m[tester::#YF3] [test-2.lox] [0m  print r2d2.mission;
-[33m[tester::#YF3] [test-2.lox] [0m}
+[33m[tester::#YF3] [test-2.lox] [0m[0mclass Robot {}[0m
+[33m[tester::#YF3] [test-2.lox] [0m[0mvar r2d2 = Robot();[0m
+[33m[tester::#YF3] [test-2.lox] [0m[0m[0m
+[33m[tester::#YF3] [test-2.lox] [0m[0m[33m// Setting properties on an instance should work[0m[0m
+[33m[tester::#YF3] [test-2.lox] [0m[0mr2d2.model = "Astromech";[0m
+[33m[tester::#YF3] [test-2.lox] [0m[0mr2d2.operational = false;[0m
+[33m[tester::#YF3] [test-2.lox] [0m[0m[0m
+[33m[tester::#YF3] [test-2.lox] [0m[0m[33m// Getting properties on an instance should work[0m[0m
+[33m[tester::#YF3] [test-2.lox] [0m[0mif (r2d2.operational) {[0m
+[33m[tester::#YF3] [test-2.lox] [0m[0m  print r2d2.model;[0m
+[33m[tester::#YF3] [test-2.lox] [0m[0m  r2d2.mission = "Navigate hyperspace";[0m
+[33m[tester::#YF3] [test-2.lox] [0m[0m  print r2d2.mission;[0m
+[33m[tester::#YF3] [test-2.lox] [0m[0m}[0m
 [33m[tester::#YF3] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
 [33m[tester::#YF3] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#YF3] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#YF3] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#YF3] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YF3] [test-3.lox] [0mclass Superhero {}
-[33m[tester::#YF3] [test-3.lox] [0mvar batman = Superhero();
-[33m[tester::#YF3] [test-3.lox] [0mvar superman = Superhero();
-[33m[tester::#YF3] [test-3.lox] [0m
-[33m[tester::#YF3] [test-3.lox] [0m[33m// Setting properties on an instance should work[0m
-[33m[tester::#YF3] [test-3.lox] [0mbatman.name = "Batman";
-[33m[tester::#YF3] [test-3.lox] [0mbatman.called = 80;
-[33m[tester::#YF3] [test-3.lox] [0m
-[33m[tester::#YF3] [test-3.lox] [0m[33m// Setting properties on an instance should work[0m
-[33m[tester::#YF3] [test-3.lox] [0msuperman.name = "Superman";
-[33m[tester::#YF3] [test-3.lox] [0msuperman.called = 16;
-[33m[tester::#YF3] [test-3.lox] [0m
-[33m[tester::#YF3] [test-3.lox] [0m[33m// Getting properties on an instance should work[0m
-[33m[tester::#YF3] [test-3.lox] [0mprint "Times " + superman.name + " was called: ";
-[33m[tester::#YF3] [test-3.lox] [0mprint superman.called;
-[33m[tester::#YF3] [test-3.lox] [0mprint "Times " + batman.name + " was called: ";
-[33m[tester::#YF3] [test-3.lox] [0mprint batman.called;
+[33m[tester::#YF3] [test-3.lox] [0m[0mclass Superhero {}[0m
+[33m[tester::#YF3] [test-3.lox] [0m[0mvar batman = Superhero();[0m
+[33m[tester::#YF3] [test-3.lox] [0m[0mvar superman = Superhero();[0m
+[33m[tester::#YF3] [test-3.lox] [0m[0m[0m
+[33m[tester::#YF3] [test-3.lox] [0m[0m[33m// Setting properties on an instance should work[0m[0m
+[33m[tester::#YF3] [test-3.lox] [0m[0mbatman.name = "Batman";[0m
+[33m[tester::#YF3] [test-3.lox] [0m[0mbatman.called = 80;[0m
+[33m[tester::#YF3] [test-3.lox] [0m[0m[0m
+[33m[tester::#YF3] [test-3.lox] [0m[0m[33m// Setting properties on an instance should work[0m[0m
+[33m[tester::#YF3] [test-3.lox] [0m[0msuperman.name = "Superman";[0m
+[33m[tester::#YF3] [test-3.lox] [0m[0msuperman.called = 16;[0m
+[33m[tester::#YF3] [test-3.lox] [0m[0m[0m
+[33m[tester::#YF3] [test-3.lox] [0m[0m[33m// Getting properties on an instance should work[0m[0m
+[33m[tester::#YF3] [test-3.lox] [0m[0mprint "Times " + superman.name + " was called: ";[0m
+[33m[tester::#YF3] [test-3.lox] [0m[0mprint superman.called;[0m
+[33m[tester::#YF3] [test-3.lox] [0m[0mprint "Times " + batman.name + " was called: ";[0m
+[33m[tester::#YF3] [test-3.lox] [0m[0mprint batman.called;[0m
 [33m[tester::#YF3] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mTimes Superman was called: 
-[33m[your_program] [0m16
-[33m[your_program] [0mTimes Batman was called: 
-[33m[your_program] [0m80
+[33m[your_program] [0m[0mTimes Superman was called: [0m
+[33m[your_program] [0m[0m16[0m
+[33m[your_program] [0m[0mTimes Batman was called: [0m
+[33m[your_program] [0m[0m80[0m
 [33m[tester::#YF3] [test-3] [0m[92m✓ 4 line(s) match on stdout[0m
 [33m[tester::#YF3] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#YF3] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#YF3] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YF3] [test-4.lox] [0mclass Wizard {}
-[33m[tester::#YF3] [test-4.lox] [0mvar gandalf = Wizard();
-[33m[tester::#YF3] [test-4.lox] [0m
-[33m[tester::#YF3] [test-4.lox] [0mgandalf.color = "Grey";
-[33m[tester::#YF3] [test-4.lox] [0mgandalf.power = nil;
-[33m[tester::#YF3] [test-4.lox] [0mprint gandalf.color;
-[33m[tester::#YF3] [test-4.lox] [0m
-[33m[tester::#YF3] [test-4.lox] [0m[33m// functions should be able to accept class[0m
-[33m[tester::#YF3] [test-4.lox] [0m[33m// instances and get or set properties on them[0m
-[33m[tester::#YF3] [test-4.lox] [0mfun promote(wizard) {
-[33m[tester::#YF3] [test-4.lox] [0m  wizard.color = "White";
-[33m[tester::#YF3] [test-4.lox] [0m  if (false) {
-[33m[tester::#YF3] [test-4.lox] [0m    wizard.power = 100;
-[33m[tester::#YF3] [test-4.lox] [0m  } else {
-[33m[tester::#YF3] [test-4.lox] [0m    wizard.power = 0;
-[33m[tester::#YF3] [test-4.lox] [0m  }
-[33m[tester::#YF3] [test-4.lox] [0m}
-[33m[tester::#YF3] [test-4.lox] [0m
-[33m[tester::#YF3] [test-4.lox] [0mpromote(gandalf);
-[33m[tester::#YF3] [test-4.lox] [0mprint gandalf.color;
-[33m[tester::#YF3] [test-4.lox] [0mprint gandalf.power;
+[33m[tester::#YF3] [test-4.lox] [0m[0mclass Wizard {}[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0mvar gandalf = Wizard();[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0m[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0mgandalf.color = "Grey";[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0mgandalf.power = nil;[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0mprint gandalf.color;[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0m[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0m[33m// functions should be able to accept class[0m[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0m[33m// instances and get or set properties on them[0m[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0mfun promote(wizard) {[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0m  wizard.color = "White";[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0m  if (false) {[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0m    wizard.power = 100;[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0m  } else {[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0m    wizard.power = 0;[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0m}[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0m[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0mpromote(gandalf);[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0mprint gandalf.color;[0m
+[33m[tester::#YF3] [test-4.lox] [0m[0mprint gandalf.power;[0m
 [33m[tester::#YF3] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mGrey
-[33m[your_program] [0mWhite
-[33m[your_program] [0m0
+[33m[your_program] [0m[0mGrey[0m
+[33m[your_program] [0m[0mWhite[0m
+[33m[your_program] [0m[0m0[0m
 [33m[tester::#YF3] [test-4] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#YF3] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#YF3] [0m[92mTest passed.[0m
@@ -243,114 +243,114 @@ Debug = true
 [33m[tester::#QR2] [0m[94mRunning tests for Stage #QR2 (qr2)[0m
 [33m[tester::#QR2] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#QR2] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#QR2] [test-1.lox] [0mclass Robot {
-[33m[tester::#QR2] [test-1.lox] [0m  beep() {
-[33m[tester::#QR2] [test-1.lox] [0m    print "Beep boop!";
-[33m[tester::#QR2] [test-1.lox] [0m  }
-[33m[tester::#QR2] [test-1.lox] [0m}
-[33m[tester::#QR2] [test-1.lox] [0m
-[33m[tester::#QR2] [test-1.lox] [0mvar r2d2 = Robot();
-[33m[tester::#QR2] [test-1.lox] [0m[33m// Calling a method on an instance should work[0m
-[33m[tester::#QR2] [test-1.lox] [0mr2d2.beep();
-[33m[tester::#QR2] [test-1.lox] [0m
-[33m[tester::#QR2] [test-1.lox] [0m[33m// Calling a method on a class instance should work[0m
-[33m[tester::#QR2] [test-1.lox] [0mRobot().beep();
+[33m[tester::#QR2] [test-1.lox] [0m[0mclass Robot {[0m
+[33m[tester::#QR2] [test-1.lox] [0m[0m  beep() {[0m
+[33m[tester::#QR2] [test-1.lox] [0m[0m    print "Beep boop!";[0m
+[33m[tester::#QR2] [test-1.lox] [0m[0m  }[0m
+[33m[tester::#QR2] [test-1.lox] [0m[0m}[0m
+[33m[tester::#QR2] [test-1.lox] [0m[0m[0m
+[33m[tester::#QR2] [test-1.lox] [0m[0mvar r2d2 = Robot();[0m
+[33m[tester::#QR2] [test-1.lox] [0m[0m[33m// Calling a method on an instance should work[0m[0m
+[33m[tester::#QR2] [test-1.lox] [0m[0mr2d2.beep();[0m
+[33m[tester::#QR2] [test-1.lox] [0m[0m[0m
+[33m[tester::#QR2] [test-1.lox] [0m[0m[33m// Calling a method on a class instance should work[0m[0m
+[33m[tester::#QR2] [test-1.lox] [0m[0mRobot().beep();[0m
 [33m[tester::#QR2] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mBeep boop!
-[33m[your_program] [0mBeep boop!
+[33m[your_program] [0m[0mBeep boop![0m
+[33m[your_program] [0m[0mBeep boop![0m
 [33m[tester::#QR2] [test-1] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#QR2] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#QR2] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#QR2] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#QR2] [test-2.lox] [0m{
-[33m[tester::#QR2] [test-2.lox] [0m  class Foo {
-[33m[tester::#QR2] [test-2.lox] [0m    returnSelf() {
-[33m[tester::#QR2] [test-2.lox] [0m      [33m// Should be able to return the class itself[0m
-[33m[tester::#QR2] [test-2.lox] [0m      return Foo;
-[33m[tester::#QR2] [test-2.lox] [0m    }
-[33m[tester::#QR2] [test-2.lox] [0m  }
-[33m[tester::#QR2] [test-2.lox] [0m
-[33m[tester::#QR2] [test-2.lox] [0m  [33m// Calling a method on an instance should work[0m
-[33m[tester::#QR2] [test-2.lox] [0m  print Foo().returnSelf();
-[33m[tester::#QR2] [test-2.lox] [0m}
+[33m[tester::#QR2] [test-2.lox] [0m[0m{[0m
+[33m[tester::#QR2] [test-2.lox] [0m[0m  class Foo {[0m
+[33m[tester::#QR2] [test-2.lox] [0m[0m    returnSelf() {[0m
+[33m[tester::#QR2] [test-2.lox] [0m[0m      [33m// Should be able to return the class itself[0m[0m
+[33m[tester::#QR2] [test-2.lox] [0m[0m      return Foo;[0m
+[33m[tester::#QR2] [test-2.lox] [0m[0m    }[0m
+[33m[tester::#QR2] [test-2.lox] [0m[0m  }[0m
+[33m[tester::#QR2] [test-2.lox] [0m[0m[0m
+[33m[tester::#QR2] [test-2.lox] [0m[0m  [33m// Calling a method on an instance should work[0m[0m
+[33m[tester::#QR2] [test-2.lox] [0m[0m  print Foo().returnSelf();[0m
+[33m[tester::#QR2] [test-2.lox] [0m[0m}[0m
 [33m[tester::#QR2] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mFoo
+[33m[your_program] [0m[0mFoo[0m
 [33m[tester::#QR2] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#QR2] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#QR2] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#QR2] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#QR2] [test-3.lox] [0mclass Wizard {
-[33m[tester::#QR2] [test-3.lox] [0m  castSpell(spell) {
-[33m[tester::#QR2] [test-3.lox] [0m    [33m// Methods should be able to accept a parameter[0m
-[33m[tester::#QR2] [test-3.lox] [0m    print "Casting a magical spell: " + spell;
-[33m[tester::#QR2] [test-3.lox] [0m  }
-[33m[tester::#QR2] [test-3.lox] [0m}
-[33m[tester::#QR2] [test-3.lox] [0m
-[33m[tester::#QR2] [test-3.lox] [0mclass Dragon {
-[33m[tester::#QR2] [test-3.lox] [0m  [33m// Methods should be able to accept multiple[0m
-[33m[tester::#QR2] [test-3.lox] [0m  [33m// parameters[0m
-[33m[tester::#QR2] [test-3.lox] [0m  breatheFire(fire, intensity) {
-[33m[tester::#QR2] [test-3.lox] [0m    print "Breathing " + fire + " with intensity: "
-[33m[tester::#QR2] [test-3.lox] [0m    + intensity;
-[33m[tester::#QR2] [test-3.lox] [0m  }
-[33m[tester::#QR2] [test-3.lox] [0m}
-[33m[tester::#QR2] [test-3.lox] [0m
-[33m[tester::#QR2] [test-3.lox] [0mvar merlin = Wizard();
-[33m[tester::#QR2] [test-3.lox] [0mvar smaug = Dragon();
-[33m[tester::#QR2] [test-3.lox] [0m
-[33m[tester::#QR2] [test-3.lox] [0mif (false) {
-[33m[tester::#QR2] [test-3.lox] [0m  var action = merlin.castSpell;
-[33m[tester::#QR2] [test-3.lox] [0m  action("Fireball");
-[33m[tester::#QR2] [test-3.lox] [0m} else {
-[33m[tester::#QR2] [test-3.lox] [0m  var action = smaug.breatheFire;
-[33m[tester::#QR2] [test-3.lox] [0m  action("Fire", "100");
-[33m[tester::#QR2] [test-3.lox] [0m}
+[33m[tester::#QR2] [test-3.lox] [0m[0mclass Wizard {[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m  castSpell(spell) {[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m    [33m// Methods should be able to accept a parameter[0m[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m    print "Casting a magical spell: " + spell;[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m  }[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m}[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0mclass Dragon {[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m  [33m// Methods should be able to accept multiple[0m[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m  [33m// parameters[0m[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m  breatheFire(fire, intensity) {[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m    print "Breathing " + fire + " with intensity: "[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m    + intensity;[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m  }[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m}[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0mvar merlin = Wizard();[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0mvar smaug = Dragon();[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0mif (false) {[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m  var action = merlin.castSpell;[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m  action("Fireball");[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m} else {[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m  var action = smaug.breatheFire;[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m  action("Fire", "100");[0m
+[33m[tester::#QR2] [test-3.lox] [0m[0m}[0m
 [33m[tester::#QR2] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mBreathing Fire with intensity: 100
+[33m[your_program] [0m[0mBreathing Fire with intensity: 100[0m
 [33m[tester::#QR2] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#QR2] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#QR2] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#QR2] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#QR2] [test-4.lox] [0mclass Superhero {
-[33m[tester::#QR2] [test-4.lox] [0m  [33m// Methods should be able to accept a parameter[0m
-[33m[tester::#QR2] [test-4.lox] [0m  useSpecialPower(hero) {
-[33m[tester::#QR2] [test-4.lox] [0m    print "Using power: " + hero.specialPower;
-[33m[tester::#QR2] [test-4.lox] [0m  }
-[33m[tester::#QR2] [test-4.lox] [0m
-[33m[tester::#QR2] [test-4.lox] [0m  [33m// Methods should be able to accept a parameter[0m
-[33m[tester::#QR2] [test-4.lox] [0m  [33m// of any type[0m
-[33m[tester::#QR2] [test-4.lox] [0m  hasSpecialPower(hero) {
-[33m[tester::#QR2] [test-4.lox] [0m    return hero.specialPower;
-[33m[tester::#QR2] [test-4.lox] [0m  }
-[33m[tester::#QR2] [test-4.lox] [0m
-[33m[tester::#QR2] [test-4.lox] [0m  [33m// Methods should be able to accept class[0m
-[33m[tester::#QR2] [test-4.lox] [0m  [33m// instances as parameters and then update their[0m
-[33m[tester::#QR2] [test-4.lox] [0m  [33m// properties[0m
-[33m[tester::#QR2] [test-4.lox] [0m  giveSpecialPower(hero, power) {
-[33m[tester::#QR2] [test-4.lox] [0m    hero.specialPower = power;
-[33m[tester::#QR2] [test-4.lox] [0m  }
-[33m[tester::#QR2] [test-4.lox] [0m}
-[33m[tester::#QR2] [test-4.lox] [0m
-[33m[tester::#QR2] [test-4.lox] [0mfun performHeroics(hero, superheroClass) {
-[33m[tester::#QR2] [test-4.lox] [0m  if (superheroClass.hasSpecialPower(hero)) {
-[33m[tester::#QR2] [test-4.lox] [0m    superheroClass.useSpecialPower(hero);
-[33m[tester::#QR2] [test-4.lox] [0m  } else {
-[33m[tester::#QR2] [test-4.lox] [0m    print "No special power available";
-[33m[tester::#QR2] [test-4.lox] [0m  }
-[33m[tester::#QR2] [test-4.lox] [0m}
-[33m[tester::#QR2] [test-4.lox] [0m
-[33m[tester::#QR2] [test-4.lox] [0mvar superman = Superhero();
-[33m[tester::#QR2] [test-4.lox] [0mvar heroClass = Superhero();
-[33m[tester::#QR2] [test-4.lox] [0m
-[33m[tester::#QR2] [test-4.lox] [0mif (false) {
-[33m[tester::#QR2] [test-4.lox] [0m  heroClass.giveSpecialPower(superman, "Flight");
-[33m[tester::#QR2] [test-4.lox] [0m} else {
-[33m[tester::#QR2] [test-4.lox] [0m  heroClass.giveSpecialPower(superman, "Strength");
-[33m[tester::#QR2] [test-4.lox] [0m}
-[33m[tester::#QR2] [test-4.lox] [0m
-[33m[tester::#QR2] [test-4.lox] [0mperformHeroics(superman, heroClass);
+[33m[tester::#QR2] [test-4.lox] [0m[0mclass Superhero {[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m  [33m// Methods should be able to accept a parameter[0m[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m  useSpecialPower(hero) {[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m    print "Using power: " + hero.specialPower;[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m  [33m// Methods should be able to accept a parameter[0m[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m  [33m// of any type[0m[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m  hasSpecialPower(hero) {[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m    return hero.specialPower;[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m  [33m// Methods should be able to accept class[0m[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m  [33m// instances as parameters and then update their[0m[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m  [33m// properties[0m[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m  giveSpecialPower(hero, power) {[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m    hero.specialPower = power;[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m}[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0mfun performHeroics(hero, superheroClass) {[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m  if (superheroClass.hasSpecialPower(hero)) {[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m    superheroClass.useSpecialPower(hero);[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m  } else {[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m    print "No special power available";[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m}[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0mvar superman = Superhero();[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0mvar heroClass = Superhero();[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0mif (false) {[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m  heroClass.giveSpecialPower(superman, "Flight");[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m} else {[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m  heroClass.giveSpecialPower(superman, "Strength");[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m}[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0m[0m
+[33m[tester::#QR2] [test-4.lox] [0m[0mperformHeroics(superman, heroClass);[0m
 [33m[tester::#QR2] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mUsing power: Strength
+[33m[your_program] [0m[0mUsing power: Strength[0m
 [33m[tester::#QR2] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#QR2] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#QR2] [0m[92mTest passed.[0m
@@ -358,92 +358,92 @@ Debug = true
 [33m[tester::#YD7] [0m[94mRunning tests for Stage #YD7 (yd7)[0m
 [33m[tester::#YD7] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#YD7] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YD7] [test-1.lox] [0mclass Spaceship {
-[33m[tester::#YD7] [test-1.lox] [0m  identify() {
-[33m[tester::#YD7] [test-1.lox] [0m    [33m// this should be bound to the instance[0m
-[33m[tester::#YD7] [test-1.lox] [0m    print this;
-[33m[tester::#YD7] [test-1.lox] [0m  }
-[33m[tester::#YD7] [test-1.lox] [0m}
-[33m[tester::#YD7] [test-1.lox] [0m
-[33m[tester::#YD7] [test-1.lox] [0m[33m// Calling a method on a class instance should work[0m
-[33m[tester::#YD7] [test-1.lox] [0mSpaceship().identify();
+[33m[tester::#YD7] [test-1.lox] [0m[0mclass Spaceship {[0m
+[33m[tester::#YD7] [test-1.lox] [0m[0m  identify() {[0m
+[33m[tester::#YD7] [test-1.lox] [0m[0m    [33m// this should be bound to the instance[0m[0m
+[33m[tester::#YD7] [test-1.lox] [0m[0m    print this;[0m
+[33m[tester::#YD7] [test-1.lox] [0m[0m  }[0m
+[33m[tester::#YD7] [test-1.lox] [0m[0m}[0m
+[33m[tester::#YD7] [test-1.lox] [0m[0m[0m
+[33m[tester::#YD7] [test-1.lox] [0m[0m[33m// Calling a method on a class instance should work[0m[0m
+[33m[tester::#YD7] [test-1.lox] [0m[0mSpaceship().identify();[0m
 [33m[tester::#YD7] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mSpaceship instance
+[33m[your_program] [0m[0mSpaceship instance[0m
 [33m[tester::#YD7] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#YD7] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#YD7] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#YD7] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YD7] [test-2.lox] [0mclass Calculator {
-[33m[tester::#YD7] [test-2.lox] [0m  add(a, b) {
-[33m[tester::#YD7] [test-2.lox] [0m    [33m// this should be bound to the instance[0m
-[33m[tester::#YD7] [test-2.lox] [0m    return a + b + this.memory;
-[33m[tester::#YD7] [test-2.lox] [0m  }
-[33m[tester::#YD7] [test-2.lox] [0m}
-[33m[tester::#YD7] [test-2.lox] [0m
-[33m[tester::#YD7] [test-2.lox] [0mvar calc = Calculator();
-[33m[tester::#YD7] [test-2.lox] [0m[33m// Instance properties should be accessible using[0m
-[33m[tester::#YD7] [test-2.lox] [0m[33m// the this keyword[0m
-[33m[tester::#YD7] [test-2.lox] [0mcalc.memory = 88;
-[33m[tester::#YD7] [test-2.lox] [0mprint calc.add(54, 1);
+[33m[tester::#YD7] [test-2.lox] [0m[0mclass Calculator {[0m
+[33m[tester::#YD7] [test-2.lox] [0m[0m  add(a, b) {[0m
+[33m[tester::#YD7] [test-2.lox] [0m[0m    [33m// this should be bound to the instance[0m[0m
+[33m[tester::#YD7] [test-2.lox] [0m[0m    return a + b + this.memory;[0m
+[33m[tester::#YD7] [test-2.lox] [0m[0m  }[0m
+[33m[tester::#YD7] [test-2.lox] [0m[0m}[0m
+[33m[tester::#YD7] [test-2.lox] [0m[0m[0m
+[33m[tester::#YD7] [test-2.lox] [0m[0mvar calc = Calculator();[0m
+[33m[tester::#YD7] [test-2.lox] [0m[0m[33m// Instance properties should be accessible using[0m[0m
+[33m[tester::#YD7] [test-2.lox] [0m[0m[33m// the this keyword[0m[0m
+[33m[tester::#YD7] [test-2.lox] [0m[0mcalc.memory = 88;[0m
+[33m[tester::#YD7] [test-2.lox] [0m[0mprint calc.add(54, 1);[0m
 [33m[tester::#YD7] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m143
+[33m[your_program] [0m[0m143[0m
 [33m[tester::#YD7] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#YD7] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#YD7] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#YD7] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YD7] [test-3.lox] [0mclass Animal {
-[33m[tester::#YD7] [test-3.lox] [0m  makeSound() {
-[33m[tester::#YD7] [test-3.lox] [0m    print this.sound;
-[33m[tester::#YD7] [test-3.lox] [0m  }
-[33m[tester::#YD7] [test-3.lox] [0m
-[33m[tester::#YD7] [test-3.lox] [0m  identify() {
-[33m[tester::#YD7] [test-3.lox] [0m    print this.species;
-[33m[tester::#YD7] [test-3.lox] [0m  }
-[33m[tester::#YD7] [test-3.lox] [0m}
-[33m[tester::#YD7] [test-3.lox] [0m
-[33m[tester::#YD7] [test-3.lox] [0mvar dog = Animal();
-[33m[tester::#YD7] [test-3.lox] [0mdog.sound = "Woof";
-[33m[tester::#YD7] [test-3.lox] [0mdog.species = "Dog";
-[33m[tester::#YD7] [test-3.lox] [0m
-[33m[tester::#YD7] [test-3.lox] [0mvar cat = Animal();
-[33m[tester::#YD7] [test-3.lox] [0mcat.sound = "Meow";
-[33m[tester::#YD7] [test-3.lox] [0mcat.species = "Cat";
-[33m[tester::#YD7] [test-3.lox] [0m
-[33m[tester::#YD7] [test-3.lox] [0m[33m// The this keyword should be bound to the[0m
-[33m[tester::#YD7] [test-3.lox] [0m[33m// class instance that the method is called on[0m
-[33m[tester::#YD7] [test-3.lox] [0mcat.makeSound = dog.makeSound;
-[33m[tester::#YD7] [test-3.lox] [0mdog.identify = cat.identify;
-[33m[tester::#YD7] [test-3.lox] [0m
-[33m[tester::#YD7] [test-3.lox] [0mcat.makeSound(); [33m// expect: Woof[0m
-[33m[tester::#YD7] [test-3.lox] [0mdog.identify(); [33m// expect: Cat[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0mclass Animal {[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0m  makeSound() {[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0m    print this.sound;[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0m  }[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0m[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0m  identify() {[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0m    print this.species;[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0m  }[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0m}[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0m[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0mvar dog = Animal();[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0mdog.sound = "Woof";[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0mdog.species = "Dog";[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0m[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0mvar cat = Animal();[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0mcat.sound = "Meow";[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0mcat.species = "Cat";[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0m[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0m[33m// The this keyword should be bound to the[0m[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0m[33m// class instance that the method is called on[0m[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0mcat.makeSound = dog.makeSound;[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0mdog.identify = cat.identify;[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0m[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0mcat.makeSound(); [33m// expect: Woof[0m[0m
+[33m[tester::#YD7] [test-3.lox] [0m[0mdog.identify(); [33m// expect: Cat[0m[0m
 [33m[tester::#YD7] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mWoof
-[33m[your_program] [0mCat
+[33m[your_program] [0m[0mWoof[0m
+[33m[your_program] [0m[0mCat[0m
 [33m[tester::#YD7] [test-3] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#YD7] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#YD7] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#YD7] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YD7] [test-4.lox] [0mclass Wizard {
-[33m[tester::#YD7] [test-4.lox] [0m  getSpellCaster() {
-[33m[tester::#YD7] [test-4.lox] [0m    fun castSpell() {
-[33m[tester::#YD7] [test-4.lox] [0m      print this;
-[33m[tester::#YD7] [test-4.lox] [0m      print "Casting spell as " + this.name;
-[33m[tester::#YD7] [test-4.lox] [0m    }
-[33m[tester::#YD7] [test-4.lox] [0m
-[33m[tester::#YD7] [test-4.lox] [0m    [33m// Functions are first-class objects in Lox[0m
-[33m[tester::#YD7] [test-4.lox] [0m    return castSpell;
-[33m[tester::#YD7] [test-4.lox] [0m  }
-[33m[tester::#YD7] [test-4.lox] [0m}
-[33m[tester::#YD7] [test-4.lox] [0m
-[33m[tester::#YD7] [test-4.lox] [0mvar wizard = Wizard();
-[33m[tester::#YD7] [test-4.lox] [0mwizard.name = "Merlin";
-[33m[tester::#YD7] [test-4.lox] [0m
-[33m[tester::#YD7] [test-4.lox] [0m[33m// Calling an instance method that returns a[0m
-[33m[tester::#YD7] [test-4.lox] [0m[33m// function should work[0m
-[33m[tester::#YD7] [test-4.lox] [0mwizard.getSpellCaster()();
+[33m[tester::#YD7] [test-4.lox] [0m[0mclass Wizard {[0m
+[33m[tester::#YD7] [test-4.lox] [0m[0m  getSpellCaster() {[0m
+[33m[tester::#YD7] [test-4.lox] [0m[0m    fun castSpell() {[0m
+[33m[tester::#YD7] [test-4.lox] [0m[0m      print this;[0m
+[33m[tester::#YD7] [test-4.lox] [0m[0m      print "Casting spell as " + this.name;[0m
+[33m[tester::#YD7] [test-4.lox] [0m[0m    }[0m
+[33m[tester::#YD7] [test-4.lox] [0m[0m[0m
+[33m[tester::#YD7] [test-4.lox] [0m[0m    [33m// Functions are first-class objects in Lox[0m[0m
+[33m[tester::#YD7] [test-4.lox] [0m[0m    return castSpell;[0m
+[33m[tester::#YD7] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#YD7] [test-4.lox] [0m[0m}[0m
+[33m[tester::#YD7] [test-4.lox] [0m[0m[0m
+[33m[tester::#YD7] [test-4.lox] [0m[0mvar wizard = Wizard();[0m
+[33m[tester::#YD7] [test-4.lox] [0m[0mwizard.name = "Merlin";[0m
+[33m[tester::#YD7] [test-4.lox] [0m[0m[0m
+[33m[tester::#YD7] [test-4.lox] [0m[0m[33m// Calling an instance method that returns a[0m[0m
+[33m[tester::#YD7] [test-4.lox] [0m[0m[33m// function should work[0m[0m
+[33m[tester::#YD7] [test-4.lox] [0m[0mwizard.getSpellCaster()();[0m
 [33m[tester::#YD7] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mWizard instance
-[33m[your_program] [0mCasting spell as Merlin
+[33m[your_program] [0m[0mWizard instance[0m
+[33m[your_program] [0m[0mCasting spell as Merlin[0m
 [33m[tester::#YD7] [test-4] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#YD7] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#YD7] [0m[92mTest passed.[0m
@@ -451,59 +451,59 @@ Debug = true
 [33m[tester::#DG2] [0m[94mRunning tests for Stage #DG2 (dg2)[0m
 [33m[tester::#DG2] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#DG2] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#DG2] [test-1.lox] [0m[33m// The this keyword used outside of a class[0m
-[33m[tester::#DG2] [test-1.lox] [0m[33m// should be a compile error[0m
-[33m[tester::#DG2] [test-1.lox] [0mprint this;
+[33m[tester::#DG2] [test-1.lox] [0m[0m[33m// The this keyword used outside of a class[0m[0m
+[33m[tester::#DG2] [test-1.lox] [0m[0m[33m// should be a compile error[0m[0m
+[33m[tester::#DG2] [test-1.lox] [0m[0mprint this;[0m
 [33m[tester::#DG2] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 3] Error at 'this': Can't use 'this' outside of a class.
+[33m[your_program] [0m[0m[line 3] Error at 'this': Can't use 'this' outside of a class.[0m
 [33m[tester::#DG2] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#DG2] [test-1] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#DG2] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#DG2] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#DG2] [test-2.lox] [0m[33m// using this outside of a class shouldn't work[0m
-[33m[tester::#DG2] [test-2.lox] [0mfun notAMethod() {
-[33m[tester::#DG2] [test-2.lox] [0m  print this; [33m// expect compile error[0m
-[33m[tester::#DG2] [test-2.lox] [0m}
+[33m[tester::#DG2] [test-2.lox] [0m[0m[33m// using this outside of a class shouldn't work[0m[0m
+[33m[tester::#DG2] [test-2.lox] [0m[0mfun notAMethod() {[0m
+[33m[tester::#DG2] [test-2.lox] [0m[0m  print this; [33m// expect compile error[0m[0m
+[33m[tester::#DG2] [test-2.lox] [0m[0m}[0m
 [33m[tester::#DG2] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 3] Error at 'this': Can't use 'this' outside of a class.
+[33m[your_program] [0m[0m[line 3] Error at 'this': Can't use 'this' outside of a class.[0m
 [33m[tester::#DG2] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#DG2] [test-2] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#DG2] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#DG2] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#DG2] [test-3.lox] [0mclass Person {
-[33m[tester::#DG2] [test-3.lox] [0m  sayName() {
-[33m[tester::#DG2] [test-3.lox] [0m    [33m// this is not a callable object[0m
-[33m[tester::#DG2] [test-3.lox] [0m    print this(); [33m// expect runtime error[0m
-[33m[tester::#DG2] [test-3.lox] [0m  }
-[33m[tester::#DG2] [test-3.lox] [0m}
-[33m[tester::#DG2] [test-3.lox] [0mPerson().sayName();
+[33m[tester::#DG2] [test-3.lox] [0m[0mclass Person {[0m
+[33m[tester::#DG2] [test-3.lox] [0m[0m  sayName() {[0m
+[33m[tester::#DG2] [test-3.lox] [0m[0m    [33m// this is not a callable object[0m[0m
+[33m[tester::#DG2] [test-3.lox] [0m[0m    print this(); [33m// expect runtime error[0m[0m
+[33m[tester::#DG2] [test-3.lox] [0m[0m  }[0m
+[33m[tester::#DG2] [test-3.lox] [0m[0m}[0m
+[33m[tester::#DG2] [test-3.lox] [0m[0mPerson().sayName();[0m
 [33m[tester::#DG2] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mCan only call functions and classes.
-[33m[your_program] [0m[line 4]
+[33m[your_program] [0m[0mCan only call functions and classes.[0m
+[33m[your_program] [0m[0m[line 4][0m
 [33m[tester::#DG2] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#DG2] [test-3] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#DG2] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#DG2] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#DG2] [test-4.lox] [0mclass Confused {
-[33m[tester::#DG2] [test-4.lox] [0m  method() {
-[33m[tester::#DG2] [test-4.lox] [0m    fun inner(instance) {
-[33m[tester::#DG2] [test-4.lox] [0m      [33m// this is a local variable[0m
-[33m[tester::#DG2] [test-4.lox] [0m      var feeling = "confused";
-[33m[tester::#DG2] [test-4.lox] [0m      [33m// Unless explicitly set, feeling can't be[0m
-[33m[tester::#DG2] [test-4.lox] [0m      [33m// accessed using this keyword[0m
-[33m[tester::#DG2] [test-4.lox] [0m      print this.feeling; [33m// expect runtime error[0m
-[33m[tester::#DG2] [test-4.lox] [0m    }
-[33m[tester::#DG2] [test-4.lox] [0m    return inner;
-[33m[tester::#DG2] [test-4.lox] [0m  }
-[33m[tester::#DG2] [test-4.lox] [0m}
-[33m[tester::#DG2] [test-4.lox] [0m
-[33m[tester::#DG2] [test-4.lox] [0mvar instance = Confused();
-[33m[tester::#DG2] [test-4.lox] [0mvar m = instance.method();
-[33m[tester::#DG2] [test-4.lox] [0m[33m// calling the function returned should work[0m
-[33m[tester::#DG2] [test-4.lox] [0mm(instance);
+[33m[tester::#DG2] [test-4.lox] [0m[0mclass Confused {[0m
+[33m[tester::#DG2] [test-4.lox] [0m[0m  method() {[0m
+[33m[tester::#DG2] [test-4.lox] [0m[0m    fun inner(instance) {[0m
+[33m[tester::#DG2] [test-4.lox] [0m[0m      [33m// this is a local variable[0m[0m
+[33m[tester::#DG2] [test-4.lox] [0m[0m      var feeling = "confused";[0m
+[33m[tester::#DG2] [test-4.lox] [0m[0m      [33m// Unless explicitly set, feeling can't be[0m[0m
+[33m[tester::#DG2] [test-4.lox] [0m[0m      [33m// accessed using this keyword[0m[0m
+[33m[tester::#DG2] [test-4.lox] [0m[0m      print this.feeling; [33m// expect runtime error[0m[0m
+[33m[tester::#DG2] [test-4.lox] [0m[0m    }[0m
+[33m[tester::#DG2] [test-4.lox] [0m[0m    return inner;[0m
+[33m[tester::#DG2] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#DG2] [test-4.lox] [0m[0m}[0m
+[33m[tester::#DG2] [test-4.lox] [0m[0m[0m
+[33m[tester::#DG2] [test-4.lox] [0m[0mvar instance = Confused();[0m
+[33m[tester::#DG2] [test-4.lox] [0m[0mvar m = instance.method();[0m
+[33m[tester::#DG2] [test-4.lox] [0m[0m[33m// calling the function returned should work[0m[0m
+[33m[tester::#DG2] [test-4.lox] [0m[0mm(instance);[0m
 [33m[tester::#DG2] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mUndefined property 'feeling'.
-[33m[your_program] [0m[line 8]
+[33m[your_program] [0m[0mUndefined property 'feeling'.[0m
+[33m[your_program] [0m[0m[line 8][0m
 [33m[tester::#DG2] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#DG2] [test-4] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#DG2] [0m[92mTest passed.[0m
@@ -511,97 +511,97 @@ Debug = true
 [33m[tester::#OU5] [0m[94mRunning tests for Stage #OU5 (ou5)[0m
 [33m[tester::#OU5] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#OU5] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#OU5] [test-1.lox] [0mclass Default {
-[33m[tester::#OU5] [test-1.lox] [0m  [33m// this is the constructor[0m
-[33m[tester::#OU5] [test-1.lox] [0m  init() {
-[33m[tester::#OU5] [test-1.lox] [0m    [33m// it should be able to set[0m
-[33m[tester::#OU5] [test-1.lox] [0m    [33m// properties on the instance[0m
-[33m[tester::#OU5] [test-1.lox] [0m    this.x = "baz";
-[33m[tester::#OU5] [test-1.lox] [0m    this.y = 59;
-[33m[tester::#OU5] [test-1.lox] [0m  }
-[33m[tester::#OU5] [test-1.lox] [0m}
-[33m[tester::#OU5] [test-1.lox] [0m
-[33m[tester::#OU5] [test-1.lox] [0m[33m// the constructor should be called[0m
-[33m[tester::#OU5] [test-1.lox] [0m[33m// automatically  when the class is being[0m
-[33m[tester::#OU5] [test-1.lox] [0m[33m// instantiated[0m
-[33m[tester::#OU5] [test-1.lox] [0mprint Default().x;
-[33m[tester::#OU5] [test-1.lox] [0mprint Default().y;
+[33m[tester::#OU5] [test-1.lox] [0m[0mclass Default {[0m
+[33m[tester::#OU5] [test-1.lox] [0m[0m  [33m// this is the constructor[0m[0m
+[33m[tester::#OU5] [test-1.lox] [0m[0m  init() {[0m
+[33m[tester::#OU5] [test-1.lox] [0m[0m    [33m// it should be able to set[0m[0m
+[33m[tester::#OU5] [test-1.lox] [0m[0m    [33m// properties on the instance[0m[0m
+[33m[tester::#OU5] [test-1.lox] [0m[0m    this.x = "baz";[0m
+[33m[tester::#OU5] [test-1.lox] [0m[0m    this.y = 59;[0m
+[33m[tester::#OU5] [test-1.lox] [0m[0m  }[0m
+[33m[tester::#OU5] [test-1.lox] [0m[0m}[0m
+[33m[tester::#OU5] [test-1.lox] [0m[0m[0m
+[33m[tester::#OU5] [test-1.lox] [0m[0m[33m// the constructor should be called[0m[0m
+[33m[tester::#OU5] [test-1.lox] [0m[0m[33m// automatically  when the class is being[0m[0m
+[33m[tester::#OU5] [test-1.lox] [0m[0m[33m// instantiated[0m[0m
+[33m[tester::#OU5] [test-1.lox] [0m[0mprint Default().x;[0m
+[33m[tester::#OU5] [test-1.lox] [0m[0mprint Default().y;[0m
 [33m[tester::#OU5] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mbaz
-[33m[your_program] [0m59
+[33m[your_program] [0m[0mbaz[0m
+[33m[your_program] [0m[0m59[0m
 [33m[tester::#OU5] [test-1] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#OU5] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#OU5] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#OU5] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#OU5] [test-2.lox] [0mclass Robot {
-[33m[tester::#OU5] [test-2.lox] [0m  [33m// constructors should be able to accept[0m
-[33m[tester::#OU5] [test-2.lox] [0m  [33m// one or more parameters[0m
-[33m[tester::#OU5] [test-2.lox] [0m  init(model, function) {
-[33m[tester::#OU5] [test-2.lox] [0m    this.model = model;
-[33m[tester::#OU5] [test-2.lox] [0m    this.function = function;
-[33m[tester::#OU5] [test-2.lox] [0m  }
-[33m[tester::#OU5] [test-2.lox] [0m}
-[33m[tester::#OU5] [test-2.lox] [0mprint Robot("R2-D2", "Astromech").model;
+[33m[tester::#OU5] [test-2.lox] [0m[0mclass Robot {[0m
+[33m[tester::#OU5] [test-2.lox] [0m[0m  [33m// constructors should be able to accept[0m[0m
+[33m[tester::#OU5] [test-2.lox] [0m[0m  [33m// one or more parameters[0m[0m
+[33m[tester::#OU5] [test-2.lox] [0m[0m  init(model, function) {[0m
+[33m[tester::#OU5] [test-2.lox] [0m[0m    this.model = model;[0m
+[33m[tester::#OU5] [test-2.lox] [0m[0m    this.function = function;[0m
+[33m[tester::#OU5] [test-2.lox] [0m[0m  }[0m
+[33m[tester::#OU5] [test-2.lox] [0m[0m}[0m
+[33m[tester::#OU5] [test-2.lox] [0m[0mprint Robot("R2-D2", "Astromech").model;[0m
 [33m[tester::#OU5] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mR2-D2
+[33m[your_program] [0m[0mR2-D2[0m
 [33m[tester::#OU5] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#OU5] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#OU5] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#OU5] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#OU5] [test-3.lox] [0mclass Counter {
-[33m[tester::#OU5] [test-3.lox] [0m  init(startValue) {
-[33m[tester::#OU5] [test-3.lox] [0m    if (startValue < 0) {
-[33m[tester::#OU5] [test-3.lox] [0m      print "startValue can't be negative";
-[33m[tester::#OU5] [test-3.lox] [0m      this.count = 0;
-[33m[tester::#OU5] [test-3.lox] [0m    } else {
-[33m[tester::#OU5] [test-3.lox] [0m      this.count = startValue;
-[33m[tester::#OU5] [test-3.lox] [0m    }
-[33m[tester::#OU5] [test-3.lox] [0m  }
-[33m[tester::#OU5] [test-3.lox] [0m}
-[33m[tester::#OU5] [test-3.lox] [0m
-[33m[tester::#OU5] [test-3.lox] [0m[33m// constructor is called automatically here[0m
-[33m[tester::#OU5] [test-3.lox] [0mvar instance = Counter(-11);
-[33m[tester::#OU5] [test-3.lox] [0mprint instance.count;
-[33m[tester::#OU5] [test-3.lox] [0m
-[33m[tester::#OU5] [test-3.lox] [0m[33m// it should be possible to call the constructor[0m
-[33m[tester::#OU5] [test-3.lox] [0m[33m// on a class instance as well[0m
-[33m[tester::#OU5] [test-3.lox] [0mprint instance.init(11).count;
+[33m[tester::#OU5] [test-3.lox] [0m[0mclass Counter {[0m
+[33m[tester::#OU5] [test-3.lox] [0m[0m  init(startValue) {[0m
+[33m[tester::#OU5] [test-3.lox] [0m[0m    if (startValue < 0) {[0m
+[33m[tester::#OU5] [test-3.lox] [0m[0m      print "startValue can't be negative";[0m
+[33m[tester::#OU5] [test-3.lox] [0m[0m      this.count = 0;[0m
+[33m[tester::#OU5] [test-3.lox] [0m[0m    } else {[0m
+[33m[tester::#OU5] [test-3.lox] [0m[0m      this.count = startValue;[0m
+[33m[tester::#OU5] [test-3.lox] [0m[0m    }[0m
+[33m[tester::#OU5] [test-3.lox] [0m[0m  }[0m
+[33m[tester::#OU5] [test-3.lox] [0m[0m}[0m
+[33m[tester::#OU5] [test-3.lox] [0m[0m[0m
+[33m[tester::#OU5] [test-3.lox] [0m[0m[33m// constructor is called automatically here[0m[0m
+[33m[tester::#OU5] [test-3.lox] [0m[0mvar instance = Counter(-11);[0m
+[33m[tester::#OU5] [test-3.lox] [0m[0mprint instance.count;[0m
+[33m[tester::#OU5] [test-3.lox] [0m[0m[0m
+[33m[tester::#OU5] [test-3.lox] [0m[0m[33m// it should be possible to call the constructor[0m[0m
+[33m[tester::#OU5] [test-3.lox] [0m[0m[33m// on a class instance as well[0m[0m
+[33m[tester::#OU5] [test-3.lox] [0m[0mprint instance.init(11).count;[0m
 [33m[tester::#OU5] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mstartValue can't be negative
-[33m[your_program] [0m0
-[33m[your_program] [0m11
+[33m[your_program] [0m[0mstartValue can't be negative[0m
+[33m[your_program] [0m[0m0[0m
+[33m[your_program] [0m[0m11[0m
 [33m[tester::#OU5] [test-3] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#OU5] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#OU5] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#OU5] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#OU5] [test-4.lox] [0mclass Vehicle {
-[33m[tester::#OU5] [test-4.lox] [0m  init(type) {
-[33m[tester::#OU5] [test-4.lox] [0m    this.type = type;
-[33m[tester::#OU5] [test-4.lox] [0m  }
-[33m[tester::#OU5] [test-4.lox] [0m}
-[33m[tester::#OU5] [test-4.lox] [0m
-[33m[tester::#OU5] [test-4.lox] [0mclass Car {
-[33m[tester::#OU5] [test-4.lox] [0m  init(make, model) {
-[33m[tester::#OU5] [test-4.lox] [0m    this.make = make;
-[33m[tester::#OU5] [test-4.lox] [0m    this.model = model;
-[33m[tester::#OU5] [test-4.lox] [0m    this.wheels = "four";
-[33m[tester::#OU5] [test-4.lox] [0m  }
-[33m[tester::#OU5] [test-4.lox] [0m
-[33m[tester::#OU5] [test-4.lox] [0m  describe() {
-[33m[tester::#OU5] [test-4.lox] [0m    [33m// expression across multiple lines should work[0m
-[33m[tester::#OU5] [test-4.lox] [0m    print this.make + " " + this.model +
-[33m[tester::#OU5] [test-4.lox] [0m    " with " + this.wheels + " wheels";
-[33m[tester::#OU5] [test-4.lox] [0m  }
-[33m[tester::#OU5] [test-4.lox] [0m}
-[33m[tester::#OU5] [test-4.lox] [0m
-[33m[tester::#OU5] [test-4.lox] [0mvar vehicle = Vehicle("Generic");
-[33m[tester::#OU5] [test-4.lox] [0mprint "Generic " + vehicle.type;
-[33m[tester::#OU5] [test-4.lox] [0m
-[33m[tester::#OU5] [test-4.lox] [0mvar myCar = Car("Toyota", "Corolla");
-[33m[tester::#OU5] [test-4.lox] [0mmyCar.describe();
+[33m[tester::#OU5] [test-4.lox] [0m[0mclass Vehicle {[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0m  init(type) {[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0m    this.type = type;[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0m}[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0m[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0mclass Car {[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0m  init(make, model) {[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0m    this.make = make;[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0m    this.model = model;[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0m    this.wheels = "four";[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0m[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0m  describe() {[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0m    [33m// expression across multiple lines should work[0m[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0m    print this.make + " " + this.model +[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0m    " with " + this.wheels + " wheels";[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0m}[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0m[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0mvar vehicle = Vehicle("Generic");[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0mprint "Generic " + vehicle.type;[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0m[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0mvar myCar = Car("Toyota", "Corolla");[0m
+[33m[tester::#OU5] [test-4.lox] [0m[0mmyCar.describe();[0m
 [33m[tester::#OU5] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mGeneric Generic
-[33m[your_program] [0mToyota Corolla with four wheels
+[33m[your_program] [0m[0mGeneric Generic[0m
+[33m[your_program] [0m[0mToyota Corolla with four wheels[0m
 [33m[tester::#OU5] [test-4] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#OU5] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#OU5] [0m[92mTest passed.[0m
@@ -609,66 +609,66 @@ Debug = true
 [33m[tester::#EB9] [0m[94mRunning tests for Stage #EB9 (eb9)[0m
 [33m[tester::#EB9] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#EB9] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#EB9] [test-1.lox] [0mclass Person {
-[33m[tester::#EB9] [test-1.lox] [0m  init() {
-[33m[tester::#EB9] [test-1.lox] [0m    print "hello";
-[33m[tester::#EB9] [test-1.lox] [0m    [33m// constructor should return nothing[0m
-[33m[tester::#EB9] [test-1.lox] [0m    return;
-[33m[tester::#EB9] [test-1.lox] [0m  }
-[33m[tester::#EB9] [test-1.lox] [0m}
-[33m[tester::#EB9] [test-1.lox] [0m
-[33m[tester::#EB9] [test-1.lox] [0mPerson();
+[33m[tester::#EB9] [test-1.lox] [0m[0mclass Person {[0m
+[33m[tester::#EB9] [test-1.lox] [0m[0m  init() {[0m
+[33m[tester::#EB9] [test-1.lox] [0m[0m    print "hello";[0m
+[33m[tester::#EB9] [test-1.lox] [0m[0m    [33m// constructor should return nothing[0m[0m
+[33m[tester::#EB9] [test-1.lox] [0m[0m    return;[0m
+[33m[tester::#EB9] [test-1.lox] [0m[0m  }[0m
+[33m[tester::#EB9] [test-1.lox] [0m[0m}[0m
+[33m[tester::#EB9] [test-1.lox] [0m[0m[0m
+[33m[tester::#EB9] [test-1.lox] [0m[0mPerson();[0m
 [33m[tester::#EB9] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mhello
+[33m[your_program] [0m[0mhello[0m
 [33m[tester::#EB9] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#EB9] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#EB9] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#EB9] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#EB9] [test-2.lox] [0mclass ThingDefault {
-[33m[tester::#EB9] [test-2.lox] [0m  init() {
-[33m[tester::#EB9] [test-2.lox] [0m    this.x = "foo";
-[33m[tester::#EB9] [test-2.lox] [0m    this.y = 42;
-[33m[tester::#EB9] [test-2.lox] [0m    [33m// constructor should not return the instance[0m
-[33m[tester::#EB9] [test-2.lox] [0m    return this; [33m// expect compile error[0m
-[33m[tester::#EB9] [test-2.lox] [0m  }
-[33m[tester::#EB9] [test-2.lox] [0m}
-[33m[tester::#EB9] [test-2.lox] [0mvar out = ThingDefault();
-[33m[tester::#EB9] [test-2.lox] [0mprint out;
+[33m[tester::#EB9] [test-2.lox] [0m[0mclass ThingDefault {[0m
+[33m[tester::#EB9] [test-2.lox] [0m[0m  init() {[0m
+[33m[tester::#EB9] [test-2.lox] [0m[0m    this.x = "foo";[0m
+[33m[tester::#EB9] [test-2.lox] [0m[0m    this.y = 42;[0m
+[33m[tester::#EB9] [test-2.lox] [0m[0m    [33m// constructor should not return the instance[0m[0m
+[33m[tester::#EB9] [test-2.lox] [0m[0m    return this; [33m// expect compile error[0m[0m
+[33m[tester::#EB9] [test-2.lox] [0m[0m  }[0m
+[33m[tester::#EB9] [test-2.lox] [0m[0m}[0m
+[33m[tester::#EB9] [test-2.lox] [0m[0mvar out = ThingDefault();[0m
+[33m[tester::#EB9] [test-2.lox] [0m[0mprint out;[0m
 [33m[tester::#EB9] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 6] Error at 'return': Can't return a value from an initializer.
+[33m[your_program] [0m[0m[line 6] Error at 'return': Can't return a value from an initializer.[0m
 [33m[tester::#EB9] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#EB9] [test-2] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#EB9] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#EB9] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#EB9] [test-3.lox] [0mclass Foo {
-[33m[tester::#EB9] [test-3.lox] [0m  init() {
-[33m[tester::#EB9] [test-3.lox] [0m    [33m// constructor should not return anything[0m
-[33m[tester::#EB9] [test-3.lox] [0m    return "something"; [33m// expect compile error[0m
-[33m[tester::#EB9] [test-3.lox] [0m  }
-[33m[tester::#EB9] [test-3.lox] [0m}
-[33m[tester::#EB9] [test-3.lox] [0m
-[33m[tester::#EB9] [test-3.lox] [0mFoo();
+[33m[tester::#EB9] [test-3.lox] [0m[0mclass Foo {[0m
+[33m[tester::#EB9] [test-3.lox] [0m[0m  init() {[0m
+[33m[tester::#EB9] [test-3.lox] [0m[0m    [33m// constructor should not return anything[0m[0m
+[33m[tester::#EB9] [test-3.lox] [0m[0m    return "something"; [33m// expect compile error[0m[0m
+[33m[tester::#EB9] [test-3.lox] [0m[0m  }[0m
+[33m[tester::#EB9] [test-3.lox] [0m[0m}[0m
+[33m[tester::#EB9] [test-3.lox] [0m[0m[0m
+[33m[tester::#EB9] [test-3.lox] [0m[0mFoo();[0m
 [33m[tester::#EB9] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 4] Error at 'return': Can't return a value from an initializer.
+[33m[your_program] [0m[0m[line 4] Error at 'return': Can't return a value from an initializer.[0m
 [33m[tester::#EB9] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#EB9] [test-3] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#EB9] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#EB9] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#EB9] [test-4.lox] [0mclass Foo {
-[33m[tester::#EB9] [test-4.lox] [0m  init() {
-[33m[tester::#EB9] [test-4.lox] [0m    [33m// just calling the callback should've worked[0m
-[33m[tester::#EB9] [test-4.lox] [0m    [33m// but returning it is not allowed[0m
-[33m[tester::#EB9] [test-4.lox] [0m    return this.callback(); [33m// expect compile error[0m
-[33m[tester::#EB9] [test-4.lox] [0m  }
-[33m[tester::#EB9] [test-4.lox] [0m
-[33m[tester::#EB9] [test-4.lox] [0m  callback() {
-[33m[tester::#EB9] [test-4.lox] [0m    return "callback";
-[33m[tester::#EB9] [test-4.lox] [0m  }
-[33m[tester::#EB9] [test-4.lox] [0m}
-[33m[tester::#EB9] [test-4.lox] [0m
-[33m[tester::#EB9] [test-4.lox] [0mFoo();
+[33m[tester::#EB9] [test-4.lox] [0m[0mclass Foo {[0m
+[33m[tester::#EB9] [test-4.lox] [0m[0m  init() {[0m
+[33m[tester::#EB9] [test-4.lox] [0m[0m    [33m// just calling the callback should've worked[0m[0m
+[33m[tester::#EB9] [test-4.lox] [0m[0m    [33m// but returning it is not allowed[0m[0m
+[33m[tester::#EB9] [test-4.lox] [0m[0m    return this.callback(); [33m// expect compile error[0m[0m
+[33m[tester::#EB9] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#EB9] [test-4.lox] [0m[0m[0m
+[33m[tester::#EB9] [test-4.lox] [0m[0m  callback() {[0m
+[33m[tester::#EB9] [test-4.lox] [0m[0m    return "callback";[0m
+[33m[tester::#EB9] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#EB9] [test-4.lox] [0m[0m}[0m
+[33m[tester::#EB9] [test-4.lox] [0m[0m[0m
+[33m[tester::#EB9] [test-4.lox] [0m[0mFoo();[0m
 [33m[tester::#EB9] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 5] Error at 'return': Can't return a value from an initializer.
+[33m[your_program] [0m[0m[line 5] Error at 'return': Can't return a value from an initializer.[0m
 [33m[tester::#EB9] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#EB9] [test-4] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#EB9] [0m[92mTest passed.[0m

--- a/internal/test_helpers/fixtures/pass_control_flow
+++ b/internal/test_helpers/fixtures/pass_control_flow
@@ -3,54 +3,54 @@ Debug = true
 [33m[tester::#NE3] [0m[94mRunning tests for Stage #NE3 (ne3)[0m
 [33m[tester::#NE3] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#NE3] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#NE3] [test-1.lox] [0m[33m// This should print the string if the condition[0m
-[33m[tester::#NE3] [test-1.lox] [0m[33m// evaluates to True[0m
-[33m[tester::#NE3] [test-1.lox] [0mif (false) print "foo";
+[33m[tester::#NE3] [test-1.lox] [0m[0m[33m// This should print the string if the condition[0m[0m
+[33m[tester::#NE3] [test-1.lox] [0m[0m[33m// evaluates to True[0m[0m
+[33m[tester::#NE3] [test-1.lox] [0m[0mif (false) print "foo";[0m
 [33m[tester::#NE3] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
 [33m[tester::#NE3] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#NE3] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#NE3] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#NE3] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#NE3] [test-2.lox] [0m[33m// This should print "block body" if the condition[0m
-[33m[tester::#NE3] [test-2.lox] [0m[33m// evaluates to True[0m
-[33m[tester::#NE3] [test-2.lox] [0mif (false) {
-[33m[tester::#NE3] [test-2.lox] [0m  print "block body";
-[33m[tester::#NE3] [test-2.lox] [0m}
+[33m[tester::#NE3] [test-2.lox] [0m[0m[33m// This should print "block body" if the condition[0m[0m
+[33m[tester::#NE3] [test-2.lox] [0m[0m[33m// evaluates to True[0m[0m
+[33m[tester::#NE3] [test-2.lox] [0m[0mif (false) {[0m
+[33m[tester::#NE3] [test-2.lox] [0m[0m  print "block body";[0m
+[33m[tester::#NE3] [test-2.lox] [0m[0m}[0m
 [33m[tester::#NE3] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
 [33m[tester::#NE3] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#NE3] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#NE3] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#NE3] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#NE3] [test-3.lox] [0m[33m// This program tests whether the assignment[0m
-[33m[tester::#NE3] [test-3.lox] [0m[33m// operation returns the value assigned.[0m
-[33m[tester::#NE3] [test-3.lox] [0m[33m// The if condition should evaluate to true and[0m
-[33m[tester::#NE3] [test-3.lox] [0m[33m// the inner boolean expression must be printed.[0m
-[33m[tester::#NE3] [test-3.lox] [0m[33m// So, in this case the if condition evaluates to[0m
-[33m[tester::#NE3] [test-3.lox] [0m[33m//true and prints the inner boolean expression[0m
-[33m[tester::#NE3] [test-3.lox] [0mvar a = false;
-[33m[tester::#NE3] [test-3.lox] [0mif (a = true) {
-[33m[tester::#NE3] [test-3.lox] [0m  print (a == true);
-[33m[tester::#NE3] [test-3.lox] [0m}
+[33m[tester::#NE3] [test-3.lox] [0m[0m[33m// This program tests whether the assignment[0m[0m
+[33m[tester::#NE3] [test-3.lox] [0m[0m[33m// operation returns the value assigned.[0m[0m
+[33m[tester::#NE3] [test-3.lox] [0m[0m[33m// The if condition should evaluate to true and[0m[0m
+[33m[tester::#NE3] [test-3.lox] [0m[0m[33m// the inner boolean expression must be printed.[0m[0m
+[33m[tester::#NE3] [test-3.lox] [0m[0m[33m// So, in this case the if condition evaluates to[0m[0m
+[33m[tester::#NE3] [test-3.lox] [0m[0m[33m//true and prints the inner boolean expression[0m[0m
+[33m[tester::#NE3] [test-3.lox] [0m[0mvar a = false;[0m
+[33m[tester::#NE3] [test-3.lox] [0m[0mif (a = true) {[0m
+[33m[tester::#NE3] [test-3.lox] [0m[0m  print (a == true);[0m
+[33m[tester::#NE3] [test-3.lox] [0m[0m}[0m
 [33m[tester::#NE3] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mtrue
+[33m[your_program] [0m[0mtrue[0m
 [33m[tester::#NE3] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#NE3] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#NE3] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#NE3] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#NE3] [test-4.lox] [0m[33m// This program should print a different string[0m
-[33m[tester::#NE3] [test-4.lox] [0m[33m// based on the value of age[0m
-[33m[tester::#NE3] [test-4.lox] [0mvar stage = "unknown";
-[33m[tester::#NE3] [test-4.lox] [0mvar age = 73;
-[33m[tester::#NE3] [test-4.lox] [0mif (age < 18) { stage = "child"; }
-[33m[tester::#NE3] [test-4.lox] [0mif (age >= 18) { stage = "adult"; }
-[33m[tester::#NE3] [test-4.lox] [0mprint stage;
-[33m[tester::#NE3] [test-4.lox] [0m
-[33m[tester::#NE3] [test-4.lox] [0mvar isAdult = age >= 18;
-[33m[tester::#NE3] [test-4.lox] [0mif (isAdult) { print "eligible for voting"; }
-[33m[tester::#NE3] [test-4.lox] [0mif (!isAdult) { print "not eligible for voting"; }
+[33m[tester::#NE3] [test-4.lox] [0m[0m[33m// This program should print a different string[0m[0m
+[33m[tester::#NE3] [test-4.lox] [0m[0m[33m// based on the value of age[0m[0m
+[33m[tester::#NE3] [test-4.lox] [0m[0mvar stage = "unknown";[0m
+[33m[tester::#NE3] [test-4.lox] [0m[0mvar age = 73;[0m
+[33m[tester::#NE3] [test-4.lox] [0m[0mif (age < 18) { stage = "child"; }[0m
+[33m[tester::#NE3] [test-4.lox] [0m[0mif (age >= 18) { stage = "adult"; }[0m
+[33m[tester::#NE3] [test-4.lox] [0m[0mprint stage;[0m
+[33m[tester::#NE3] [test-4.lox] [0m[0m[0m
+[33m[tester::#NE3] [test-4.lox] [0m[0mvar isAdult = age >= 18;[0m
+[33m[tester::#NE3] [test-4.lox] [0m[0mif (isAdult) { print "eligible for voting"; }[0m
+[33m[tester::#NE3] [test-4.lox] [0m[0mif (!isAdult) { print "not eligible for voting"; }[0m
 [33m[tester::#NE3] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0madult
-[33m[your_program] [0meligible for voting
+[33m[your_program] [0m[0madult[0m
+[33m[your_program] [0m[0meligible for voting[0m
 [33m[tester::#NE3] [test-4] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#NE3] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#NE3] [0m[92mTest passed.[0m
@@ -58,71 +58,71 @@ Debug = true
 [33m[tester::#ST5] [0m[94mRunning tests for Stage #ST5 (st5)[0m
 [33m[tester::#ST5] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#ST5] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#ST5] [test-1.lox] [0m[33m// This program uses a random boolean to decide[0m
-[33m[tester::#ST5] [test-1.lox] [0m[33m// which branch to execute,[0m
-[33m[tester::#ST5] [test-1.lox] [0m[33m// and then prints the appropriate string[0m
-[33m[tester::#ST5] [test-1.lox] [0mif (true) print "if"; else print "else";
+[33m[tester::#ST5] [test-1.lox] [0m[0m[33m// This program uses a random boolean to decide[0m[0m
+[33m[tester::#ST5] [test-1.lox] [0m[0m[33m// which branch to execute,[0m[0m
+[33m[tester::#ST5] [test-1.lox] [0m[0m[33m// and then prints the appropriate string[0m[0m
+[33m[tester::#ST5] [test-1.lox] [0m[0mif (true) print "if"; else print "else";[0m
 [33m[tester::#ST5] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mif
+[33m[your_program] [0m[0mif[0m
 [33m[tester::#ST5] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#ST5] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#ST5] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#ST5] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#ST5] [test-2.lox] [0m[33m// This program initializes age with a random[0m
-[33m[tester::#ST5] [test-2.lox] [0m[33m// integer and then prints "adult"[0m
-[33m[tester::#ST5] [test-2.lox] [0m[33m// if the age is greater than 18, otherwise it[0m
-[33m[tester::#ST5] [test-2.lox] [0m[33m// prints "child"[0m
-[33m[tester::#ST5] [test-2.lox] [0mvar age = 64;
-[33m[tester::#ST5] [test-2.lox] [0mif (age > 18) print "adult"; else print "child";
+[33m[tester::#ST5] [test-2.lox] [0m[0m[33m// This program initializes age with a random[0m[0m
+[33m[tester::#ST5] [test-2.lox] [0m[0m[33m// integer and then prints "adult"[0m[0m
+[33m[tester::#ST5] [test-2.lox] [0m[0m[33m// if the age is greater than 18, otherwise it[0m[0m
+[33m[tester::#ST5] [test-2.lox] [0m[0m[33m// prints "child"[0m[0m
+[33m[tester::#ST5] [test-2.lox] [0m[0mvar age = 64;[0m
+[33m[tester::#ST5] [test-2.lox] [0m[0mif (age > 18) print "adult"; else print "child";[0m
 [33m[tester::#ST5] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0madult
+[33m[your_program] [0m[0madult[0m
 [33m[tester::#ST5] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#ST5] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#ST5] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#ST5] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#ST5] [test-3.lox] [0m[33m// This program uses a random boolean to decide[0m
-[33m[tester::#ST5] [test-3.lox] [0m[33m// which branch to execute,[0m
-[33m[tester::#ST5] [test-3.lox] [0m[33m// and then prints the appropriate string[0m
-[33m[tester::#ST5] [test-3.lox] [0mif (false) {
-[33m[tester::#ST5] [test-3.lox] [0m  print "if block";
-[33m[tester::#ST5] [test-3.lox] [0m} else print "else statement";
-[33m[tester::#ST5] [test-3.lox] [0m
-[33m[tester::#ST5] [test-3.lox] [0mif (false) print "if statement"; else {
-[33m[tester::#ST5] [test-3.lox] [0m  print "else block";
-[33m[tester::#ST5] [test-3.lox] [0m}
+[33m[tester::#ST5] [test-3.lox] [0m[0m[33m// This program uses a random boolean to decide[0m[0m
+[33m[tester::#ST5] [test-3.lox] [0m[0m[33m// which branch to execute,[0m[0m
+[33m[tester::#ST5] [test-3.lox] [0m[0m[33m// and then prints the appropriate string[0m[0m
+[33m[tester::#ST5] [test-3.lox] [0m[0mif (false) {[0m
+[33m[tester::#ST5] [test-3.lox] [0m[0m  print "if block";[0m
+[33m[tester::#ST5] [test-3.lox] [0m[0m} else print "else statement";[0m
+[33m[tester::#ST5] [test-3.lox] [0m[0m[0m
+[33m[tester::#ST5] [test-3.lox] [0m[0mif (false) print "if statement"; else {[0m
+[33m[tester::#ST5] [test-3.lox] [0m[0m  print "else block";[0m
+[33m[tester::#ST5] [test-3.lox] [0m[0m}[0m
 [33m[tester::#ST5] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0melse statement
-[33m[your_program] [0melse block
+[33m[your_program] [0m[0melse statement[0m
+[33m[your_program] [0m[0melse block[0m
 [33m[tester::#ST5] [test-3] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#ST5] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#ST5] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#ST5] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#ST5] [test-4.lox] [0m[33m// This program converts a random integer from[0m
-[33m[tester::#ST5] [test-4.lox] [0m[33m// Celsius to Fahrenheit[0m
-[33m[tester::#ST5] [test-4.lox] [0m[33m// and prints the result. It also prints a message[0m
-[33m[tester::#ST5] [test-4.lox] [0m[33m// based on the temperature.[0m
-[33m[tester::#ST5] [test-4.lox] [0mvar celsius = 82;
-[33m[tester::#ST5] [test-4.lox] [0mvar fahrenheit = 0;
-[33m[tester::#ST5] [test-4.lox] [0mvar isHot = false;
-[33m[tester::#ST5] [test-4.lox] [0m
-[33m[tester::#ST5] [test-4.lox] [0m{
-[33m[tester::#ST5] [test-4.lox] [0m  fahrenheit = celsius * 9 / 5 + 32;
-[33m[tester::#ST5] [test-4.lox] [0m  print celsius; print fahrenheit;
-[33m[tester::#ST5] [test-4.lox] [0m
-[33m[tester::#ST5] [test-4.lox] [0m  if (celsius > 30) {
-[33m[tester::#ST5] [test-4.lox] [0m    isHot = true;
-[33m[tester::#ST5] [test-4.lox] [0m    print "It's a hot day. Stay hydrated!";
-[33m[tester::#ST5] [test-4.lox] [0m  } else {
-[33m[tester::#ST5] [test-4.lox] [0m    print "It's cold today. Wear a jacket!";
-[33m[tester::#ST5] [test-4.lox] [0m  }
-[33m[tester::#ST5] [test-4.lox] [0m
-[33m[tester::#ST5] [test-4.lox] [0m  if (isHot) { print "Use sunscreen!"; }
-[33m[tester::#ST5] [test-4.lox] [0m}
+[33m[tester::#ST5] [test-4.lox] [0m[0m[33m// This program converts a random integer from[0m[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0m[33m// Celsius to Fahrenheit[0m[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0m[33m// and prints the result. It also prints a message[0m[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0m[33m// based on the temperature.[0m[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0mvar celsius = 82;[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0mvar fahrenheit = 0;[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0mvar isHot = false;[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0m[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0m{[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0m  fahrenheit = celsius * 9 / 5 + 32;[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0m  print celsius; print fahrenheit;[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0m[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0m  if (celsius > 30) {[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0m    isHot = true;[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0m    print "It's a hot day. Stay hydrated!";[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0m  } else {[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0m    print "It's cold today. Wear a jacket!";[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0m[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0m  if (isHot) { print "Use sunscreen!"; }[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0m}[0m
 [33m[tester::#ST5] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m82
-[33m[your_program] [0m179.6
-[33m[your_program] [0mIt's a hot day. Stay hydrated!
-[33m[your_program] [0mUse sunscreen!
+[33m[your_program] [0m[0m82[0m
+[33m[your_program] [0m[0m179.6[0m
+[33m[your_program] [0m[0mIt's a hot day. Stay hydrated![0m
+[33m[your_program] [0m[0mUse sunscreen![0m
 [33m[tester::#ST5] [test-4] [0m[92m✓ 4 line(s) match on stdout[0m
 [33m[tester::#ST5] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#ST5] [0m[92mTest passed.[0m
@@ -130,67 +130,67 @@ Debug = true
 [33m[tester::#FH8] [0m[94mRunning tests for Stage #FH8 (fh8)[0m
 [33m[tester::#FH8] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#FH8] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#FH8] [test-1.lox] [0m[33m// This program uses a random boolean to decide[0m
-[33m[tester::#FH8] [test-1.lox] [0m[33m// which branch to execute,[0m
-[33m[tester::#FH8] [test-1.lox] [0m[33m// and then prints the appropriate string[0m
-[33m[tester::#FH8] [test-1.lox] [0mif (false) print "if branch";
-[33m[tester::#FH8] [test-1.lox] [0melse if (false) print "else-if branch";
+[33m[tester::#FH8] [test-1.lox] [0m[0m[33m// This program uses a random boolean to decide[0m[0m
+[33m[tester::#FH8] [test-1.lox] [0m[0m[33m// which branch to execute,[0m[0m
+[33m[tester::#FH8] [test-1.lox] [0m[0m[33m// and then prints the appropriate string[0m[0m
+[33m[tester::#FH8] [test-1.lox] [0m[0mif (false) print "if branch";[0m
+[33m[tester::#FH8] [test-1.lox] [0m[0melse if (false) print "else-if branch";[0m
 [33m[tester::#FH8] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
 [33m[tester::#FH8] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#FH8] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#FH8] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#FH8] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#FH8] [test-2.lox] [0m[33m// This program uses a random boolean to decide[0m
-[33m[tester::#FH8] [test-2.lox] [0m[33m// which branch to execute,[0m
-[33m[tester::#FH8] [test-2.lox] [0m[33m// and then prints the appropriate string[0m
-[33m[tester::#FH8] [test-2.lox] [0mif (false) {
-[33m[tester::#FH8] [test-2.lox] [0m  print "bar";
-[33m[tester::#FH8] [test-2.lox] [0m} else if (false) print "bar";
-[33m[tester::#FH8] [test-2.lox] [0m
-[33m[tester::#FH8] [test-2.lox] [0mif (false) print "bar"; else if (false) {
-[33m[tester::#FH8] [test-2.lox] [0m  print "bar";
-[33m[tester::#FH8] [test-2.lox] [0m}
+[33m[tester::#FH8] [test-2.lox] [0m[0m[33m// This program uses a random boolean to decide[0m[0m
+[33m[tester::#FH8] [test-2.lox] [0m[0m[33m// which branch to execute,[0m[0m
+[33m[tester::#FH8] [test-2.lox] [0m[0m[33m// and then prints the appropriate string[0m[0m
+[33m[tester::#FH8] [test-2.lox] [0m[0mif (false) {[0m
+[33m[tester::#FH8] [test-2.lox] [0m[0m  print "bar";[0m
+[33m[tester::#FH8] [test-2.lox] [0m[0m} else if (false) print "bar";[0m
+[33m[tester::#FH8] [test-2.lox] [0m[0m[0m
+[33m[tester::#FH8] [test-2.lox] [0m[0mif (false) print "bar"; else if (false) {[0m
+[33m[tester::#FH8] [test-2.lox] [0m[0m  print "bar";[0m
+[33m[tester::#FH8] [test-2.lox] [0m[0m}[0m
 [33m[tester::#FH8] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
 [33m[tester::#FH8] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#FH8] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#FH8] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#FH8] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#FH8] [test-3.lox] [0m[33m// This program uses multiple if statements to[0m
-[33m[tester::#FH8] [test-3.lox] [0m[33m// categorize a person[0m
-[33m[tester::#FH8] [test-3.lox] [0m[33m// into different life stages based on their age[0m
-[33m[tester::#FH8] [test-3.lox] [0mvar age = 62;
-[33m[tester::#FH8] [test-3.lox] [0mvar stage = "unknown";
-[33m[tester::#FH8] [test-3.lox] [0mif (age < 18) { stage = "child"; }
-[33m[tester::#FH8] [test-3.lox] [0melse if (age >= 18) { stage = "adult"; }
-[33m[tester::#FH8] [test-3.lox] [0melse if (age >= 65) { stage = "senior"; }
-[33m[tester::#FH8] [test-3.lox] [0melse if (age >= 100) { stage = "centenarian"; }
-[33m[tester::#FH8] [test-3.lox] [0mprint stage;
+[33m[tester::#FH8] [test-3.lox] [0m[0m[33m// This program uses multiple if statements to[0m[0m
+[33m[tester::#FH8] [test-3.lox] [0m[0m[33m// categorize a person[0m[0m
+[33m[tester::#FH8] [test-3.lox] [0m[0m[33m// into different life stages based on their age[0m[0m
+[33m[tester::#FH8] [test-3.lox] [0m[0mvar age = 62;[0m
+[33m[tester::#FH8] [test-3.lox] [0m[0mvar stage = "unknown";[0m
+[33m[tester::#FH8] [test-3.lox] [0m[0mif (age < 18) { stage = "child"; }[0m
+[33m[tester::#FH8] [test-3.lox] [0m[0melse if (age >= 18) { stage = "adult"; }[0m
+[33m[tester::#FH8] [test-3.lox] [0m[0melse if (age >= 65) { stage = "senior"; }[0m
+[33m[tester::#FH8] [test-3.lox] [0m[0melse if (age >= 100) { stage = "centenarian"; }[0m
+[33m[tester::#FH8] [test-3.lox] [0m[0mprint stage;[0m
 [33m[tester::#FH8] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0madult
+[33m[your_program] [0m[0madult[0m
 [33m[tester::#FH8] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#FH8] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#FH8] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#FH8] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#FH8] [test-4.lox] [0m[33m// This program uses multiple if statements to[0m
-[33m[tester::#FH8] [test-4.lox] [0m[33m// determine eligibility for[0m
-[33m[tester::#FH8] [test-4.lox] [0m[33m// voting, driving, and drinking based on a random[0m
-[33m[tester::#FH8] [test-4.lox] [0m[33m// integer age[0m
-[33m[tester::#FH8] [test-4.lox] [0mvar age = 79;
-[33m[tester::#FH8] [test-4.lox] [0m
-[33m[tester::#FH8] [test-4.lox] [0mvar isAdult = age >= 18;
-[33m[tester::#FH8] [test-4.lox] [0mif (isAdult) { print "eligible for voting: true"; }
-[33m[tester::#FH8] [test-4.lox] [0melse { print "eligible for voting: false"; }
-[33m[tester::#FH8] [test-4.lox] [0m
-[33m[tester::#FH8] [test-4.lox] [0mif (age < 16) { print "not eligible for driving"; }
-[33m[tester::#FH8] [test-4.lox] [0melse if (age < 18) { print "learner's permit"; }
-[33m[tester::#FH8] [test-4.lox] [0melse { print "eligible for driving"; }
-[33m[tester::#FH8] [test-4.lox] [0m
-[33m[tester::#FH8] [test-4.lox] [0mif (age >= 21) { print "eligible for drinking"; }
-[33m[tester::#FH8] [test-4.lox] [0melse { print "not eligible for drinking"; }
+[33m[tester::#FH8] [test-4.lox] [0m[0m[33m// This program uses multiple if statements to[0m[0m
+[33m[tester::#FH8] [test-4.lox] [0m[0m[33m// determine eligibility for[0m[0m
+[33m[tester::#FH8] [test-4.lox] [0m[0m[33m// voting, driving, and drinking based on a random[0m[0m
+[33m[tester::#FH8] [test-4.lox] [0m[0m[33m// integer age[0m[0m
+[33m[tester::#FH8] [test-4.lox] [0m[0mvar age = 79;[0m
+[33m[tester::#FH8] [test-4.lox] [0m[0m[0m
+[33m[tester::#FH8] [test-4.lox] [0m[0mvar isAdult = age >= 18;[0m
+[33m[tester::#FH8] [test-4.lox] [0m[0mif (isAdult) { print "eligible for voting: true"; }[0m
+[33m[tester::#FH8] [test-4.lox] [0m[0melse { print "eligible for voting: false"; }[0m
+[33m[tester::#FH8] [test-4.lox] [0m[0m[0m
+[33m[tester::#FH8] [test-4.lox] [0m[0mif (age < 16) { print "not eligible for driving"; }[0m
+[33m[tester::#FH8] [test-4.lox] [0m[0melse if (age < 18) { print "learner's permit"; }[0m
+[33m[tester::#FH8] [test-4.lox] [0m[0melse { print "eligible for driving"; }[0m
+[33m[tester::#FH8] [test-4.lox] [0m[0m[0m
+[33m[tester::#FH8] [test-4.lox] [0m[0mif (age >= 21) { print "eligible for drinking"; }[0m
+[33m[tester::#FH8] [test-4.lox] [0m[0melse { print "not eligible for drinking"; }[0m
 [33m[tester::#FH8] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0meligible for voting: true
-[33m[your_program] [0meligible for driving
-[33m[your_program] [0meligible for drinking
+[33m[your_program] [0m[0meligible for voting: true[0m
+[33m[your_program] [0m[0meligible for driving[0m
+[33m[your_program] [0m[0meligible for drinking[0m
 [33m[tester::#FH8] [test-4] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#FH8] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#FH8] [0m[92mTest passed.[0m
@@ -198,95 +198,95 @@ Debug = true
 [33m[tester::#XJ4] [0m[94mRunning tests for Stage #XJ4 (xj4)[0m
 [33m[tester::#XJ4] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#XJ4] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#XJ4] [test-1.lox] [0m[33m// This program uses nested if statements to print[0m
-[33m[tester::#XJ4] [test-1.lox] [0m[33m// a message[0m
-[33m[tester::#XJ4] [test-1.lox] [0mif (true) if (true) print "nested true";
+[33m[tester::#XJ4] [test-1.lox] [0m[0m[33m// This program uses nested if statements to print[0m[0m
+[33m[tester::#XJ4] [test-1.lox] [0m[0m[33m// a message[0m[0m
+[33m[tester::#XJ4] [test-1.lox] [0m[0mif (true) if (true) print "nested true";[0m
 [33m[tester::#XJ4] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mnested true
+[33m[your_program] [0m[0mnested true[0m
 [33m[tester::#XJ4] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#XJ4] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#XJ4] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#XJ4] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#XJ4] [test-2.lox] [0m[33m// This program uses nested if statements to print[0m
-[33m[tester::#XJ4] [test-2.lox] [0m[33m// a message[0m
-[33m[tester::#XJ4] [test-2.lox] [0mif (true) {
-[33m[tester::#XJ4] [test-2.lox] [0m  if (true) print "baz"; else print "baz";
-[33m[tester::#XJ4] [test-2.lox] [0m}
+[33m[tester::#XJ4] [test-2.lox] [0m[0m[33m// This program uses nested if statements to print[0m[0m
+[33m[tester::#XJ4] [test-2.lox] [0m[0m[33m// a message[0m[0m
+[33m[tester::#XJ4] [test-2.lox] [0m[0mif (true) {[0m
+[33m[tester::#XJ4] [test-2.lox] [0m[0m  if (true) print "baz"; else print "baz";[0m
+[33m[tester::#XJ4] [test-2.lox] [0m[0m}[0m
 [33m[tester::#XJ4] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mbaz
+[33m[your_program] [0m[0mbaz[0m
 [33m[tester::#XJ4] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#XJ4] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#XJ4] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#XJ4] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#XJ4] [test-3.lox] [0m[33m// This program categorizes a person into[0m
-[33m[tester::#XJ4] [test-3.lox] [0m[33m// different life stages based on their age[0m
-[33m[tester::#XJ4] [test-3.lox] [0m[33m// Then based on the age, it prints a message[0m
-[33m[tester::#XJ4] [test-3.lox] [0m[33m// about the person's eligibility for voting,[0m
-[33m[tester::#XJ4] [test-3.lox] [0m[33m// driving, and drinking[0m
-[33m[tester::#XJ4] [test-3.lox] [0mvar stage = "unknown";
-[33m[tester::#XJ4] [test-3.lox] [0mvar age = 68;
-[33m[tester::#XJ4] [test-3.lox] [0mif (age < 18) {
-[33m[tester::#XJ4] [test-3.lox] [0m    if (age < 13) { stage = "child"; }
-[33m[tester::#XJ4] [test-3.lox] [0m    else if (age < 16) {
-[33m[tester::#XJ4] [test-3.lox] [0m        stage = "young teenager";
-[33m[tester::#XJ4] [test-3.lox] [0m    }
-[33m[tester::#XJ4] [test-3.lox] [0m    else { stage = "teenager"; }
-[33m[tester::#XJ4] [test-3.lox] [0m}
-[33m[tester::#XJ4] [test-3.lox] [0melse if (age < 65) {
-[33m[tester::#XJ4] [test-3.lox] [0m    if (age < 30) { stage = "young adult"; }
-[33m[tester::#XJ4] [test-3.lox] [0m    else if (age < 50) { stage = "adult"; }
-[33m[tester::#XJ4] [test-3.lox] [0m    else { stage = "middle-aged adult"; }
-[33m[tester::#XJ4] [test-3.lox] [0m}
-[33m[tester::#XJ4] [test-3.lox] [0melse { stage = "senior"; }
-[33m[tester::#XJ4] [test-3.lox] [0mprint stage;
-[33m[tester::#XJ4] [test-3.lox] [0m
-[33m[tester::#XJ4] [test-3.lox] [0mvar isAdult = age >= 18;
-[33m[tester::#XJ4] [test-3.lox] [0mif (isAdult) {
-[33m[tester::#XJ4] [test-3.lox] [0m    print "eligible for voting: true";
-[33m[tester::#XJ4] [test-3.lox] [0m    if (age < 25) {
-[33m[tester::#XJ4] [test-3.lox] [0m        print "first-time voter: likely";
-[33m[tester::#XJ4] [test-3.lox] [0m    }
-[33m[tester::#XJ4] [test-3.lox] [0m    else { print "first-time voter: unlikely"; }
-[33m[tester::#XJ4] [test-3.lox] [0m}
-[33m[tester::#XJ4] [test-3.lox] [0melse { print "eligible for voting: false"; }
-[33m[tester::#XJ4] [test-3.lox] [0m
-[33m[tester::#XJ4] [test-3.lox] [0mif (age < 16) { print "not eligible for driving"; }
-[33m[tester::#XJ4] [test-3.lox] [0melse if (age < 18) {
-[33m[tester::#XJ4] [test-3.lox] [0m    print "eligible for driving: learner's permit";
-[33m[tester::#XJ4] [test-3.lox] [0m    if (age < 17) {
-[33m[tester::#XJ4] [test-3.lox] [0m        print "supervised driving required";
-[33m[tester::#XJ4] [test-3.lox] [0m    }
-[33m[tester::#XJ4] [test-3.lox] [0m    else {
-[33m[tester::#XJ4] [test-3.lox] [0m        print "driving allowed with restrictions";
-[33m[tester::#XJ4] [test-3.lox] [0m    }
-[33m[tester::#XJ4] [test-3.lox] [0m}
-[33m[tester::#XJ4] [test-3.lox] [0melse { print "eligible for driving"; }
-[33m[tester::#XJ4] [test-3.lox] [0m
-[33m[tester::#XJ4] [test-3.lox] [0mif (age < 21) {
-[33m[tester::#XJ4] [test-3.lox] [0m    print "not eligible for drinking";
-[33m[tester::#XJ4] [test-3.lox] [0m}
-[33m[tester::#XJ4] [test-3.lox] [0melse {
-[33m[tester::#XJ4] [test-3.lox] [0m    print "eligible for drinking";
-[33m[tester::#XJ4] [test-3.lox] [0m    if (age < 25) {
-[33m[tester::#XJ4] [test-3.lox] [0m        print "remember: drink responsibly!";
-[33m[tester::#XJ4] [test-3.lox] [0m    }
-[33m[tester::#XJ4] [test-3.lox] [0m}
+[33m[tester::#XJ4] [test-3.lox] [0m[0m[33m// This program categorizes a person into[0m[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m[33m// different life stages based on their age[0m[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m[33m// Then based on the age, it prints a message[0m[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m[33m// about the person's eligibility for voting,[0m[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m[33m// driving, and drinking[0m[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0mvar stage = "unknown";[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0mvar age = 68;[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0mif (age < 18) {[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    if (age < 13) { stage = "child"; }[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    else if (age < 16) {[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m        stage = "young teenager";[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    }[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    else { stage = "teenager"; }[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m}[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0melse if (age < 65) {[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    if (age < 30) { stage = "young adult"; }[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    else if (age < 50) { stage = "adult"; }[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    else { stage = "middle-aged adult"; }[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m}[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0melse { stage = "senior"; }[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0mprint stage;[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0mvar isAdult = age >= 18;[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0mif (isAdult) {[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    print "eligible for voting: true";[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    if (age < 25) {[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m        print "first-time voter: likely";[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    }[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    else { print "first-time voter: unlikely"; }[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m}[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0melse { print "eligible for voting: false"; }[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0mif (age < 16) { print "not eligible for driving"; }[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0melse if (age < 18) {[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    print "eligible for driving: learner's permit";[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    if (age < 17) {[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m        print "supervised driving required";[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    }[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    else {[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m        print "driving allowed with restrictions";[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    }[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m}[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0melse { print "eligible for driving"; }[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0mif (age < 21) {[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    print "not eligible for drinking";[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m}[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0melse {[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    print "eligible for drinking";[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    if (age < 25) {[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m        print "remember: drink responsibly!";[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    }[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m}[0m
 [33m[tester::#XJ4] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0msenior
-[33m[your_program] [0meligible for voting: true
-[33m[your_program] [0mfirst-time voter: unlikely
-[33m[your_program] [0meligible for driving
-[33m[your_program] [0meligible for drinking
+[33m[your_program] [0m[0msenior[0m
+[33m[your_program] [0m[0meligible for voting: true[0m
+[33m[your_program] [0m[0mfirst-time voter: unlikely[0m
+[33m[your_program] [0m[0meligible for driving[0m
+[33m[your_program] [0m[0meligible for drinking[0m
 [33m[tester::#XJ4] [test-3] [0m[92m✓ 5 line(s) match on stdout[0m
 [33m[tester::#XJ4] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#XJ4] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#XJ4] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#XJ4] [test-4.lox] [0m[33m// This program uses nested if statements to print[0m
-[33m[tester::#XJ4] [test-4.lox] [0m[33m// a message[0m
-[33m[tester::#XJ4] [test-4.lox] [0mif (true) if (false) print "bar";
-[33m[tester::#XJ4] [test-4.lox] [0melse print "foo";
+[33m[tester::#XJ4] [test-4.lox] [0m[0m[33m// This program uses nested if statements to print[0m[0m
+[33m[tester::#XJ4] [test-4.lox] [0m[0m[33m// a message[0m[0m
+[33m[tester::#XJ4] [test-4.lox] [0m[0mif (true) if (false) print "bar";[0m
+[33m[tester::#XJ4] [test-4.lox] [0m[0melse print "foo";[0m
 [33m[tester::#XJ4] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mfoo
+[33m[your_program] [0m[0mfoo[0m
 [33m[tester::#XJ4] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#XJ4] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#XJ4] [0m[92mTest passed.[0m
@@ -294,79 +294,79 @@ Debug = true
 [33m[tester::#WK8] [0m[94mRunning tests for Stage #WK8 (wk8)[0m
 [33m[tester::#WK8] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#WK8] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#WK8] [test-1.lox] [0m[33m// The logical OR operator should return the first[0m
-[33m[tester::#WK8] [test-1.lox] [0m[33m// value that is truthy[0m
-[33m[tester::#WK8] [test-1.lox] [0mif (false or "ok") print "world";
-[33m[tester::#WK8] [test-1.lox] [0mif (nil or "ok") print "world";
-[33m[tester::#WK8] [test-1.lox] [0m
-[33m[tester::#WK8] [test-1.lox] [0mif (false or false) print "bar";
-[33m[tester::#WK8] [test-1.lox] [0mif (true or "bar") print "bar";
-[33m[tester::#WK8] [test-1.lox] [0m
-[33m[tester::#WK8] [test-1.lox] [0mif (67 or "hello") print "hello";
-[33m[tester::#WK8] [test-1.lox] [0mif ("hello" or "hello") print "hello";
+[33m[tester::#WK8] [test-1.lox] [0m[0m[33m// The logical OR operator should return the first[0m[0m
+[33m[tester::#WK8] [test-1.lox] [0m[0m[33m// value that is truthy[0m[0m
+[33m[tester::#WK8] [test-1.lox] [0m[0mif (false or "ok") print "world";[0m
+[33m[tester::#WK8] [test-1.lox] [0m[0mif (nil or "ok") print "world";[0m
+[33m[tester::#WK8] [test-1.lox] [0m[0m[0m
+[33m[tester::#WK8] [test-1.lox] [0m[0mif (false or false) print "bar";[0m
+[33m[tester::#WK8] [test-1.lox] [0m[0mif (true or "bar") print "bar";[0m
+[33m[tester::#WK8] [test-1.lox] [0m[0m[0m
+[33m[tester::#WK8] [test-1.lox] [0m[0mif (67 or "hello") print "hello";[0m
+[33m[tester::#WK8] [test-1.lox] [0m[0mif ("hello" or "hello") print "hello";[0m
 [33m[tester::#WK8] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mworld
-[33m[your_program] [0mworld
-[33m[your_program] [0mbar
-[33m[your_program] [0mhello
-[33m[your_program] [0mhello
+[33m[your_program] [0m[0mworld[0m
+[33m[your_program] [0m[0mworld[0m
+[33m[your_program] [0m[0mbar[0m
+[33m[your_program] [0m[0mhello[0m
+[33m[your_program] [0m[0mhello[0m
 [33m[tester::#WK8] [test-1] [0m[92m✓ 5 line(s) match on stdout[0m
 [33m[tester::#WK8] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#WK8] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#WK8] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#WK8] [test-2.lox] [0m[33m// This program uses the logical OR operator to[0m
-[33m[tester::#WK8] [test-2.lox] [0m[33m// print the first value that is truthy[0m
-[33m[tester::#WK8] [test-2.lox] [0mprint 16 or true;
-[33m[tester::#WK8] [test-2.lox] [0mprint false or 16;
-[33m[tester::#WK8] [test-2.lox] [0mprint false or false or true;
-[33m[tester::#WK8] [test-2.lox] [0m
-[33m[tester::#WK8] [test-2.lox] [0mprint false or false;
-[33m[tester::#WK8] [test-2.lox] [0mprint false or false or false;
-[33m[tester::#WK8] [test-2.lox] [0mprint false or false or false or false;
+[33m[tester::#WK8] [test-2.lox] [0m[0m[33m// This program uses the logical OR operator to[0m[0m
+[33m[tester::#WK8] [test-2.lox] [0m[0m[33m// print the first value that is truthy[0m[0m
+[33m[tester::#WK8] [test-2.lox] [0m[0mprint 16 or true;[0m
+[33m[tester::#WK8] [test-2.lox] [0m[0mprint false or 16;[0m
+[33m[tester::#WK8] [test-2.lox] [0m[0mprint false or false or true;[0m
+[33m[tester::#WK8] [test-2.lox] [0m[0m[0m
+[33m[tester::#WK8] [test-2.lox] [0m[0mprint false or false;[0m
+[33m[tester::#WK8] [test-2.lox] [0m[0mprint false or false or false;[0m
+[33m[tester::#WK8] [test-2.lox] [0m[0mprint false or false or false or false;[0m
 [33m[tester::#WK8] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m16
-[33m[your_program] [0m16
-[33m[your_program] [0mtrue
-[33m[your_program] [0mfalse
-[33m[your_program] [0mfalse
-[33m[your_program] [0mfalse
+[33m[your_program] [0m[0m16[0m
+[33m[your_program] [0m[0m16[0m
+[33m[your_program] [0m[0mtrue[0m
+[33m[your_program] [0m[0mfalse[0m
+[33m[your_program] [0m[0mfalse[0m
+[33m[your_program] [0m[0mfalse[0m
 [33m[tester::#WK8] [test-2] [0m[92m✓ 6 line(s) match on stdout[0m
 [33m[tester::#WK8] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#WK8] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#WK8] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#WK8] [test-3.lox] [0m[33m// This program relies on the fact that[0m
-[33m[tester::#WK8] [test-3.lox] [0m[33m// assignments return the assigned value[0m
-[33m[tester::#WK8] [test-3.lox] [0m[33m// And that the logical OR operator short-circuits[0m
-[33m[tester::#WK8] [test-3.lox] [0m[33m// So, if the first assignment is truthy, it[0m
-[33m[tester::#WK8] [test-3.lox] [0m[33m// wouldn't proceed to the subsequent assignments[0m
-[33m[tester::#WK8] [test-3.lox] [0m[33m// And then prints the assigned values[0m
-[33m[tester::#WK8] [test-3.lox] [0mvar a = "hello";
-[33m[tester::#WK8] [test-3.lox] [0mvar b = "hello";
-[33m[tester::#WK8] [test-3.lox] [0m(a = false) or (b = true) or (a = "hello");
-[33m[tester::#WK8] [test-3.lox] [0mprint a;
-[33m[tester::#WK8] [test-3.lox] [0mprint b;
+[33m[tester::#WK8] [test-3.lox] [0m[0m[33m// This program relies on the fact that[0m[0m
+[33m[tester::#WK8] [test-3.lox] [0m[0m[33m// assignments return the assigned value[0m[0m
+[33m[tester::#WK8] [test-3.lox] [0m[0m[33m// And that the logical OR operator short-circuits[0m[0m
+[33m[tester::#WK8] [test-3.lox] [0m[0m[33m// So, if the first assignment is truthy, it[0m[0m
+[33m[tester::#WK8] [test-3.lox] [0m[0m[33m// wouldn't proceed to the subsequent assignments[0m[0m
+[33m[tester::#WK8] [test-3.lox] [0m[0m[33m// And then prints the assigned values[0m[0m
+[33m[tester::#WK8] [test-3.lox] [0m[0mvar a = "hello";[0m
+[33m[tester::#WK8] [test-3.lox] [0m[0mvar b = "hello";[0m
+[33m[tester::#WK8] [test-3.lox] [0m[0m(a = false) or (b = true) or (a = "hello");[0m
+[33m[tester::#WK8] [test-3.lox] [0m[0mprint a;[0m
+[33m[tester::#WK8] [test-3.lox] [0m[0mprint b;[0m
 [33m[tester::#WK8] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mfalse
-[33m[your_program] [0mtrue
+[33m[your_program] [0m[0mfalse[0m
+[33m[your_program] [0m[0mtrue[0m
 [33m[tester::#WK8] [test-3] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#WK8] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#WK8] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#WK8] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#WK8] [test-4.lox] [0m[33m// This program uses if conditions to get the stage[0m
-[33m[tester::#WK8] [test-4.lox] [0m[33m// of a person's life based on their age, and then[0m
-[33m[tester::#WK8] [test-4.lox] [0m[33m// prints if they are eligible for voting[0m
-[33m[tester::#WK8] [test-4.lox] [0mvar stage = "unknown";
-[33m[tester::#WK8] [test-4.lox] [0mvar age = 79;
-[33m[tester::#WK8] [test-4.lox] [0mif (age < 18) { stage = "child"; }
-[33m[tester::#WK8] [test-4.lox] [0mif (age >= 18) { stage = "adult"; }
-[33m[tester::#WK8] [test-4.lox] [0mprint stage;
-[33m[tester::#WK8] [test-4.lox] [0m
-[33m[tester::#WK8] [test-4.lox] [0mvar isAdult = age >= 18;
-[33m[tester::#WK8] [test-4.lox] [0mif (isAdult) { print "eligible for voting"; }
-[33m[tester::#WK8] [test-4.lox] [0mif (!isAdult) { print "not eligible for voting"; }
+[33m[tester::#WK8] [test-4.lox] [0m[0m[33m// This program uses if conditions to get the stage[0m[0m
+[33m[tester::#WK8] [test-4.lox] [0m[0m[33m// of a person's life based on their age, and then[0m[0m
+[33m[tester::#WK8] [test-4.lox] [0m[0m[33m// prints if they are eligible for voting[0m[0m
+[33m[tester::#WK8] [test-4.lox] [0m[0mvar stage = "unknown";[0m
+[33m[tester::#WK8] [test-4.lox] [0m[0mvar age = 79;[0m
+[33m[tester::#WK8] [test-4.lox] [0m[0mif (age < 18) { stage = "child"; }[0m
+[33m[tester::#WK8] [test-4.lox] [0m[0mif (age >= 18) { stage = "adult"; }[0m
+[33m[tester::#WK8] [test-4.lox] [0m[0mprint stage;[0m
+[33m[tester::#WK8] [test-4.lox] [0m[0m[0m
+[33m[tester::#WK8] [test-4.lox] [0m[0mvar isAdult = age >= 18;[0m
+[33m[tester::#WK8] [test-4.lox] [0m[0mif (isAdult) { print "eligible for voting"; }[0m
+[33m[tester::#WK8] [test-4.lox] [0m[0mif (!isAdult) { print "not eligible for voting"; }[0m
 [33m[tester::#WK8] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0madult
-[33m[your_program] [0meligible for voting
+[33m[your_program] [0m[0madult[0m
+[33m[your_program] [0m[0meligible for voting[0m
 [33m[tester::#WK8] [test-4] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#WK8] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#WK8] [0m[92mTest passed.[0m
@@ -374,78 +374,78 @@ Debug = true
 [33m[tester::#JX4] [0m[94mRunning tests for Stage #JX4 (jx4)[0m
 [33m[tester::#JX4] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#JX4] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#JX4] [test-1.lox] [0m[33m// The logical AND operator should return the[0m
-[33m[tester::#JX4] [test-1.lox] [0m[33m// first falsy value[0m
-[33m[tester::#JX4] [test-1.lox] [0mif (false and "bad") print "hello";
-[33m[tester::#JX4] [test-1.lox] [0mif (nil and "bad") print "hello";
-[33m[tester::#JX4] [test-1.lox] [0m
-[33m[tester::#JX4] [test-1.lox] [0m[33m// If all values are truthy, it returns the last[0m
-[33m[tester::#JX4] [test-1.lox] [0m[33m// value[0m
-[33m[tester::#JX4] [test-1.lox] [0mif (true and "baz") print "baz";
-[33m[tester::#JX4] [test-1.lox] [0mif (77 and "quz") print "quz";
-[33m[tester::#JX4] [test-1.lox] [0mif ("quz" and "quz") print "quz";
-[33m[tester::#JX4] [test-1.lox] [0mif ("" and "world") print "world";
+[33m[tester::#JX4] [test-1.lox] [0m[0m[33m// The logical AND operator should return the[0m[0m
+[33m[tester::#JX4] [test-1.lox] [0m[0m[33m// first falsy value[0m[0m
+[33m[tester::#JX4] [test-1.lox] [0m[0mif (false and "bad") print "hello";[0m
+[33m[tester::#JX4] [test-1.lox] [0m[0mif (nil and "bad") print "hello";[0m
+[33m[tester::#JX4] [test-1.lox] [0m[0m[0m
+[33m[tester::#JX4] [test-1.lox] [0m[0m[33m// If all values are truthy, it returns the last[0m[0m
+[33m[tester::#JX4] [test-1.lox] [0m[0m[33m// value[0m[0m
+[33m[tester::#JX4] [test-1.lox] [0m[0mif (true and "baz") print "baz";[0m
+[33m[tester::#JX4] [test-1.lox] [0m[0mif (77 and "quz") print "quz";[0m
+[33m[tester::#JX4] [test-1.lox] [0m[0mif ("quz" and "quz") print "quz";[0m
+[33m[tester::#JX4] [test-1.lox] [0m[0mif ("" and "world") print "world";[0m
 [33m[tester::#JX4] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mbaz
-[33m[your_program] [0mquz
-[33m[your_program] [0mquz
-[33m[your_program] [0mworld
+[33m[your_program] [0m[0mbaz[0m
+[33m[your_program] [0m[0mquz[0m
+[33m[your_program] [0m[0mquz[0m
+[33m[your_program] [0m[0mworld[0m
 [33m[tester::#JX4] [test-1] [0m[92m✓ 4 line(s) match on stdout[0m
 [33m[tester::#JX4] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#JX4] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#JX4] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#JX4] [test-2.lox] [0m[33m// This program uses the logical AND operator to[0m
-[33m[tester::#JX4] [test-2.lox] [0m[33m// print the first falsy value[0m
-[33m[tester::#JX4] [test-2.lox] [0m[33m// Or the last value if all values are truthy[0m
-[33m[tester::#JX4] [test-2.lox] [0mprint false and 1;
-[33m[tester::#JX4] [test-2.lox] [0mprint true and 1;
-[33m[tester::#JX4] [test-2.lox] [0mprint 59 and "quz" and false;
-[33m[tester::#JX4] [test-2.lox] [0m
-[33m[tester::#JX4] [test-2.lox] [0mprint 59 and true;
-[33m[tester::#JX4] [test-2.lox] [0mprint 59 and "quz" and 59;
+[33m[tester::#JX4] [test-2.lox] [0m[0m[33m// This program uses the logical AND operator to[0m[0m
+[33m[tester::#JX4] [test-2.lox] [0m[0m[33m// print the first falsy value[0m[0m
+[33m[tester::#JX4] [test-2.lox] [0m[0m[33m// Or the last value if all values are truthy[0m[0m
+[33m[tester::#JX4] [test-2.lox] [0m[0mprint false and 1;[0m
+[33m[tester::#JX4] [test-2.lox] [0m[0mprint true and 1;[0m
+[33m[tester::#JX4] [test-2.lox] [0m[0mprint 59 and "quz" and false;[0m
+[33m[tester::#JX4] [test-2.lox] [0m[0m[0m
+[33m[tester::#JX4] [test-2.lox] [0m[0mprint 59 and true;[0m
+[33m[tester::#JX4] [test-2.lox] [0m[0mprint 59 and "quz" and 59;[0m
 [33m[tester::#JX4] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mfalse
-[33m[your_program] [0m1
-[33m[your_program] [0mfalse
-[33m[your_program] [0mtrue
-[33m[your_program] [0m59
+[33m[your_program] [0m[0mfalse[0m
+[33m[your_program] [0m[0m1[0m
+[33m[your_program] [0m[0mfalse[0m
+[33m[your_program] [0m[0mtrue[0m
+[33m[your_program] [0m[0m59[0m
 [33m[tester::#JX4] [test-2] [0m[92m✓ 5 line(s) match on stdout[0m
 [33m[tester::#JX4] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#JX4] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#JX4] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#JX4] [test-3.lox] [0m[33m// This program relies on the fact that[0m
-[33m[tester::#JX4] [test-3.lox] [0m[33m// assignments return the assigned value[0m
-[33m[tester::#JX4] [test-3.lox] [0m[33m// And that the logical AND operator short-circuits[0m
-[33m[tester::#JX4] [test-3.lox] [0m[33m// So, when it encounters a falsy value, it[0m
-[33m[tester::#JX4] [test-3.lox] [0m[33m// wouldn't proceed to the subsequent assignments[0m
-[33m[tester::#JX4] [test-3.lox] [0m[33m// And then prints the assigned values[0m
-[33m[tester::#JX4] [test-3.lox] [0mvar a = "bar";
-[33m[tester::#JX4] [test-3.lox] [0mvar b = "bar";
-[33m[tester::#JX4] [test-3.lox] [0m(a = true) and (b = false) and (a = "bad");
-[33m[tester::#JX4] [test-3.lox] [0mprint a;
-[33m[tester::#JX4] [test-3.lox] [0mprint b;
+[33m[tester::#JX4] [test-3.lox] [0m[0m[33m// This program relies on the fact that[0m[0m
+[33m[tester::#JX4] [test-3.lox] [0m[0m[33m// assignments return the assigned value[0m[0m
+[33m[tester::#JX4] [test-3.lox] [0m[0m[33m// And that the logical AND operator short-circuits[0m[0m
+[33m[tester::#JX4] [test-3.lox] [0m[0m[33m// So, when it encounters a falsy value, it[0m[0m
+[33m[tester::#JX4] [test-3.lox] [0m[0m[33m// wouldn't proceed to the subsequent assignments[0m[0m
+[33m[tester::#JX4] [test-3.lox] [0m[0m[33m// And then prints the assigned values[0m[0m
+[33m[tester::#JX4] [test-3.lox] [0m[0mvar a = "bar";[0m
+[33m[tester::#JX4] [test-3.lox] [0m[0mvar b = "bar";[0m
+[33m[tester::#JX4] [test-3.lox] [0m[0m(a = true) and (b = false) and (a = "bad");[0m
+[33m[tester::#JX4] [test-3.lox] [0m[0mprint a;[0m
+[33m[tester::#JX4] [test-3.lox] [0m[0mprint b;[0m
 [33m[tester::#JX4] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mtrue
-[33m[your_program] [0mfalse
+[33m[your_program] [0m[0mtrue[0m
+[33m[your_program] [0m[0mfalse[0m
 [33m[tester::#JX4] [test-3] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#JX4] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#JX4] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#JX4] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#JX4] [test-4.lox] [0m[33m// This program uses if conditions to get the stage[0m
-[33m[tester::#JX4] [test-4.lox] [0m[33m// of a person's life based on their age, and then[0m
-[33m[tester::#JX4] [test-4.lox] [0m[33m// prints if they are eligible for voting[0m
-[33m[tester::#JX4] [test-4.lox] [0mvar stage = "unknown";
-[33m[tester::#JX4] [test-4.lox] [0mvar age = 62;
-[33m[tester::#JX4] [test-4.lox] [0mif (age < 18) { stage = "child"; }
-[33m[tester::#JX4] [test-4.lox] [0mif (age >= 18) { stage = "adult"; }
-[33m[tester::#JX4] [test-4.lox] [0mprint stage;
-[33m[tester::#JX4] [test-4.lox] [0m
-[33m[tester::#JX4] [test-4.lox] [0mvar isAdult = age >= 18;
-[33m[tester::#JX4] [test-4.lox] [0mif (isAdult) { print "eligible for voting"; }
-[33m[tester::#JX4] [test-4.lox] [0mif (!isAdult) { print "not eligible for voting"; }
+[33m[tester::#JX4] [test-4.lox] [0m[0m[33m// This program uses if conditions to get the stage[0m[0m
+[33m[tester::#JX4] [test-4.lox] [0m[0m[33m// of a person's life based on their age, and then[0m[0m
+[33m[tester::#JX4] [test-4.lox] [0m[0m[33m// prints if they are eligible for voting[0m[0m
+[33m[tester::#JX4] [test-4.lox] [0m[0mvar stage = "unknown";[0m
+[33m[tester::#JX4] [test-4.lox] [0m[0mvar age = 62;[0m
+[33m[tester::#JX4] [test-4.lox] [0m[0mif (age < 18) { stage = "child"; }[0m
+[33m[tester::#JX4] [test-4.lox] [0m[0mif (age >= 18) { stage = "adult"; }[0m
+[33m[tester::#JX4] [test-4.lox] [0m[0mprint stage;[0m
+[33m[tester::#JX4] [test-4.lox] [0m[0m[0m
+[33m[tester::#JX4] [test-4.lox] [0m[0mvar isAdult = age >= 18;[0m
+[33m[tester::#JX4] [test-4.lox] [0m[0mif (isAdult) { print "eligible for voting"; }[0m
+[33m[tester::#JX4] [test-4.lox] [0m[0mif (!isAdult) { print "not eligible for voting"; }[0m
 [33m[tester::#JX4] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0madult
-[33m[your_program] [0meligible for voting
+[33m[your_program] [0m[0madult[0m
+[33m[your_program] [0m[0meligible for voting[0m
 [33m[tester::#JX4] [test-4] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#JX4] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#JX4] [0m[92mTest passed.[0m
@@ -453,84 +453,84 @@ Debug = true
 [33m[tester::#QY3] [0m[94mRunning tests for Stage #QY3 (qy3)[0m
 [33m[tester::#QY3] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#QY3] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#QY3] [test-1.lox] [0m[33m// This program uses a while loop to print the[0m
-[33m[tester::#QY3] [test-1.lox] [0m[33m// numbers from 0 to N[0m
-[33m[tester::#QY3] [test-1.lox] [0m[33m// The assignment operation returns the assigned[0m
-[33m[tester::#QY3] [test-1.lox] [0m[33m// value[0m
-[33m[tester::#QY3] [test-1.lox] [0mvar baz = 0;
-[33m[tester::#QY3] [test-1.lox] [0mwhile (baz < 3) print baz = baz + 1;
+[33m[tester::#QY3] [test-1.lox] [0m[0m[33m// This program uses a while loop to print the[0m[0m
+[33m[tester::#QY3] [test-1.lox] [0m[0m[33m// numbers from 0 to N[0m[0m
+[33m[tester::#QY3] [test-1.lox] [0m[0m[33m// The assignment operation returns the assigned[0m[0m
+[33m[tester::#QY3] [test-1.lox] [0m[0m[33m// value[0m[0m
+[33m[tester::#QY3] [test-1.lox] [0m[0mvar baz = 0;[0m
+[33m[tester::#QY3] [test-1.lox] [0m[0mwhile (baz < 3) print baz = baz + 1;[0m
 [33m[tester::#QY3] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m1
-[33m[your_program] [0m2
-[33m[your_program] [0m3
+[33m[your_program] [0m[0m1[0m
+[33m[your_program] [0m[0m2[0m
+[33m[your_program] [0m[0m3[0m
 [33m[tester::#QY3] [test-1] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#QY3] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#QY3] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#QY3] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#QY3] [test-2.lox] [0m[33m// This program uses a while loop to print the[0m
-[33m[tester::#QY3] [test-2.lox] [0m[33m// numbers from 0 to 3[0m
-[33m[tester::#QY3] [test-2.lox] [0m[33m// The statement inside the block is executed[0m
-[33m[tester::#QY3] [test-2.lox] [0m[33m// every time the loop condition is true[0m
-[33m[tester::#QY3] [test-2.lox] [0mvar baz = 0;
-[33m[tester::#QY3] [test-2.lox] [0mwhile (baz < 3) {
-[33m[tester::#QY3] [test-2.lox] [0m  print baz;
-[33m[tester::#QY3] [test-2.lox] [0m  baz = baz + 1;
-[33m[tester::#QY3] [test-2.lox] [0m}
+[33m[tester::#QY3] [test-2.lox] [0m[0m[33m// This program uses a while loop to print the[0m[0m
+[33m[tester::#QY3] [test-2.lox] [0m[0m[33m// numbers from 0 to 3[0m[0m
+[33m[tester::#QY3] [test-2.lox] [0m[0m[33m// The statement inside the block is executed[0m[0m
+[33m[tester::#QY3] [test-2.lox] [0m[0m[33m// every time the loop condition is true[0m[0m
+[33m[tester::#QY3] [test-2.lox] [0m[0mvar baz = 0;[0m
+[33m[tester::#QY3] [test-2.lox] [0m[0mwhile (baz < 3) {[0m
+[33m[tester::#QY3] [test-2.lox] [0m[0m  print baz;[0m
+[33m[tester::#QY3] [test-2.lox] [0m[0m  baz = baz + 1;[0m
+[33m[tester::#QY3] [test-2.lox] [0m[0m}[0m
 [33m[tester::#QY3] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m0
-[33m[your_program] [0m1
-[33m[your_program] [0m2
+[33m[your_program] [0m[0m0[0m
+[33m[your_program] [0m[0m1[0m
+[33m[your_program] [0m[0m2[0m
 [33m[tester::#QY3] [test-2] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#QY3] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#QY3] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#QY3] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#QY3] [test-3.lox] [0m[33m// This program uses a while loop to calculate the[0m
-[33m[tester::#QY3] [test-3.lox] [0m[33m// factorial of 5[0m
-[33m[tester::#QY3] [test-3.lox] [0m[33m// The first while loop never runs because the[0m
-[33m[tester::#QY3] [test-3.lox] [0m[33m// condition is false[0m
-[33m[tester::#QY3] [test-3.lox] [0mwhile (false) { print "should not print"; }
-[33m[tester::#QY3] [test-3.lox] [0m
-[33m[tester::#QY3] [test-3.lox] [0mvar product = 1;
-[33m[tester::#QY3] [test-3.lox] [0mvar i = 1;
-[33m[tester::#QY3] [test-3.lox] [0m
-[33m[tester::#QY3] [test-3.lox] [0mwhile (i <= 5) {
-[33m[tester::#QY3] [test-3.lox] [0m  product = product * i;
-[33m[tester::#QY3] [test-3.lox] [0m  i = i + 1;
-[33m[tester::#QY3] [test-3.lox] [0m}
-[33m[tester::#QY3] [test-3.lox] [0m
-[33m[tester::#QY3] [test-3.lox] [0mprint "Factorial of 5: "; print product;
+[33m[tester::#QY3] [test-3.lox] [0m[0m[33m// This program uses a while loop to calculate the[0m[0m
+[33m[tester::#QY3] [test-3.lox] [0m[0m[33m// factorial of 5[0m[0m
+[33m[tester::#QY3] [test-3.lox] [0m[0m[33m// The first while loop never runs because the[0m[0m
+[33m[tester::#QY3] [test-3.lox] [0m[0m[33m// condition is false[0m[0m
+[33m[tester::#QY3] [test-3.lox] [0m[0mwhile (false) { print "should not print"; }[0m
+[33m[tester::#QY3] [test-3.lox] [0m[0m[0m
+[33m[tester::#QY3] [test-3.lox] [0m[0mvar product = 1;[0m
+[33m[tester::#QY3] [test-3.lox] [0m[0mvar i = 1;[0m
+[33m[tester::#QY3] [test-3.lox] [0m[0m[0m
+[33m[tester::#QY3] [test-3.lox] [0m[0mwhile (i <= 5) {[0m
+[33m[tester::#QY3] [test-3.lox] [0m[0m  product = product * i;[0m
+[33m[tester::#QY3] [test-3.lox] [0m[0m  i = i + 1;[0m
+[33m[tester::#QY3] [test-3.lox] [0m[0m}[0m
+[33m[tester::#QY3] [test-3.lox] [0m[0m[0m
+[33m[tester::#QY3] [test-3.lox] [0m[0mprint "Factorial of 5: "; print product;[0m
 [33m[tester::#QY3] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mFactorial of 5: 
-[33m[your_program] [0m120
+[33m[your_program] [0m[0mFactorial of 5: [0m
+[33m[your_program] [0m[0m120[0m
 [33m[tester::#QY3] [test-3] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#QY3] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#QY3] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#QY3] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#QY3] [test-4.lox] [0m[33m// This program uses a while loop to generate and[0m
-[33m[tester::#QY3] [test-4.lox] [0m[33m// print the first N Fibonacci numbers[0m
-[33m[tester::#QY3] [test-4.lox] [0mvar n = 10;
-[33m[tester::#QY3] [test-4.lox] [0mvar fm = 0;
-[33m[tester::#QY3] [test-4.lox] [0mvar fn = 1;
-[33m[tester::#QY3] [test-4.lox] [0mvar index = 0;
-[33m[tester::#QY3] [test-4.lox] [0m
-[33m[tester::#QY3] [test-4.lox] [0mwhile (index < n) {
-[33m[tester::#QY3] [test-4.lox] [0m    print fm;
-[33m[tester::#QY3] [test-4.lox] [0m    var temp = fm;
-[33m[tester::#QY3] [test-4.lox] [0m    fm = fn;
-[33m[tester::#QY3] [test-4.lox] [0m    fn = temp + fn;
-[33m[tester::#QY3] [test-4.lox] [0m    index = index + 1;
-[33m[tester::#QY3] [test-4.lox] [0m}
+[33m[tester::#QY3] [test-4.lox] [0m[0m[33m// This program uses a while loop to generate and[0m[0m
+[33m[tester::#QY3] [test-4.lox] [0m[0m[33m// print the first N Fibonacci numbers[0m[0m
+[33m[tester::#QY3] [test-4.lox] [0m[0mvar n = 10;[0m
+[33m[tester::#QY3] [test-4.lox] [0m[0mvar fm = 0;[0m
+[33m[tester::#QY3] [test-4.lox] [0m[0mvar fn = 1;[0m
+[33m[tester::#QY3] [test-4.lox] [0m[0mvar index = 0;[0m
+[33m[tester::#QY3] [test-4.lox] [0m[0m[0m
+[33m[tester::#QY3] [test-4.lox] [0m[0mwhile (index < n) {[0m
+[33m[tester::#QY3] [test-4.lox] [0m[0m    print fm;[0m
+[33m[tester::#QY3] [test-4.lox] [0m[0m    var temp = fm;[0m
+[33m[tester::#QY3] [test-4.lox] [0m[0m    fm = fn;[0m
+[33m[tester::#QY3] [test-4.lox] [0m[0m    fn = temp + fn;[0m
+[33m[tester::#QY3] [test-4.lox] [0m[0m    index = index + 1;[0m
+[33m[tester::#QY3] [test-4.lox] [0m[0m}[0m
 [33m[tester::#QY3] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m0
-[33m[your_program] [0m1
-[33m[your_program] [0m1
-[33m[your_program] [0m2
-[33m[your_program] [0m3
-[33m[your_program] [0m5
-[33m[your_program] [0m8
-[33m[your_program] [0m13
-[33m[your_program] [0m21
-[33m[your_program] [0m34
+[33m[your_program] [0m[0m0[0m
+[33m[your_program] [0m[0m1[0m
+[33m[your_program] [0m[0m1[0m
+[33m[your_program] [0m[0m2[0m
+[33m[your_program] [0m[0m3[0m
+[33m[your_program] [0m[0m5[0m
+[33m[your_program] [0m[0m8[0m
+[33m[your_program] [0m[0m13[0m
+[33m[your_program] [0m[0m21[0m
+[33m[your_program] [0m[0m34[0m
 [33m[tester::#QY3] [test-4] [0m[92m✓ 10 line(s) match on stdout[0m
 [33m[tester::#QY3] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#QY3] [0m[92mTest passed.[0m
@@ -538,83 +538,83 @@ Debug = true
 [33m[tester::#BW6] [0m[94mRunning tests for Stage #BW6 (bw6)[0m
 [33m[tester::#BW6] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#BW6] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#BW6] [test-1.lox] [0m[33m// This program uses a for loop to print the[0m
-[33m[tester::#BW6] [test-1.lox] [0m[33m// numbers from 0 to 3[0m
-[33m[tester::#BW6] [test-1.lox] [0m[33m// The assignment operation returns the assigned[0m
-[33m[tester::#BW6] [test-1.lox] [0m[33m// value[0m
-[33m[tester::#BW6] [test-1.lox] [0mfor (var foo = 0; foo < 3;) print foo = foo + 1;
+[33m[tester::#BW6] [test-1.lox] [0m[0m[33m// This program uses a for loop to print the[0m[0m
+[33m[tester::#BW6] [test-1.lox] [0m[0m[33m// numbers from 0 to 3[0m[0m
+[33m[tester::#BW6] [test-1.lox] [0m[0m[33m// The assignment operation returns the assigned[0m[0m
+[33m[tester::#BW6] [test-1.lox] [0m[0m[33m// value[0m[0m
+[33m[tester::#BW6] [test-1.lox] [0m[0mfor (var foo = 0; foo < 3;) print foo = foo + 1;[0m
 [33m[tester::#BW6] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m1
-[33m[your_program] [0m2
-[33m[your_program] [0m3
+[33m[your_program] [0m[0m1[0m
+[33m[your_program] [0m[0m2[0m
+[33m[your_program] [0m[0m3[0m
 [33m[tester::#BW6] [test-1] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#BW6] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#BW6] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#BW6] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#BW6] [test-2.lox] [0m[33m// This program uses a for loop to print the[0m
-[33m[tester::#BW6] [test-2.lox] [0m[33m// numbers from 0 to 3[0m
-[33m[tester::#BW6] [test-2.lox] [0mfor (var bar = 0; bar < 3; bar = bar + 1) {
-[33m[tester::#BW6] [test-2.lox] [0m  print bar;
-[33m[tester::#BW6] [test-2.lox] [0m}
+[33m[tester::#BW6] [test-2.lox] [0m[0m[33m// This program uses a for loop to print the[0m[0m
+[33m[tester::#BW6] [test-2.lox] [0m[0m[33m// numbers from 0 to 3[0m[0m
+[33m[tester::#BW6] [test-2.lox] [0m[0mfor (var bar = 0; bar < 3; bar = bar + 1) {[0m
+[33m[tester::#BW6] [test-2.lox] [0m[0m  print bar;[0m
+[33m[tester::#BW6] [test-2.lox] [0m[0m}[0m
 [33m[tester::#BW6] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m0
-[33m[your_program] [0m1
-[33m[your_program] [0m2
+[33m[your_program] [0m[0m0[0m
+[33m[your_program] [0m[0m1[0m
+[33m[your_program] [0m[0m2[0m
 [33m[tester::#BW6] [test-2] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#BW6] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#BW6] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#BW6] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#BW6] [test-3.lox] [0m[33m// This program uses a for loop to print the[0m
-[33m[tester::#BW6] [test-3.lox] [0m[33m// numbers from 0 to 2[0m
-[33m[tester::#BW6] [test-3.lox] [0m[33m// The loop initializer is ignored in this loop[0m
-[33m[tester::#BW6] [test-3.lox] [0mvar baz = 0;
-[33m[tester::#BW6] [test-3.lox] [0mfor (; baz < 2; baz = baz + 1) print baz;
-[33m[tester::#BW6] [test-3.lox] [0m
-[33m[tester::#BW6] [test-3.lox] [0m[33m// This program uses a for loop to print the[0m
-[33m[tester::#BW6] [test-3.lox] [0m[33m// numbers from 0 to 2[0m
-[33m[tester::#BW6] [test-3.lox] [0m[33m// The loop increment clause is ignored in this[0m
-[33m[tester::#BW6] [test-3.lox] [0m[33m// loop[0m
-[33m[tester::#BW6] [test-3.lox] [0mfor (var bar = 0; bar < 2;) {
-[33m[tester::#BW6] [test-3.lox] [0m  print bar;
-[33m[tester::#BW6] [test-3.lox] [0m  bar = bar + 1;
-[33m[tester::#BW6] [test-3.lox] [0m}
+[33m[tester::#BW6] [test-3.lox] [0m[0m[33m// This program uses a for loop to print the[0m[0m
+[33m[tester::#BW6] [test-3.lox] [0m[0m[33m// numbers from 0 to 2[0m[0m
+[33m[tester::#BW6] [test-3.lox] [0m[0m[33m// The loop initializer is ignored in this loop[0m[0m
+[33m[tester::#BW6] [test-3.lox] [0m[0mvar baz = 0;[0m
+[33m[tester::#BW6] [test-3.lox] [0m[0mfor (; baz < 2; baz = baz + 1) print baz;[0m
+[33m[tester::#BW6] [test-3.lox] [0m[0m[0m
+[33m[tester::#BW6] [test-3.lox] [0m[0m[33m// This program uses a for loop to print the[0m[0m
+[33m[tester::#BW6] [test-3.lox] [0m[0m[33m// numbers from 0 to 2[0m[0m
+[33m[tester::#BW6] [test-3.lox] [0m[0m[33m// The loop increment clause is ignored in this[0m[0m
+[33m[tester::#BW6] [test-3.lox] [0m[0m[33m// loop[0m[0m
+[33m[tester::#BW6] [test-3.lox] [0m[0mfor (var bar = 0; bar < 2;) {[0m
+[33m[tester::#BW6] [test-3.lox] [0m[0m  print bar;[0m
+[33m[tester::#BW6] [test-3.lox] [0m[0m  bar = bar + 1;[0m
+[33m[tester::#BW6] [test-3.lox] [0m[0m}[0m
 [33m[tester::#BW6] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m0
-[33m[your_program] [0m1
-[33m[your_program] [0m0
-[33m[your_program] [0m1
+[33m[your_program] [0m[0m0[0m
+[33m[your_program] [0m[0m1[0m
+[33m[your_program] [0m[0m0[0m
+[33m[your_program] [0m[0m1[0m
 [33m[tester::#BW6] [test-3] [0m[92m✓ 4 line(s) match on stdout[0m
 [33m[tester::#BW6] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#BW6] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#BW6] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#BW6] [test-4.lox] [0m[33m// This program uses for loops and block scopes[0m
-[33m[tester::#BW6] [test-4.lox] [0m[33m// to print the updates to the same variable[0m
-[33m[tester::#BW6] [test-4.lox] [0mvar baz = "after";
-[33m[tester::#BW6] [test-4.lox] [0m{
-[33m[tester::#BW6] [test-4.lox] [0m  var baz = "before";
-[33m[tester::#BW6] [test-4.lox] [0m
-[33m[tester::#BW6] [test-4.lox] [0m  for (var baz = 0; baz < 1; baz = baz + 1) {
-[33m[tester::#BW6] [test-4.lox] [0m    print baz;
-[33m[tester::#BW6] [test-4.lox] [0m    var baz = -1;
-[33m[tester::#BW6] [test-4.lox] [0m    print baz;
-[33m[tester::#BW6] [test-4.lox] [0m  }
-[33m[tester::#BW6] [test-4.lox] [0m}
-[33m[tester::#BW6] [test-4.lox] [0m
-[33m[tester::#BW6] [test-4.lox] [0m{
-[33m[tester::#BW6] [test-4.lox] [0m  for (var baz = 0; baz > 0; baz = baz + 1) {}
-[33m[tester::#BW6] [test-4.lox] [0m
-[33m[tester::#BW6] [test-4.lox] [0m  var baz = "after";
-[33m[tester::#BW6] [test-4.lox] [0m  print baz;
-[33m[tester::#BW6] [test-4.lox] [0m
-[33m[tester::#BW6] [test-4.lox] [0m  for (baz = 0; baz < 1; baz = baz + 1) {
-[33m[tester::#BW6] [test-4.lox] [0m    print baz;
-[33m[tester::#BW6] [test-4.lox] [0m  }
-[33m[tester::#BW6] [test-4.lox] [0m}
+[33m[tester::#BW6] [test-4.lox] [0m[0m[33m// This program uses for loops and block scopes[0m[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m[33m// to print the updates to the same variable[0m[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0mvar baz = "after";[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m{[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m  var baz = "before";[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m  for (var baz = 0; baz < 1; baz = baz + 1) {[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m    print baz;[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m    var baz = -1;[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m    print baz;[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m}[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m{[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m  for (var baz = 0; baz > 0; baz = baz + 1) {}[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m  var baz = "after";[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m  print baz;[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m  for (baz = 0; baz < 1; baz = baz + 1) {[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m    print baz;[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m}[0m
 [33m[tester::#BW6] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m0
-[33m[your_program] [0m-1
-[33m[your_program] [0mafter
-[33m[your_program] [0m0
+[33m[your_program] [0m[0m0[0m
+[33m[your_program] [0m[0m-1[0m
+[33m[your_program] [0m[0mafter[0m
+[33m[your_program] [0m[0m0[0m
 [33m[tester::#BW6] [test-4] [0m[92m✓ 4 line(s) match on stdout[0m
 [33m[tester::#BW6] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#BW6] [0m[92mTest passed.[0m
@@ -622,41 +622,41 @@ Debug = true
 [33m[tester::#VT1] [0m[94mRunning tests for Stage #VT1 (vt1)[0m
 [33m[tester::#VT1] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#VT1] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#VT1] [test-1.lox] [0m[33m// This program would give a compile error[0m
-[33m[tester::#VT1] [test-1.lox] [0m[33m// because the variable declaration is not[0m
-[33m[tester::#VT1] [test-1.lox] [0m[33m// inside a block[0m
-[33m[tester::#VT1] [test-1.lox] [0mfor (;;) var foo;
+[33m[tester::#VT1] [test-1.lox] [0m[0m[33m// This program would give a compile error[0m[0m
+[33m[tester::#VT1] [test-1.lox] [0m[0m[33m// because the variable declaration is not[0m[0m
+[33m[tester::#VT1] [test-1.lox] [0m[0m[33m// inside a block[0m[0m
+[33m[tester::#VT1] [test-1.lox] [0m[0mfor (;;) var foo;[0m
 [33m[tester::#VT1] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 4] Error at 'var': Expect expression.
+[33m[your_program] [0m[0m[line 4] Error at 'var': Expect expression.[0m
 [33m[tester::#VT1] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#VT1] [test-1] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#VT1] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#VT1] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#VT1] [test-2.lox] [0m[33m// This program would give a compile error[0m
-[33m[tester::#VT1] [test-2.lox] [0m[33m// because the condition is not valid[0m
-[33m[tester::#VT1] [test-2.lox] [0mfor (var a = 1; {}; a = a + 1) {}
+[33m[tester::#VT1] [test-2.lox] [0m[0m[33m// This program would give a compile error[0m[0m
+[33m[tester::#VT1] [test-2.lox] [0m[0m[33m// because the condition is not valid[0m[0m
+[33m[tester::#VT1] [test-2.lox] [0m[0mfor (var a = 1; {}; a = a + 1) {}[0m
 [33m[tester::#VT1] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 3] Error at '{': Expect expression.
-[33m[your_program] [0m[line 3] Error at ')': Expect ';' after expression.
+[33m[your_program] [0m[0m[line 3] Error at '{': Expect expression.[0m
+[33m[your_program] [0m[0m[line 3] Error at ')': Expect ';' after expression.[0m
 [33m[tester::#VT1] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#VT1] [test-2] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#VT1] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#VT1] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#VT1] [test-3.lox] [0m[33m// This program would give a compile error[0m
-[33m[tester::#VT1] [test-3.lox] [0m[33m// because the increment clause is not valid[0m
-[33m[tester::#VT1] [test-3.lox] [0mfor (var a = 1; a < 2; {}) {}
+[33m[tester::#VT1] [test-3.lox] [0m[0m[33m// This program would give a compile error[0m[0m
+[33m[tester::#VT1] [test-3.lox] [0m[0m[33m// because the increment clause is not valid[0m[0m
+[33m[tester::#VT1] [test-3.lox] [0m[0mfor (var a = 1; a < 2; {}) {}[0m
 [33m[tester::#VT1] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 3] Error at '{': Expect expression.
+[33m[your_program] [0m[0m[line 3] Error at '{': Expect expression.[0m
 [33m[tester::#VT1] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#VT1] [test-3] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#VT1] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#VT1] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#VT1] [test-4.lox] [0m[33m// This program would give a compile error[0m
-[33m[tester::#VT1] [test-4.lox] [0m[33m// because the initialization clause is not valid[0m
-[33m[tester::#VT1] [test-4.lox] [0mfor ({}; a < 2; a = a + 1) {}
+[33m[tester::#VT1] [test-4.lox] [0m[0m[33m// This program would give a compile error[0m[0m
+[33m[tester::#VT1] [test-4.lox] [0m[0m[33m// because the initialization clause is not valid[0m[0m
+[33m[tester::#VT1] [test-4.lox] [0m[0mfor ({}; a < 2; a = a + 1) {}[0m
 [33m[tester::#VT1] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 3] Error at '{': Expect expression.
-[33m[your_program] [0m[line 3] Error at ')': Expect ';' after expression.
+[33m[your_program] [0m[0m[line 3] Error at '{': Expect expression.[0m
+[33m[your_program] [0m[0m[line 3] Error at ')': Expect ';' after expression.[0m
 [33m[tester::#VT1] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#VT1] [test-4] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#VT1] [0m[92mTest passed.[0m

--- a/internal/test_helpers/fixtures/pass_control_flow_final
+++ b/internal/test_helpers/fixtures/pass_control_flow_final
@@ -3,54 +3,54 @@ Debug = true
 [33m[tester::#NE3] [0m[94mRunning tests for Stage #NE3 (ne3)[0m
 [33m[tester::#NE3] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#NE3] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#NE3] [test-1.lox] [0m[33m// This should print the string if the condition[0m
-[33m[tester::#NE3] [test-1.lox] [0m[33m// evaluates to True[0m
-[33m[tester::#NE3] [test-1.lox] [0mif (false) print "foo";
+[33m[tester::#NE3] [test-1.lox] [0m[0m[33m// This should print the string if the condition[0m[0m
+[33m[tester::#NE3] [test-1.lox] [0m[0m[33m// evaluates to True[0m[0m
+[33m[tester::#NE3] [test-1.lox] [0m[0mif (false) print "foo";[0m
 [33m[tester::#NE3] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
 [33m[tester::#NE3] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#NE3] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#NE3] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#NE3] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#NE3] [test-2.lox] [0m[33m// This should print "block body" if the condition[0m
-[33m[tester::#NE3] [test-2.lox] [0m[33m// evaluates to True[0m
-[33m[tester::#NE3] [test-2.lox] [0mif (false) {
-[33m[tester::#NE3] [test-2.lox] [0m  print "block body";
-[33m[tester::#NE3] [test-2.lox] [0m}
+[33m[tester::#NE3] [test-2.lox] [0m[0m[33m// This should print "block body" if the condition[0m[0m
+[33m[tester::#NE3] [test-2.lox] [0m[0m[33m// evaluates to True[0m[0m
+[33m[tester::#NE3] [test-2.lox] [0m[0mif (false) {[0m
+[33m[tester::#NE3] [test-2.lox] [0m[0m  print "block body";[0m
+[33m[tester::#NE3] [test-2.lox] [0m[0m}[0m
 [33m[tester::#NE3] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
 [33m[tester::#NE3] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#NE3] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#NE3] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#NE3] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#NE3] [test-3.lox] [0m[33m// This program tests whether the assignment[0m
-[33m[tester::#NE3] [test-3.lox] [0m[33m// operation returns the value assigned.[0m
-[33m[tester::#NE3] [test-3.lox] [0m[33m// The if condition should evaluate to true and[0m
-[33m[tester::#NE3] [test-3.lox] [0m[33m// the inner boolean expression must be printed.[0m
-[33m[tester::#NE3] [test-3.lox] [0m[33m// So, in this case the if condition evaluates to[0m
-[33m[tester::#NE3] [test-3.lox] [0m[33m//true and prints the inner boolean expression[0m
-[33m[tester::#NE3] [test-3.lox] [0mvar a = false;
-[33m[tester::#NE3] [test-3.lox] [0mif (a = true) {
-[33m[tester::#NE3] [test-3.lox] [0m  print (a == true);
-[33m[tester::#NE3] [test-3.lox] [0m}
+[33m[tester::#NE3] [test-3.lox] [0m[0m[33m// This program tests whether the assignment[0m[0m
+[33m[tester::#NE3] [test-3.lox] [0m[0m[33m// operation returns the value assigned.[0m[0m
+[33m[tester::#NE3] [test-3.lox] [0m[0m[33m// The if condition should evaluate to true and[0m[0m
+[33m[tester::#NE3] [test-3.lox] [0m[0m[33m// the inner boolean expression must be printed.[0m[0m
+[33m[tester::#NE3] [test-3.lox] [0m[0m[33m// So, in this case the if condition evaluates to[0m[0m
+[33m[tester::#NE3] [test-3.lox] [0m[0m[33m//true and prints the inner boolean expression[0m[0m
+[33m[tester::#NE3] [test-3.lox] [0m[0mvar a = false;[0m
+[33m[tester::#NE3] [test-3.lox] [0m[0mif (a = true) {[0m
+[33m[tester::#NE3] [test-3.lox] [0m[0m  print (a == true);[0m
+[33m[tester::#NE3] [test-3.lox] [0m[0m}[0m
 [33m[tester::#NE3] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mtrue
+[33m[your_program] [0m[0mtrue[0m
 [33m[tester::#NE3] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#NE3] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#NE3] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#NE3] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#NE3] [test-4.lox] [0m[33m// This program should print a different string[0m
-[33m[tester::#NE3] [test-4.lox] [0m[33m// based on the value of age[0m
-[33m[tester::#NE3] [test-4.lox] [0mvar stage = "unknown";
-[33m[tester::#NE3] [test-4.lox] [0mvar age = 73;
-[33m[tester::#NE3] [test-4.lox] [0mif (age < 18) { stage = "child"; }
-[33m[tester::#NE3] [test-4.lox] [0mif (age >= 18) { stage = "adult"; }
-[33m[tester::#NE3] [test-4.lox] [0mprint stage;
-[33m[tester::#NE3] [test-4.lox] [0m
-[33m[tester::#NE3] [test-4.lox] [0mvar isAdult = age >= 18;
-[33m[tester::#NE3] [test-4.lox] [0mif (isAdult) { print "eligible for voting"; }
-[33m[tester::#NE3] [test-4.lox] [0mif (!isAdult) { print "not eligible for voting"; }
+[33m[tester::#NE3] [test-4.lox] [0m[0m[33m// This program should print a different string[0m[0m
+[33m[tester::#NE3] [test-4.lox] [0m[0m[33m// based on the value of age[0m[0m
+[33m[tester::#NE3] [test-4.lox] [0m[0mvar stage = "unknown";[0m
+[33m[tester::#NE3] [test-4.lox] [0m[0mvar age = 73;[0m
+[33m[tester::#NE3] [test-4.lox] [0m[0mif (age < 18) { stage = "child"; }[0m
+[33m[tester::#NE3] [test-4.lox] [0m[0mif (age >= 18) { stage = "adult"; }[0m
+[33m[tester::#NE3] [test-4.lox] [0m[0mprint stage;[0m
+[33m[tester::#NE3] [test-4.lox] [0m[0m[0m
+[33m[tester::#NE3] [test-4.lox] [0m[0mvar isAdult = age >= 18;[0m
+[33m[tester::#NE3] [test-4.lox] [0m[0mif (isAdult) { print "eligible for voting"; }[0m
+[33m[tester::#NE3] [test-4.lox] [0m[0mif (!isAdult) { print "not eligible for voting"; }[0m
 [33m[tester::#NE3] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0madult
-[33m[your_program] [0meligible for voting
+[33m[your_program] [0m[0madult[0m
+[33m[your_program] [0m[0meligible for voting[0m
 [33m[tester::#NE3] [test-4] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#NE3] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#NE3] [0m[92mTest passed.[0m
@@ -58,71 +58,71 @@ Debug = true
 [33m[tester::#ST5] [0m[94mRunning tests for Stage #ST5 (st5)[0m
 [33m[tester::#ST5] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#ST5] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#ST5] [test-1.lox] [0m[33m// This program uses a random boolean to decide[0m
-[33m[tester::#ST5] [test-1.lox] [0m[33m// which branch to execute,[0m
-[33m[tester::#ST5] [test-1.lox] [0m[33m// and then prints the appropriate string[0m
-[33m[tester::#ST5] [test-1.lox] [0mif (true) print "if"; else print "else";
+[33m[tester::#ST5] [test-1.lox] [0m[0m[33m// This program uses a random boolean to decide[0m[0m
+[33m[tester::#ST5] [test-1.lox] [0m[0m[33m// which branch to execute,[0m[0m
+[33m[tester::#ST5] [test-1.lox] [0m[0m[33m// and then prints the appropriate string[0m[0m
+[33m[tester::#ST5] [test-1.lox] [0m[0mif (true) print "if"; else print "else";[0m
 [33m[tester::#ST5] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mif
+[33m[your_program] [0m[0mif[0m
 [33m[tester::#ST5] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#ST5] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#ST5] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#ST5] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#ST5] [test-2.lox] [0m[33m// This program initializes age with a random[0m
-[33m[tester::#ST5] [test-2.lox] [0m[33m// integer and then prints "adult"[0m
-[33m[tester::#ST5] [test-2.lox] [0m[33m// if the age is greater than 18, otherwise it[0m
-[33m[tester::#ST5] [test-2.lox] [0m[33m// prints "child"[0m
-[33m[tester::#ST5] [test-2.lox] [0mvar age = 64;
-[33m[tester::#ST5] [test-2.lox] [0mif (age > 18) print "adult"; else print "child";
+[33m[tester::#ST5] [test-2.lox] [0m[0m[33m// This program initializes age with a random[0m[0m
+[33m[tester::#ST5] [test-2.lox] [0m[0m[33m// integer and then prints "adult"[0m[0m
+[33m[tester::#ST5] [test-2.lox] [0m[0m[33m// if the age is greater than 18, otherwise it[0m[0m
+[33m[tester::#ST5] [test-2.lox] [0m[0m[33m// prints "child"[0m[0m
+[33m[tester::#ST5] [test-2.lox] [0m[0mvar age = 64;[0m
+[33m[tester::#ST5] [test-2.lox] [0m[0mif (age > 18) print "adult"; else print "child";[0m
 [33m[tester::#ST5] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0madult
+[33m[your_program] [0m[0madult[0m
 [33m[tester::#ST5] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#ST5] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#ST5] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#ST5] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#ST5] [test-3.lox] [0m[33m// This program uses a random boolean to decide[0m
-[33m[tester::#ST5] [test-3.lox] [0m[33m// which branch to execute,[0m
-[33m[tester::#ST5] [test-3.lox] [0m[33m// and then prints the appropriate string[0m
-[33m[tester::#ST5] [test-3.lox] [0mif (false) {
-[33m[tester::#ST5] [test-3.lox] [0m  print "if block";
-[33m[tester::#ST5] [test-3.lox] [0m} else print "else statement";
-[33m[tester::#ST5] [test-3.lox] [0m
-[33m[tester::#ST5] [test-3.lox] [0mif (false) print "if statement"; else {
-[33m[tester::#ST5] [test-3.lox] [0m  print "else block";
-[33m[tester::#ST5] [test-3.lox] [0m}
+[33m[tester::#ST5] [test-3.lox] [0m[0m[33m// This program uses a random boolean to decide[0m[0m
+[33m[tester::#ST5] [test-3.lox] [0m[0m[33m// which branch to execute,[0m[0m
+[33m[tester::#ST5] [test-3.lox] [0m[0m[33m// and then prints the appropriate string[0m[0m
+[33m[tester::#ST5] [test-3.lox] [0m[0mif (false) {[0m
+[33m[tester::#ST5] [test-3.lox] [0m[0m  print "if block";[0m
+[33m[tester::#ST5] [test-3.lox] [0m[0m} else print "else statement";[0m
+[33m[tester::#ST5] [test-3.lox] [0m[0m[0m
+[33m[tester::#ST5] [test-3.lox] [0m[0mif (false) print "if statement"; else {[0m
+[33m[tester::#ST5] [test-3.lox] [0m[0m  print "else block";[0m
+[33m[tester::#ST5] [test-3.lox] [0m[0m}[0m
 [33m[tester::#ST5] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0melse statement
-[33m[your_program] [0melse block
+[33m[your_program] [0m[0melse statement[0m
+[33m[your_program] [0m[0melse block[0m
 [33m[tester::#ST5] [test-3] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#ST5] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#ST5] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#ST5] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#ST5] [test-4.lox] [0m[33m// This program converts a random integer from[0m
-[33m[tester::#ST5] [test-4.lox] [0m[33m// Celsius to Fahrenheit[0m
-[33m[tester::#ST5] [test-4.lox] [0m[33m// and prints the result. It also prints a message[0m
-[33m[tester::#ST5] [test-4.lox] [0m[33m// based on the temperature.[0m
-[33m[tester::#ST5] [test-4.lox] [0mvar celsius = 82;
-[33m[tester::#ST5] [test-4.lox] [0mvar fahrenheit = 0;
-[33m[tester::#ST5] [test-4.lox] [0mvar isHot = false;
-[33m[tester::#ST5] [test-4.lox] [0m
-[33m[tester::#ST5] [test-4.lox] [0m{
-[33m[tester::#ST5] [test-4.lox] [0m  fahrenheit = celsius * 9 / 5 + 32;
-[33m[tester::#ST5] [test-4.lox] [0m  print celsius; print fahrenheit;
-[33m[tester::#ST5] [test-4.lox] [0m
-[33m[tester::#ST5] [test-4.lox] [0m  if (celsius > 30) {
-[33m[tester::#ST5] [test-4.lox] [0m    isHot = true;
-[33m[tester::#ST5] [test-4.lox] [0m    print "It's a hot day. Stay hydrated!";
-[33m[tester::#ST5] [test-4.lox] [0m  } else {
-[33m[tester::#ST5] [test-4.lox] [0m    print "It's cold today. Wear a jacket!";
-[33m[tester::#ST5] [test-4.lox] [0m  }
-[33m[tester::#ST5] [test-4.lox] [0m
-[33m[tester::#ST5] [test-4.lox] [0m  if (isHot) { print "Use sunscreen!"; }
-[33m[tester::#ST5] [test-4.lox] [0m}
+[33m[tester::#ST5] [test-4.lox] [0m[0m[33m// This program converts a random integer from[0m[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0m[33m// Celsius to Fahrenheit[0m[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0m[33m// and prints the result. It also prints a message[0m[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0m[33m// based on the temperature.[0m[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0mvar celsius = 82;[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0mvar fahrenheit = 0;[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0mvar isHot = false;[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0m[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0m{[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0m  fahrenheit = celsius * 9 / 5 + 32;[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0m  print celsius; print fahrenheit;[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0m[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0m  if (celsius > 30) {[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0m    isHot = true;[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0m    print "It's a hot day. Stay hydrated!";[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0m  } else {[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0m    print "It's cold today. Wear a jacket!";[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0m[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0m  if (isHot) { print "Use sunscreen!"; }[0m
+[33m[tester::#ST5] [test-4.lox] [0m[0m}[0m
 [33m[tester::#ST5] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m82
-[33m[your_program] [0m179.6
-[33m[your_program] [0mIt's a hot day. Stay hydrated!
-[33m[your_program] [0mUse sunscreen!
+[33m[your_program] [0m[0m82[0m
+[33m[your_program] [0m[0m179.6[0m
+[33m[your_program] [0m[0mIt's a hot day. Stay hydrated![0m
+[33m[your_program] [0m[0mUse sunscreen![0m
 [33m[tester::#ST5] [test-4] [0m[92m✓ 4 line(s) match on stdout[0m
 [33m[tester::#ST5] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#ST5] [0m[92mTest passed.[0m
@@ -130,67 +130,67 @@ Debug = true
 [33m[tester::#FH8] [0m[94mRunning tests for Stage #FH8 (fh8)[0m
 [33m[tester::#FH8] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#FH8] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#FH8] [test-1.lox] [0m[33m// This program uses a random boolean to decide[0m
-[33m[tester::#FH8] [test-1.lox] [0m[33m// which branch to execute,[0m
-[33m[tester::#FH8] [test-1.lox] [0m[33m// and then prints the appropriate string[0m
-[33m[tester::#FH8] [test-1.lox] [0mif (false) print "if branch";
-[33m[tester::#FH8] [test-1.lox] [0melse if (false) print "else-if branch";
+[33m[tester::#FH8] [test-1.lox] [0m[0m[33m// This program uses a random boolean to decide[0m[0m
+[33m[tester::#FH8] [test-1.lox] [0m[0m[33m// which branch to execute,[0m[0m
+[33m[tester::#FH8] [test-1.lox] [0m[0m[33m// and then prints the appropriate string[0m[0m
+[33m[tester::#FH8] [test-1.lox] [0m[0mif (false) print "if branch";[0m
+[33m[tester::#FH8] [test-1.lox] [0m[0melse if (false) print "else-if branch";[0m
 [33m[tester::#FH8] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
 [33m[tester::#FH8] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#FH8] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#FH8] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#FH8] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#FH8] [test-2.lox] [0m[33m// This program uses a random boolean to decide[0m
-[33m[tester::#FH8] [test-2.lox] [0m[33m// which branch to execute,[0m
-[33m[tester::#FH8] [test-2.lox] [0m[33m// and then prints the appropriate string[0m
-[33m[tester::#FH8] [test-2.lox] [0mif (false) {
-[33m[tester::#FH8] [test-2.lox] [0m  print "bar";
-[33m[tester::#FH8] [test-2.lox] [0m} else if (false) print "bar";
-[33m[tester::#FH8] [test-2.lox] [0m
-[33m[tester::#FH8] [test-2.lox] [0mif (false) print "bar"; else if (false) {
-[33m[tester::#FH8] [test-2.lox] [0m  print "bar";
-[33m[tester::#FH8] [test-2.lox] [0m}
+[33m[tester::#FH8] [test-2.lox] [0m[0m[33m// This program uses a random boolean to decide[0m[0m
+[33m[tester::#FH8] [test-2.lox] [0m[0m[33m// which branch to execute,[0m[0m
+[33m[tester::#FH8] [test-2.lox] [0m[0m[33m// and then prints the appropriate string[0m[0m
+[33m[tester::#FH8] [test-2.lox] [0m[0mif (false) {[0m
+[33m[tester::#FH8] [test-2.lox] [0m[0m  print "bar";[0m
+[33m[tester::#FH8] [test-2.lox] [0m[0m} else if (false) print "bar";[0m
+[33m[tester::#FH8] [test-2.lox] [0m[0m[0m
+[33m[tester::#FH8] [test-2.lox] [0m[0mif (false) print "bar"; else if (false) {[0m
+[33m[tester::#FH8] [test-2.lox] [0m[0m  print "bar";[0m
+[33m[tester::#FH8] [test-2.lox] [0m[0m}[0m
 [33m[tester::#FH8] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
 [33m[tester::#FH8] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#FH8] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#FH8] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#FH8] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#FH8] [test-3.lox] [0m[33m// This program uses multiple if statements to[0m
-[33m[tester::#FH8] [test-3.lox] [0m[33m// categorize a person[0m
-[33m[tester::#FH8] [test-3.lox] [0m[33m// into different life stages based on their age[0m
-[33m[tester::#FH8] [test-3.lox] [0mvar age = 62;
-[33m[tester::#FH8] [test-3.lox] [0mvar stage = "unknown";
-[33m[tester::#FH8] [test-3.lox] [0mif (age < 18) { stage = "child"; }
-[33m[tester::#FH8] [test-3.lox] [0melse if (age >= 18) { stage = "adult"; }
-[33m[tester::#FH8] [test-3.lox] [0melse if (age >= 65) { stage = "senior"; }
-[33m[tester::#FH8] [test-3.lox] [0melse if (age >= 100) { stage = "centenarian"; }
-[33m[tester::#FH8] [test-3.lox] [0mprint stage;
+[33m[tester::#FH8] [test-3.lox] [0m[0m[33m// This program uses multiple if statements to[0m[0m
+[33m[tester::#FH8] [test-3.lox] [0m[0m[33m// categorize a person[0m[0m
+[33m[tester::#FH8] [test-3.lox] [0m[0m[33m// into different life stages based on their age[0m[0m
+[33m[tester::#FH8] [test-3.lox] [0m[0mvar age = 62;[0m
+[33m[tester::#FH8] [test-3.lox] [0m[0mvar stage = "unknown";[0m
+[33m[tester::#FH8] [test-3.lox] [0m[0mif (age < 18) { stage = "child"; }[0m
+[33m[tester::#FH8] [test-3.lox] [0m[0melse if (age >= 18) { stage = "adult"; }[0m
+[33m[tester::#FH8] [test-3.lox] [0m[0melse if (age >= 65) { stage = "senior"; }[0m
+[33m[tester::#FH8] [test-3.lox] [0m[0melse if (age >= 100) { stage = "centenarian"; }[0m
+[33m[tester::#FH8] [test-3.lox] [0m[0mprint stage;[0m
 [33m[tester::#FH8] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0madult
+[33m[your_program] [0m[0madult[0m
 [33m[tester::#FH8] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#FH8] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#FH8] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#FH8] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#FH8] [test-4.lox] [0m[33m// This program uses multiple if statements to[0m
-[33m[tester::#FH8] [test-4.lox] [0m[33m// determine eligibility for[0m
-[33m[tester::#FH8] [test-4.lox] [0m[33m// voting, driving, and drinking based on a random[0m
-[33m[tester::#FH8] [test-4.lox] [0m[33m// integer age[0m
-[33m[tester::#FH8] [test-4.lox] [0mvar age = 79;
-[33m[tester::#FH8] [test-4.lox] [0m
-[33m[tester::#FH8] [test-4.lox] [0mvar isAdult = age >= 18;
-[33m[tester::#FH8] [test-4.lox] [0mif (isAdult) { print "eligible for voting: true"; }
-[33m[tester::#FH8] [test-4.lox] [0melse { print "eligible for voting: false"; }
-[33m[tester::#FH8] [test-4.lox] [0m
-[33m[tester::#FH8] [test-4.lox] [0mif (age < 16) { print "not eligible for driving"; }
-[33m[tester::#FH8] [test-4.lox] [0melse if (age < 18) { print "learner's permit"; }
-[33m[tester::#FH8] [test-4.lox] [0melse { print "eligible for driving"; }
-[33m[tester::#FH8] [test-4.lox] [0m
-[33m[tester::#FH8] [test-4.lox] [0mif (age >= 21) { print "eligible for drinking"; }
-[33m[tester::#FH8] [test-4.lox] [0melse { print "not eligible for drinking"; }
+[33m[tester::#FH8] [test-4.lox] [0m[0m[33m// This program uses multiple if statements to[0m[0m
+[33m[tester::#FH8] [test-4.lox] [0m[0m[33m// determine eligibility for[0m[0m
+[33m[tester::#FH8] [test-4.lox] [0m[0m[33m// voting, driving, and drinking based on a random[0m[0m
+[33m[tester::#FH8] [test-4.lox] [0m[0m[33m// integer age[0m[0m
+[33m[tester::#FH8] [test-4.lox] [0m[0mvar age = 79;[0m
+[33m[tester::#FH8] [test-4.lox] [0m[0m[0m
+[33m[tester::#FH8] [test-4.lox] [0m[0mvar isAdult = age >= 18;[0m
+[33m[tester::#FH8] [test-4.lox] [0m[0mif (isAdult) { print "eligible for voting: true"; }[0m
+[33m[tester::#FH8] [test-4.lox] [0m[0melse { print "eligible for voting: false"; }[0m
+[33m[tester::#FH8] [test-4.lox] [0m[0m[0m
+[33m[tester::#FH8] [test-4.lox] [0m[0mif (age < 16) { print "not eligible for driving"; }[0m
+[33m[tester::#FH8] [test-4.lox] [0m[0melse if (age < 18) { print "learner's permit"; }[0m
+[33m[tester::#FH8] [test-4.lox] [0m[0melse { print "eligible for driving"; }[0m
+[33m[tester::#FH8] [test-4.lox] [0m[0m[0m
+[33m[tester::#FH8] [test-4.lox] [0m[0mif (age >= 21) { print "eligible for drinking"; }[0m
+[33m[tester::#FH8] [test-4.lox] [0m[0melse { print "not eligible for drinking"; }[0m
 [33m[tester::#FH8] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0meligible for voting: true
-[33m[your_program] [0meligible for driving
-[33m[your_program] [0meligible for drinking
+[33m[your_program] [0m[0meligible for voting: true[0m
+[33m[your_program] [0m[0meligible for driving[0m
+[33m[your_program] [0m[0meligible for drinking[0m
 [33m[tester::#FH8] [test-4] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#FH8] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#FH8] [0m[92mTest passed.[0m
@@ -198,95 +198,95 @@ Debug = true
 [33m[tester::#XJ4] [0m[94mRunning tests for Stage #XJ4 (xj4)[0m
 [33m[tester::#XJ4] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#XJ4] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#XJ4] [test-1.lox] [0m[33m// This program uses nested if statements to print[0m
-[33m[tester::#XJ4] [test-1.lox] [0m[33m// a message[0m
-[33m[tester::#XJ4] [test-1.lox] [0mif (true) if (true) print "nested true";
+[33m[tester::#XJ4] [test-1.lox] [0m[0m[33m// This program uses nested if statements to print[0m[0m
+[33m[tester::#XJ4] [test-1.lox] [0m[0m[33m// a message[0m[0m
+[33m[tester::#XJ4] [test-1.lox] [0m[0mif (true) if (true) print "nested true";[0m
 [33m[tester::#XJ4] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mnested true
+[33m[your_program] [0m[0mnested true[0m
 [33m[tester::#XJ4] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#XJ4] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#XJ4] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#XJ4] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#XJ4] [test-2.lox] [0m[33m// This program uses nested if statements to print[0m
-[33m[tester::#XJ4] [test-2.lox] [0m[33m// a message[0m
-[33m[tester::#XJ4] [test-2.lox] [0mif (true) {
-[33m[tester::#XJ4] [test-2.lox] [0m  if (true) print "baz"; else print "baz";
-[33m[tester::#XJ4] [test-2.lox] [0m}
+[33m[tester::#XJ4] [test-2.lox] [0m[0m[33m// This program uses nested if statements to print[0m[0m
+[33m[tester::#XJ4] [test-2.lox] [0m[0m[33m// a message[0m[0m
+[33m[tester::#XJ4] [test-2.lox] [0m[0mif (true) {[0m
+[33m[tester::#XJ4] [test-2.lox] [0m[0m  if (true) print "baz"; else print "baz";[0m
+[33m[tester::#XJ4] [test-2.lox] [0m[0m}[0m
 [33m[tester::#XJ4] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mbaz
+[33m[your_program] [0m[0mbaz[0m
 [33m[tester::#XJ4] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#XJ4] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#XJ4] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#XJ4] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#XJ4] [test-3.lox] [0m[33m// This program categorizes a person into[0m
-[33m[tester::#XJ4] [test-3.lox] [0m[33m// different life stages based on their age[0m
-[33m[tester::#XJ4] [test-3.lox] [0m[33m// Then based on the age, it prints a message[0m
-[33m[tester::#XJ4] [test-3.lox] [0m[33m// about the person's eligibility for voting,[0m
-[33m[tester::#XJ4] [test-3.lox] [0m[33m// driving, and drinking[0m
-[33m[tester::#XJ4] [test-3.lox] [0mvar stage = "unknown";
-[33m[tester::#XJ4] [test-3.lox] [0mvar age = 68;
-[33m[tester::#XJ4] [test-3.lox] [0mif (age < 18) {
-[33m[tester::#XJ4] [test-3.lox] [0m    if (age < 13) { stage = "child"; }
-[33m[tester::#XJ4] [test-3.lox] [0m    else if (age < 16) {
-[33m[tester::#XJ4] [test-3.lox] [0m        stage = "young teenager";
-[33m[tester::#XJ4] [test-3.lox] [0m    }
-[33m[tester::#XJ4] [test-3.lox] [0m    else { stage = "teenager"; }
-[33m[tester::#XJ4] [test-3.lox] [0m}
-[33m[tester::#XJ4] [test-3.lox] [0melse if (age < 65) {
-[33m[tester::#XJ4] [test-3.lox] [0m    if (age < 30) { stage = "young adult"; }
-[33m[tester::#XJ4] [test-3.lox] [0m    else if (age < 50) { stage = "adult"; }
-[33m[tester::#XJ4] [test-3.lox] [0m    else { stage = "middle-aged adult"; }
-[33m[tester::#XJ4] [test-3.lox] [0m}
-[33m[tester::#XJ4] [test-3.lox] [0melse { stage = "senior"; }
-[33m[tester::#XJ4] [test-3.lox] [0mprint stage;
-[33m[tester::#XJ4] [test-3.lox] [0m
-[33m[tester::#XJ4] [test-3.lox] [0mvar isAdult = age >= 18;
-[33m[tester::#XJ4] [test-3.lox] [0mif (isAdult) {
-[33m[tester::#XJ4] [test-3.lox] [0m    print "eligible for voting: true";
-[33m[tester::#XJ4] [test-3.lox] [0m    if (age < 25) {
-[33m[tester::#XJ4] [test-3.lox] [0m        print "first-time voter: likely";
-[33m[tester::#XJ4] [test-3.lox] [0m    }
-[33m[tester::#XJ4] [test-3.lox] [0m    else { print "first-time voter: unlikely"; }
-[33m[tester::#XJ4] [test-3.lox] [0m}
-[33m[tester::#XJ4] [test-3.lox] [0melse { print "eligible for voting: false"; }
-[33m[tester::#XJ4] [test-3.lox] [0m
-[33m[tester::#XJ4] [test-3.lox] [0mif (age < 16) { print "not eligible for driving"; }
-[33m[tester::#XJ4] [test-3.lox] [0melse if (age < 18) {
-[33m[tester::#XJ4] [test-3.lox] [0m    print "eligible for driving: learner's permit";
-[33m[tester::#XJ4] [test-3.lox] [0m    if (age < 17) {
-[33m[tester::#XJ4] [test-3.lox] [0m        print "supervised driving required";
-[33m[tester::#XJ4] [test-3.lox] [0m    }
-[33m[tester::#XJ4] [test-3.lox] [0m    else {
-[33m[tester::#XJ4] [test-3.lox] [0m        print "driving allowed with restrictions";
-[33m[tester::#XJ4] [test-3.lox] [0m    }
-[33m[tester::#XJ4] [test-3.lox] [0m}
-[33m[tester::#XJ4] [test-3.lox] [0melse { print "eligible for driving"; }
-[33m[tester::#XJ4] [test-3.lox] [0m
-[33m[tester::#XJ4] [test-3.lox] [0mif (age < 21) {
-[33m[tester::#XJ4] [test-3.lox] [0m    print "not eligible for drinking";
-[33m[tester::#XJ4] [test-3.lox] [0m}
-[33m[tester::#XJ4] [test-3.lox] [0melse {
-[33m[tester::#XJ4] [test-3.lox] [0m    print "eligible for drinking";
-[33m[tester::#XJ4] [test-3.lox] [0m    if (age < 25) {
-[33m[tester::#XJ4] [test-3.lox] [0m        print "remember: drink responsibly!";
-[33m[tester::#XJ4] [test-3.lox] [0m    }
-[33m[tester::#XJ4] [test-3.lox] [0m}
+[33m[tester::#XJ4] [test-3.lox] [0m[0m[33m// This program categorizes a person into[0m[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m[33m// different life stages based on their age[0m[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m[33m// Then based on the age, it prints a message[0m[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m[33m// about the person's eligibility for voting,[0m[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m[33m// driving, and drinking[0m[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0mvar stage = "unknown";[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0mvar age = 68;[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0mif (age < 18) {[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    if (age < 13) { stage = "child"; }[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    else if (age < 16) {[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m        stage = "young teenager";[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    }[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    else { stage = "teenager"; }[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m}[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0melse if (age < 65) {[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    if (age < 30) { stage = "young adult"; }[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    else if (age < 50) { stage = "adult"; }[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    else { stage = "middle-aged adult"; }[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m}[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0melse { stage = "senior"; }[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0mprint stage;[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0mvar isAdult = age >= 18;[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0mif (isAdult) {[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    print "eligible for voting: true";[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    if (age < 25) {[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m        print "first-time voter: likely";[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    }[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    else { print "first-time voter: unlikely"; }[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m}[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0melse { print "eligible for voting: false"; }[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0mif (age < 16) { print "not eligible for driving"; }[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0melse if (age < 18) {[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    print "eligible for driving: learner's permit";[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    if (age < 17) {[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m        print "supervised driving required";[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    }[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    else {[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m        print "driving allowed with restrictions";[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    }[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m}[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0melse { print "eligible for driving"; }[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0mif (age < 21) {[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    print "not eligible for drinking";[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m}[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0melse {[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    print "eligible for drinking";[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    if (age < 25) {[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m        print "remember: drink responsibly!";[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m    }[0m
+[33m[tester::#XJ4] [test-3.lox] [0m[0m}[0m
 [33m[tester::#XJ4] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0msenior
-[33m[your_program] [0meligible for voting: true
-[33m[your_program] [0mfirst-time voter: unlikely
-[33m[your_program] [0meligible for driving
-[33m[your_program] [0meligible for drinking
+[33m[your_program] [0m[0msenior[0m
+[33m[your_program] [0m[0meligible for voting: true[0m
+[33m[your_program] [0m[0mfirst-time voter: unlikely[0m
+[33m[your_program] [0m[0meligible for driving[0m
+[33m[your_program] [0m[0meligible for drinking[0m
 [33m[tester::#XJ4] [test-3] [0m[92m✓ 5 line(s) match on stdout[0m
 [33m[tester::#XJ4] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#XJ4] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#XJ4] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#XJ4] [test-4.lox] [0m[33m// This program uses nested if statements to print[0m
-[33m[tester::#XJ4] [test-4.lox] [0m[33m// a message[0m
-[33m[tester::#XJ4] [test-4.lox] [0mif (true) if (false) print "bar";
-[33m[tester::#XJ4] [test-4.lox] [0melse print "foo";
+[33m[tester::#XJ4] [test-4.lox] [0m[0m[33m// This program uses nested if statements to print[0m[0m
+[33m[tester::#XJ4] [test-4.lox] [0m[0m[33m// a message[0m[0m
+[33m[tester::#XJ4] [test-4.lox] [0m[0mif (true) if (false) print "bar";[0m
+[33m[tester::#XJ4] [test-4.lox] [0m[0melse print "foo";[0m
 [33m[tester::#XJ4] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mfoo
+[33m[your_program] [0m[0mfoo[0m
 [33m[tester::#XJ4] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#XJ4] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#XJ4] [0m[92mTest passed.[0m
@@ -294,79 +294,79 @@ Debug = true
 [33m[tester::#WK8] [0m[94mRunning tests for Stage #WK8 (wk8)[0m
 [33m[tester::#WK8] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#WK8] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#WK8] [test-1.lox] [0m[33m// The logical OR operator should return the first[0m
-[33m[tester::#WK8] [test-1.lox] [0m[33m// value that is truthy[0m
-[33m[tester::#WK8] [test-1.lox] [0mif (false or "ok") print "world";
-[33m[tester::#WK8] [test-1.lox] [0mif (nil or "ok") print "world";
-[33m[tester::#WK8] [test-1.lox] [0m
-[33m[tester::#WK8] [test-1.lox] [0mif (false or false) print "bar";
-[33m[tester::#WK8] [test-1.lox] [0mif (true or "bar") print "bar";
-[33m[tester::#WK8] [test-1.lox] [0m
-[33m[tester::#WK8] [test-1.lox] [0mif (67 or "hello") print "hello";
-[33m[tester::#WK8] [test-1.lox] [0mif ("hello" or "hello") print "hello";
+[33m[tester::#WK8] [test-1.lox] [0m[0m[33m// The logical OR operator should return the first[0m[0m
+[33m[tester::#WK8] [test-1.lox] [0m[0m[33m// value that is truthy[0m[0m
+[33m[tester::#WK8] [test-1.lox] [0m[0mif (false or "ok") print "world";[0m
+[33m[tester::#WK8] [test-1.lox] [0m[0mif (nil or "ok") print "world";[0m
+[33m[tester::#WK8] [test-1.lox] [0m[0m[0m
+[33m[tester::#WK8] [test-1.lox] [0m[0mif (false or false) print "bar";[0m
+[33m[tester::#WK8] [test-1.lox] [0m[0mif (true or "bar") print "bar";[0m
+[33m[tester::#WK8] [test-1.lox] [0m[0m[0m
+[33m[tester::#WK8] [test-1.lox] [0m[0mif (67 or "hello") print "hello";[0m
+[33m[tester::#WK8] [test-1.lox] [0m[0mif ("hello" or "hello") print "hello";[0m
 [33m[tester::#WK8] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mworld
-[33m[your_program] [0mworld
-[33m[your_program] [0mbar
-[33m[your_program] [0mhello
-[33m[your_program] [0mhello
+[33m[your_program] [0m[0mworld[0m
+[33m[your_program] [0m[0mworld[0m
+[33m[your_program] [0m[0mbar[0m
+[33m[your_program] [0m[0mhello[0m
+[33m[your_program] [0m[0mhello[0m
 [33m[tester::#WK8] [test-1] [0m[92m✓ 5 line(s) match on stdout[0m
 [33m[tester::#WK8] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#WK8] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#WK8] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#WK8] [test-2.lox] [0m[33m// This program uses the logical OR operator to[0m
-[33m[tester::#WK8] [test-2.lox] [0m[33m// print the first value that is truthy[0m
-[33m[tester::#WK8] [test-2.lox] [0mprint 16 or true;
-[33m[tester::#WK8] [test-2.lox] [0mprint false or 16;
-[33m[tester::#WK8] [test-2.lox] [0mprint false or false or true;
-[33m[tester::#WK8] [test-2.lox] [0m
-[33m[tester::#WK8] [test-2.lox] [0mprint false or false;
-[33m[tester::#WK8] [test-2.lox] [0mprint false or false or false;
-[33m[tester::#WK8] [test-2.lox] [0mprint false or false or false or false;
+[33m[tester::#WK8] [test-2.lox] [0m[0m[33m// This program uses the logical OR operator to[0m[0m
+[33m[tester::#WK8] [test-2.lox] [0m[0m[33m// print the first value that is truthy[0m[0m
+[33m[tester::#WK8] [test-2.lox] [0m[0mprint 16 or true;[0m
+[33m[tester::#WK8] [test-2.lox] [0m[0mprint false or 16;[0m
+[33m[tester::#WK8] [test-2.lox] [0m[0mprint false or false or true;[0m
+[33m[tester::#WK8] [test-2.lox] [0m[0m[0m
+[33m[tester::#WK8] [test-2.lox] [0m[0mprint false or false;[0m
+[33m[tester::#WK8] [test-2.lox] [0m[0mprint false or false or false;[0m
+[33m[tester::#WK8] [test-2.lox] [0m[0mprint false or false or false or false;[0m
 [33m[tester::#WK8] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m16
-[33m[your_program] [0m16
-[33m[your_program] [0mtrue
-[33m[your_program] [0mfalse
-[33m[your_program] [0mfalse
-[33m[your_program] [0mfalse
+[33m[your_program] [0m[0m16[0m
+[33m[your_program] [0m[0m16[0m
+[33m[your_program] [0m[0mtrue[0m
+[33m[your_program] [0m[0mfalse[0m
+[33m[your_program] [0m[0mfalse[0m
+[33m[your_program] [0m[0mfalse[0m
 [33m[tester::#WK8] [test-2] [0m[92m✓ 6 line(s) match on stdout[0m
 [33m[tester::#WK8] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#WK8] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#WK8] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#WK8] [test-3.lox] [0m[33m// This program relies on the fact that[0m
-[33m[tester::#WK8] [test-3.lox] [0m[33m// assignments return the assigned value[0m
-[33m[tester::#WK8] [test-3.lox] [0m[33m// And that the logical OR operator short-circuits[0m
-[33m[tester::#WK8] [test-3.lox] [0m[33m// So, if the first assignment is truthy, it[0m
-[33m[tester::#WK8] [test-3.lox] [0m[33m// wouldn't proceed to the subsequent assignments[0m
-[33m[tester::#WK8] [test-3.lox] [0m[33m// And then prints the assigned values[0m
-[33m[tester::#WK8] [test-3.lox] [0mvar a = "hello";
-[33m[tester::#WK8] [test-3.lox] [0mvar b = "hello";
-[33m[tester::#WK8] [test-3.lox] [0m(a = false) or (b = true) or (a = "hello");
-[33m[tester::#WK8] [test-3.lox] [0mprint a;
-[33m[tester::#WK8] [test-3.lox] [0mprint b;
+[33m[tester::#WK8] [test-3.lox] [0m[0m[33m// This program relies on the fact that[0m[0m
+[33m[tester::#WK8] [test-3.lox] [0m[0m[33m// assignments return the assigned value[0m[0m
+[33m[tester::#WK8] [test-3.lox] [0m[0m[33m// And that the logical OR operator short-circuits[0m[0m
+[33m[tester::#WK8] [test-3.lox] [0m[0m[33m// So, if the first assignment is truthy, it[0m[0m
+[33m[tester::#WK8] [test-3.lox] [0m[0m[33m// wouldn't proceed to the subsequent assignments[0m[0m
+[33m[tester::#WK8] [test-3.lox] [0m[0m[33m// And then prints the assigned values[0m[0m
+[33m[tester::#WK8] [test-3.lox] [0m[0mvar a = "hello";[0m
+[33m[tester::#WK8] [test-3.lox] [0m[0mvar b = "hello";[0m
+[33m[tester::#WK8] [test-3.lox] [0m[0m(a = false) or (b = true) or (a = "hello");[0m
+[33m[tester::#WK8] [test-3.lox] [0m[0mprint a;[0m
+[33m[tester::#WK8] [test-3.lox] [0m[0mprint b;[0m
 [33m[tester::#WK8] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mfalse
-[33m[your_program] [0mtrue
+[33m[your_program] [0m[0mfalse[0m
+[33m[your_program] [0m[0mtrue[0m
 [33m[tester::#WK8] [test-3] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#WK8] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#WK8] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#WK8] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#WK8] [test-4.lox] [0m[33m// This program uses if conditions to get the stage[0m
-[33m[tester::#WK8] [test-4.lox] [0m[33m// of a person's life based on their age, and then[0m
-[33m[tester::#WK8] [test-4.lox] [0m[33m// prints if they are eligible for voting[0m
-[33m[tester::#WK8] [test-4.lox] [0mvar stage = "unknown";
-[33m[tester::#WK8] [test-4.lox] [0mvar age = 79;
-[33m[tester::#WK8] [test-4.lox] [0mif (age < 18) { stage = "child"; }
-[33m[tester::#WK8] [test-4.lox] [0mif (age >= 18) { stage = "adult"; }
-[33m[tester::#WK8] [test-4.lox] [0mprint stage;
-[33m[tester::#WK8] [test-4.lox] [0m
-[33m[tester::#WK8] [test-4.lox] [0mvar isAdult = age >= 18;
-[33m[tester::#WK8] [test-4.lox] [0mif (isAdult) { print "eligible for voting"; }
-[33m[tester::#WK8] [test-4.lox] [0mif (!isAdult) { print "not eligible for voting"; }
+[33m[tester::#WK8] [test-4.lox] [0m[0m[33m// This program uses if conditions to get the stage[0m[0m
+[33m[tester::#WK8] [test-4.lox] [0m[0m[33m// of a person's life based on their age, and then[0m[0m
+[33m[tester::#WK8] [test-4.lox] [0m[0m[33m// prints if they are eligible for voting[0m[0m
+[33m[tester::#WK8] [test-4.lox] [0m[0mvar stage = "unknown";[0m
+[33m[tester::#WK8] [test-4.lox] [0m[0mvar age = 79;[0m
+[33m[tester::#WK8] [test-4.lox] [0m[0mif (age < 18) { stage = "child"; }[0m
+[33m[tester::#WK8] [test-4.lox] [0m[0mif (age >= 18) { stage = "adult"; }[0m
+[33m[tester::#WK8] [test-4.lox] [0m[0mprint stage;[0m
+[33m[tester::#WK8] [test-4.lox] [0m[0m[0m
+[33m[tester::#WK8] [test-4.lox] [0m[0mvar isAdult = age >= 18;[0m
+[33m[tester::#WK8] [test-4.lox] [0m[0mif (isAdult) { print "eligible for voting"; }[0m
+[33m[tester::#WK8] [test-4.lox] [0m[0mif (!isAdult) { print "not eligible for voting"; }[0m
 [33m[tester::#WK8] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0madult
-[33m[your_program] [0meligible for voting
+[33m[your_program] [0m[0madult[0m
+[33m[your_program] [0m[0meligible for voting[0m
 [33m[tester::#WK8] [test-4] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#WK8] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#WK8] [0m[92mTest passed.[0m
@@ -374,78 +374,78 @@ Debug = true
 [33m[tester::#JX4] [0m[94mRunning tests for Stage #JX4 (jx4)[0m
 [33m[tester::#JX4] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#JX4] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#JX4] [test-1.lox] [0m[33m// The logical AND operator should return the[0m
-[33m[tester::#JX4] [test-1.lox] [0m[33m// first falsy value[0m
-[33m[tester::#JX4] [test-1.lox] [0mif (false and "bad") print "hello";
-[33m[tester::#JX4] [test-1.lox] [0mif (nil and "bad") print "hello";
-[33m[tester::#JX4] [test-1.lox] [0m
-[33m[tester::#JX4] [test-1.lox] [0m[33m// If all values are truthy, it returns the last[0m
-[33m[tester::#JX4] [test-1.lox] [0m[33m// value[0m
-[33m[tester::#JX4] [test-1.lox] [0mif (true and "baz") print "baz";
-[33m[tester::#JX4] [test-1.lox] [0mif (77 and "quz") print "quz";
-[33m[tester::#JX4] [test-1.lox] [0mif ("quz" and "quz") print "quz";
-[33m[tester::#JX4] [test-1.lox] [0mif ("" and "world") print "world";
+[33m[tester::#JX4] [test-1.lox] [0m[0m[33m// The logical AND operator should return the[0m[0m
+[33m[tester::#JX4] [test-1.lox] [0m[0m[33m// first falsy value[0m[0m
+[33m[tester::#JX4] [test-1.lox] [0m[0mif (false and "bad") print "hello";[0m
+[33m[tester::#JX4] [test-1.lox] [0m[0mif (nil and "bad") print "hello";[0m
+[33m[tester::#JX4] [test-1.lox] [0m[0m[0m
+[33m[tester::#JX4] [test-1.lox] [0m[0m[33m// If all values are truthy, it returns the last[0m[0m
+[33m[tester::#JX4] [test-1.lox] [0m[0m[33m// value[0m[0m
+[33m[tester::#JX4] [test-1.lox] [0m[0mif (true and "baz") print "baz";[0m
+[33m[tester::#JX4] [test-1.lox] [0m[0mif (77 and "quz") print "quz";[0m
+[33m[tester::#JX4] [test-1.lox] [0m[0mif ("quz" and "quz") print "quz";[0m
+[33m[tester::#JX4] [test-1.lox] [0m[0mif ("" and "world") print "world";[0m
 [33m[tester::#JX4] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mbaz
-[33m[your_program] [0mquz
-[33m[your_program] [0mquz
-[33m[your_program] [0mworld
+[33m[your_program] [0m[0mbaz[0m
+[33m[your_program] [0m[0mquz[0m
+[33m[your_program] [0m[0mquz[0m
+[33m[your_program] [0m[0mworld[0m
 [33m[tester::#JX4] [test-1] [0m[92m✓ 4 line(s) match on stdout[0m
 [33m[tester::#JX4] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#JX4] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#JX4] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#JX4] [test-2.lox] [0m[33m// This program uses the logical AND operator to[0m
-[33m[tester::#JX4] [test-2.lox] [0m[33m// print the first falsy value[0m
-[33m[tester::#JX4] [test-2.lox] [0m[33m// Or the last value if all values are truthy[0m
-[33m[tester::#JX4] [test-2.lox] [0mprint false and 1;
-[33m[tester::#JX4] [test-2.lox] [0mprint true and 1;
-[33m[tester::#JX4] [test-2.lox] [0mprint 59 and "quz" and false;
-[33m[tester::#JX4] [test-2.lox] [0m
-[33m[tester::#JX4] [test-2.lox] [0mprint 59 and true;
-[33m[tester::#JX4] [test-2.lox] [0mprint 59 and "quz" and 59;
+[33m[tester::#JX4] [test-2.lox] [0m[0m[33m// This program uses the logical AND operator to[0m[0m
+[33m[tester::#JX4] [test-2.lox] [0m[0m[33m// print the first falsy value[0m[0m
+[33m[tester::#JX4] [test-2.lox] [0m[0m[33m// Or the last value if all values are truthy[0m[0m
+[33m[tester::#JX4] [test-2.lox] [0m[0mprint false and 1;[0m
+[33m[tester::#JX4] [test-2.lox] [0m[0mprint true and 1;[0m
+[33m[tester::#JX4] [test-2.lox] [0m[0mprint 59 and "quz" and false;[0m
+[33m[tester::#JX4] [test-2.lox] [0m[0m[0m
+[33m[tester::#JX4] [test-2.lox] [0m[0mprint 59 and true;[0m
+[33m[tester::#JX4] [test-2.lox] [0m[0mprint 59 and "quz" and 59;[0m
 [33m[tester::#JX4] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mfalse
-[33m[your_program] [0m1
-[33m[your_program] [0mfalse
-[33m[your_program] [0mtrue
-[33m[your_program] [0m59
+[33m[your_program] [0m[0mfalse[0m
+[33m[your_program] [0m[0m1[0m
+[33m[your_program] [0m[0mfalse[0m
+[33m[your_program] [0m[0mtrue[0m
+[33m[your_program] [0m[0m59[0m
 [33m[tester::#JX4] [test-2] [0m[92m✓ 5 line(s) match on stdout[0m
 [33m[tester::#JX4] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#JX4] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#JX4] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#JX4] [test-3.lox] [0m[33m// This program relies on the fact that[0m
-[33m[tester::#JX4] [test-3.lox] [0m[33m// assignments return the assigned value[0m
-[33m[tester::#JX4] [test-3.lox] [0m[33m// And that the logical AND operator short-circuits[0m
-[33m[tester::#JX4] [test-3.lox] [0m[33m// So, when it encounters a falsy value, it[0m
-[33m[tester::#JX4] [test-3.lox] [0m[33m// wouldn't proceed to the subsequent assignments[0m
-[33m[tester::#JX4] [test-3.lox] [0m[33m// And then prints the assigned values[0m
-[33m[tester::#JX4] [test-3.lox] [0mvar a = "bar";
-[33m[tester::#JX4] [test-3.lox] [0mvar b = "bar";
-[33m[tester::#JX4] [test-3.lox] [0m(a = true) and (b = false) and (a = "bad");
-[33m[tester::#JX4] [test-3.lox] [0mprint a;
-[33m[tester::#JX4] [test-3.lox] [0mprint b;
+[33m[tester::#JX4] [test-3.lox] [0m[0m[33m// This program relies on the fact that[0m[0m
+[33m[tester::#JX4] [test-3.lox] [0m[0m[33m// assignments return the assigned value[0m[0m
+[33m[tester::#JX4] [test-3.lox] [0m[0m[33m// And that the logical AND operator short-circuits[0m[0m
+[33m[tester::#JX4] [test-3.lox] [0m[0m[33m// So, when it encounters a falsy value, it[0m[0m
+[33m[tester::#JX4] [test-3.lox] [0m[0m[33m// wouldn't proceed to the subsequent assignments[0m[0m
+[33m[tester::#JX4] [test-3.lox] [0m[0m[33m// And then prints the assigned values[0m[0m
+[33m[tester::#JX4] [test-3.lox] [0m[0mvar a = "bar";[0m
+[33m[tester::#JX4] [test-3.lox] [0m[0mvar b = "bar";[0m
+[33m[tester::#JX4] [test-3.lox] [0m[0m(a = true) and (b = false) and (a = "bad");[0m
+[33m[tester::#JX4] [test-3.lox] [0m[0mprint a;[0m
+[33m[tester::#JX4] [test-3.lox] [0m[0mprint b;[0m
 [33m[tester::#JX4] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mtrue
-[33m[your_program] [0mfalse
+[33m[your_program] [0m[0mtrue[0m
+[33m[your_program] [0m[0mfalse[0m
 [33m[tester::#JX4] [test-3] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#JX4] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#JX4] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#JX4] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#JX4] [test-4.lox] [0m[33m// This program uses if conditions to get the stage[0m
-[33m[tester::#JX4] [test-4.lox] [0m[33m// of a person's life based on their age, and then[0m
-[33m[tester::#JX4] [test-4.lox] [0m[33m// prints if they are eligible for voting[0m
-[33m[tester::#JX4] [test-4.lox] [0mvar stage = "unknown";
-[33m[tester::#JX4] [test-4.lox] [0mvar age = 62;
-[33m[tester::#JX4] [test-4.lox] [0mif (age < 18) { stage = "child"; }
-[33m[tester::#JX4] [test-4.lox] [0mif (age >= 18) { stage = "adult"; }
-[33m[tester::#JX4] [test-4.lox] [0mprint stage;
-[33m[tester::#JX4] [test-4.lox] [0m
-[33m[tester::#JX4] [test-4.lox] [0mvar isAdult = age >= 18;
-[33m[tester::#JX4] [test-4.lox] [0mif (isAdult) { print "eligible for voting"; }
-[33m[tester::#JX4] [test-4.lox] [0mif (!isAdult) { print "not eligible for voting"; }
+[33m[tester::#JX4] [test-4.lox] [0m[0m[33m// This program uses if conditions to get the stage[0m[0m
+[33m[tester::#JX4] [test-4.lox] [0m[0m[33m// of a person's life based on their age, and then[0m[0m
+[33m[tester::#JX4] [test-4.lox] [0m[0m[33m// prints if they are eligible for voting[0m[0m
+[33m[tester::#JX4] [test-4.lox] [0m[0mvar stage = "unknown";[0m
+[33m[tester::#JX4] [test-4.lox] [0m[0mvar age = 62;[0m
+[33m[tester::#JX4] [test-4.lox] [0m[0mif (age < 18) { stage = "child"; }[0m
+[33m[tester::#JX4] [test-4.lox] [0m[0mif (age >= 18) { stage = "adult"; }[0m
+[33m[tester::#JX4] [test-4.lox] [0m[0mprint stage;[0m
+[33m[tester::#JX4] [test-4.lox] [0m[0m[0m
+[33m[tester::#JX4] [test-4.lox] [0m[0mvar isAdult = age >= 18;[0m
+[33m[tester::#JX4] [test-4.lox] [0m[0mif (isAdult) { print "eligible for voting"; }[0m
+[33m[tester::#JX4] [test-4.lox] [0m[0mif (!isAdult) { print "not eligible for voting"; }[0m
 [33m[tester::#JX4] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0madult
-[33m[your_program] [0meligible for voting
+[33m[your_program] [0m[0madult[0m
+[33m[your_program] [0m[0meligible for voting[0m
 [33m[tester::#JX4] [test-4] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#JX4] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#JX4] [0m[92mTest passed.[0m
@@ -453,84 +453,84 @@ Debug = true
 [33m[tester::#QY3] [0m[94mRunning tests for Stage #QY3 (qy3)[0m
 [33m[tester::#QY3] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#QY3] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#QY3] [test-1.lox] [0m[33m// This program uses a while loop to print the[0m
-[33m[tester::#QY3] [test-1.lox] [0m[33m// numbers from 0 to N[0m
-[33m[tester::#QY3] [test-1.lox] [0m[33m// The assignment operation returns the assigned[0m
-[33m[tester::#QY3] [test-1.lox] [0m[33m// value[0m
-[33m[tester::#QY3] [test-1.lox] [0mvar baz = 0;
-[33m[tester::#QY3] [test-1.lox] [0mwhile (baz < 3) print baz = baz + 1;
+[33m[tester::#QY3] [test-1.lox] [0m[0m[33m// This program uses a while loop to print the[0m[0m
+[33m[tester::#QY3] [test-1.lox] [0m[0m[33m// numbers from 0 to N[0m[0m
+[33m[tester::#QY3] [test-1.lox] [0m[0m[33m// The assignment operation returns the assigned[0m[0m
+[33m[tester::#QY3] [test-1.lox] [0m[0m[33m// value[0m[0m
+[33m[tester::#QY3] [test-1.lox] [0m[0mvar baz = 0;[0m
+[33m[tester::#QY3] [test-1.lox] [0m[0mwhile (baz < 3) print baz = baz + 1;[0m
 [33m[tester::#QY3] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m1
-[33m[your_program] [0m2
-[33m[your_program] [0m3
+[33m[your_program] [0m[0m1[0m
+[33m[your_program] [0m[0m2[0m
+[33m[your_program] [0m[0m3[0m
 [33m[tester::#QY3] [test-1] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#QY3] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#QY3] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#QY3] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#QY3] [test-2.lox] [0m[33m// This program uses a while loop to print the[0m
-[33m[tester::#QY3] [test-2.lox] [0m[33m// numbers from 0 to 3[0m
-[33m[tester::#QY3] [test-2.lox] [0m[33m// The statement inside the block is executed[0m
-[33m[tester::#QY3] [test-2.lox] [0m[33m// every time the loop condition is true[0m
-[33m[tester::#QY3] [test-2.lox] [0mvar baz = 0;
-[33m[tester::#QY3] [test-2.lox] [0mwhile (baz < 3) {
-[33m[tester::#QY3] [test-2.lox] [0m  print baz;
-[33m[tester::#QY3] [test-2.lox] [0m  baz = baz + 1;
-[33m[tester::#QY3] [test-2.lox] [0m}
+[33m[tester::#QY3] [test-2.lox] [0m[0m[33m// This program uses a while loop to print the[0m[0m
+[33m[tester::#QY3] [test-2.lox] [0m[0m[33m// numbers from 0 to 3[0m[0m
+[33m[tester::#QY3] [test-2.lox] [0m[0m[33m// The statement inside the block is executed[0m[0m
+[33m[tester::#QY3] [test-2.lox] [0m[0m[33m// every time the loop condition is true[0m[0m
+[33m[tester::#QY3] [test-2.lox] [0m[0mvar baz = 0;[0m
+[33m[tester::#QY3] [test-2.lox] [0m[0mwhile (baz < 3) {[0m
+[33m[tester::#QY3] [test-2.lox] [0m[0m  print baz;[0m
+[33m[tester::#QY3] [test-2.lox] [0m[0m  baz = baz + 1;[0m
+[33m[tester::#QY3] [test-2.lox] [0m[0m}[0m
 [33m[tester::#QY3] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m0
-[33m[your_program] [0m1
-[33m[your_program] [0m2
+[33m[your_program] [0m[0m0[0m
+[33m[your_program] [0m[0m1[0m
+[33m[your_program] [0m[0m2[0m
 [33m[tester::#QY3] [test-2] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#QY3] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#QY3] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#QY3] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#QY3] [test-3.lox] [0m[33m// This program uses a while loop to calculate the[0m
-[33m[tester::#QY3] [test-3.lox] [0m[33m// factorial of 5[0m
-[33m[tester::#QY3] [test-3.lox] [0m[33m// The first while loop never runs because the[0m
-[33m[tester::#QY3] [test-3.lox] [0m[33m// condition is false[0m
-[33m[tester::#QY3] [test-3.lox] [0mwhile (false) { print "should not print"; }
-[33m[tester::#QY3] [test-3.lox] [0m
-[33m[tester::#QY3] [test-3.lox] [0mvar product = 1;
-[33m[tester::#QY3] [test-3.lox] [0mvar i = 1;
-[33m[tester::#QY3] [test-3.lox] [0m
-[33m[tester::#QY3] [test-3.lox] [0mwhile (i <= 5) {
-[33m[tester::#QY3] [test-3.lox] [0m  product = product * i;
-[33m[tester::#QY3] [test-3.lox] [0m  i = i + 1;
-[33m[tester::#QY3] [test-3.lox] [0m}
-[33m[tester::#QY3] [test-3.lox] [0m
-[33m[tester::#QY3] [test-3.lox] [0mprint "Factorial of 5: "; print product;
+[33m[tester::#QY3] [test-3.lox] [0m[0m[33m// This program uses a while loop to calculate the[0m[0m
+[33m[tester::#QY3] [test-3.lox] [0m[0m[33m// factorial of 5[0m[0m
+[33m[tester::#QY3] [test-3.lox] [0m[0m[33m// The first while loop never runs because the[0m[0m
+[33m[tester::#QY3] [test-3.lox] [0m[0m[33m// condition is false[0m[0m
+[33m[tester::#QY3] [test-3.lox] [0m[0mwhile (false) { print "should not print"; }[0m
+[33m[tester::#QY3] [test-3.lox] [0m[0m[0m
+[33m[tester::#QY3] [test-3.lox] [0m[0mvar product = 1;[0m
+[33m[tester::#QY3] [test-3.lox] [0m[0mvar i = 1;[0m
+[33m[tester::#QY3] [test-3.lox] [0m[0m[0m
+[33m[tester::#QY3] [test-3.lox] [0m[0mwhile (i <= 5) {[0m
+[33m[tester::#QY3] [test-3.lox] [0m[0m  product = product * i;[0m
+[33m[tester::#QY3] [test-3.lox] [0m[0m  i = i + 1;[0m
+[33m[tester::#QY3] [test-3.lox] [0m[0m}[0m
+[33m[tester::#QY3] [test-3.lox] [0m[0m[0m
+[33m[tester::#QY3] [test-3.lox] [0m[0mprint "Factorial of 5: "; print product;[0m
 [33m[tester::#QY3] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mFactorial of 5: 
-[33m[your_program] [0m120
+[33m[your_program] [0m[0mFactorial of 5: [0m
+[33m[your_program] [0m[0m120[0m
 [33m[tester::#QY3] [test-3] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#QY3] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#QY3] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#QY3] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#QY3] [test-4.lox] [0m[33m// This program uses a while loop to generate and[0m
-[33m[tester::#QY3] [test-4.lox] [0m[33m// print the first N Fibonacci numbers[0m
-[33m[tester::#QY3] [test-4.lox] [0mvar n = 10;
-[33m[tester::#QY3] [test-4.lox] [0mvar fm = 0;
-[33m[tester::#QY3] [test-4.lox] [0mvar fn = 1;
-[33m[tester::#QY3] [test-4.lox] [0mvar index = 0;
-[33m[tester::#QY3] [test-4.lox] [0m
-[33m[tester::#QY3] [test-4.lox] [0mwhile (index < n) {
-[33m[tester::#QY3] [test-4.lox] [0m    print fm;
-[33m[tester::#QY3] [test-4.lox] [0m    var temp = fm;
-[33m[tester::#QY3] [test-4.lox] [0m    fm = fn;
-[33m[tester::#QY3] [test-4.lox] [0m    fn = temp + fn;
-[33m[tester::#QY3] [test-4.lox] [0m    index = index + 1;
-[33m[tester::#QY3] [test-4.lox] [0m}
+[33m[tester::#QY3] [test-4.lox] [0m[0m[33m// This program uses a while loop to generate and[0m[0m
+[33m[tester::#QY3] [test-4.lox] [0m[0m[33m// print the first N Fibonacci numbers[0m[0m
+[33m[tester::#QY3] [test-4.lox] [0m[0mvar n = 10;[0m
+[33m[tester::#QY3] [test-4.lox] [0m[0mvar fm = 0;[0m
+[33m[tester::#QY3] [test-4.lox] [0m[0mvar fn = 1;[0m
+[33m[tester::#QY3] [test-4.lox] [0m[0mvar index = 0;[0m
+[33m[tester::#QY3] [test-4.lox] [0m[0m[0m
+[33m[tester::#QY3] [test-4.lox] [0m[0mwhile (index < n) {[0m
+[33m[tester::#QY3] [test-4.lox] [0m[0m    print fm;[0m
+[33m[tester::#QY3] [test-4.lox] [0m[0m    var temp = fm;[0m
+[33m[tester::#QY3] [test-4.lox] [0m[0m    fm = fn;[0m
+[33m[tester::#QY3] [test-4.lox] [0m[0m    fn = temp + fn;[0m
+[33m[tester::#QY3] [test-4.lox] [0m[0m    index = index + 1;[0m
+[33m[tester::#QY3] [test-4.lox] [0m[0m}[0m
 [33m[tester::#QY3] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m0
-[33m[your_program] [0m1
-[33m[your_program] [0m1
-[33m[your_program] [0m2
-[33m[your_program] [0m3
-[33m[your_program] [0m5
-[33m[your_program] [0m8
-[33m[your_program] [0m13
-[33m[your_program] [0m21
-[33m[your_program] [0m34
+[33m[your_program] [0m[0m0[0m
+[33m[your_program] [0m[0m1[0m
+[33m[your_program] [0m[0m1[0m
+[33m[your_program] [0m[0m2[0m
+[33m[your_program] [0m[0m3[0m
+[33m[your_program] [0m[0m5[0m
+[33m[your_program] [0m[0m8[0m
+[33m[your_program] [0m[0m13[0m
+[33m[your_program] [0m[0m21[0m
+[33m[your_program] [0m[0m34[0m
 [33m[tester::#QY3] [test-4] [0m[92m✓ 10 line(s) match on stdout[0m
 [33m[tester::#QY3] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#QY3] [0m[92mTest passed.[0m
@@ -538,83 +538,83 @@ Debug = true
 [33m[tester::#BW6] [0m[94mRunning tests for Stage #BW6 (bw6)[0m
 [33m[tester::#BW6] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#BW6] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#BW6] [test-1.lox] [0m[33m// This program uses a for loop to print the[0m
-[33m[tester::#BW6] [test-1.lox] [0m[33m// numbers from 0 to 3[0m
-[33m[tester::#BW6] [test-1.lox] [0m[33m// The assignment operation returns the assigned[0m
-[33m[tester::#BW6] [test-1.lox] [0m[33m// value[0m
-[33m[tester::#BW6] [test-1.lox] [0mfor (var foo = 0; foo < 3;) print foo = foo + 1;
+[33m[tester::#BW6] [test-1.lox] [0m[0m[33m// This program uses a for loop to print the[0m[0m
+[33m[tester::#BW6] [test-1.lox] [0m[0m[33m// numbers from 0 to 3[0m[0m
+[33m[tester::#BW6] [test-1.lox] [0m[0m[33m// The assignment operation returns the assigned[0m[0m
+[33m[tester::#BW6] [test-1.lox] [0m[0m[33m// value[0m[0m
+[33m[tester::#BW6] [test-1.lox] [0m[0mfor (var foo = 0; foo < 3;) print foo = foo + 1;[0m
 [33m[tester::#BW6] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m1
-[33m[your_program] [0m2
-[33m[your_program] [0m3
+[33m[your_program] [0m[0m1[0m
+[33m[your_program] [0m[0m2[0m
+[33m[your_program] [0m[0m3[0m
 [33m[tester::#BW6] [test-1] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#BW6] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#BW6] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#BW6] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#BW6] [test-2.lox] [0m[33m// This program uses a for loop to print the[0m
-[33m[tester::#BW6] [test-2.lox] [0m[33m// numbers from 0 to 3[0m
-[33m[tester::#BW6] [test-2.lox] [0mfor (var bar = 0; bar < 3; bar = bar + 1) {
-[33m[tester::#BW6] [test-2.lox] [0m  print bar;
-[33m[tester::#BW6] [test-2.lox] [0m}
+[33m[tester::#BW6] [test-2.lox] [0m[0m[33m// This program uses a for loop to print the[0m[0m
+[33m[tester::#BW6] [test-2.lox] [0m[0m[33m// numbers from 0 to 3[0m[0m
+[33m[tester::#BW6] [test-2.lox] [0m[0mfor (var bar = 0; bar < 3; bar = bar + 1) {[0m
+[33m[tester::#BW6] [test-2.lox] [0m[0m  print bar;[0m
+[33m[tester::#BW6] [test-2.lox] [0m[0m}[0m
 [33m[tester::#BW6] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m0
-[33m[your_program] [0m1
-[33m[your_program] [0m2
+[33m[your_program] [0m[0m0[0m
+[33m[your_program] [0m[0m1[0m
+[33m[your_program] [0m[0m2[0m
 [33m[tester::#BW6] [test-2] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#BW6] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#BW6] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#BW6] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#BW6] [test-3.lox] [0m[33m// This program uses a for loop to print the[0m
-[33m[tester::#BW6] [test-3.lox] [0m[33m// numbers from 0 to 2[0m
-[33m[tester::#BW6] [test-3.lox] [0m[33m// The loop initializer is ignored in this loop[0m
-[33m[tester::#BW6] [test-3.lox] [0mvar baz = 0;
-[33m[tester::#BW6] [test-3.lox] [0mfor (; baz < 2; baz = baz + 1) print baz;
-[33m[tester::#BW6] [test-3.lox] [0m
-[33m[tester::#BW6] [test-3.lox] [0m[33m// This program uses a for loop to print the[0m
-[33m[tester::#BW6] [test-3.lox] [0m[33m// numbers from 0 to 2[0m
-[33m[tester::#BW6] [test-3.lox] [0m[33m// The loop increment clause is ignored in this[0m
-[33m[tester::#BW6] [test-3.lox] [0m[33m// loop[0m
-[33m[tester::#BW6] [test-3.lox] [0mfor (var bar = 0; bar < 2;) {
-[33m[tester::#BW6] [test-3.lox] [0m  print bar;
-[33m[tester::#BW6] [test-3.lox] [0m  bar = bar + 1;
-[33m[tester::#BW6] [test-3.lox] [0m}
+[33m[tester::#BW6] [test-3.lox] [0m[0m[33m// This program uses a for loop to print the[0m[0m
+[33m[tester::#BW6] [test-3.lox] [0m[0m[33m// numbers from 0 to 2[0m[0m
+[33m[tester::#BW6] [test-3.lox] [0m[0m[33m// The loop initializer is ignored in this loop[0m[0m
+[33m[tester::#BW6] [test-3.lox] [0m[0mvar baz = 0;[0m
+[33m[tester::#BW6] [test-3.lox] [0m[0mfor (; baz < 2; baz = baz + 1) print baz;[0m
+[33m[tester::#BW6] [test-3.lox] [0m[0m[0m
+[33m[tester::#BW6] [test-3.lox] [0m[0m[33m// This program uses a for loop to print the[0m[0m
+[33m[tester::#BW6] [test-3.lox] [0m[0m[33m// numbers from 0 to 2[0m[0m
+[33m[tester::#BW6] [test-3.lox] [0m[0m[33m// The loop increment clause is ignored in this[0m[0m
+[33m[tester::#BW6] [test-3.lox] [0m[0m[33m// loop[0m[0m
+[33m[tester::#BW6] [test-3.lox] [0m[0mfor (var bar = 0; bar < 2;) {[0m
+[33m[tester::#BW6] [test-3.lox] [0m[0m  print bar;[0m
+[33m[tester::#BW6] [test-3.lox] [0m[0m  bar = bar + 1;[0m
+[33m[tester::#BW6] [test-3.lox] [0m[0m}[0m
 [33m[tester::#BW6] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m0
-[33m[your_program] [0m1
-[33m[your_program] [0m0
-[33m[your_program] [0m1
+[33m[your_program] [0m[0m0[0m
+[33m[your_program] [0m[0m1[0m
+[33m[your_program] [0m[0m0[0m
+[33m[your_program] [0m[0m1[0m
 [33m[tester::#BW6] [test-3] [0m[92m✓ 4 line(s) match on stdout[0m
 [33m[tester::#BW6] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#BW6] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#BW6] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#BW6] [test-4.lox] [0m[33m// This program uses for loops and block scopes[0m
-[33m[tester::#BW6] [test-4.lox] [0m[33m// to print the updates to the same variable[0m
-[33m[tester::#BW6] [test-4.lox] [0mvar baz = "after";
-[33m[tester::#BW6] [test-4.lox] [0m{
-[33m[tester::#BW6] [test-4.lox] [0m  var baz = "before";
-[33m[tester::#BW6] [test-4.lox] [0m
-[33m[tester::#BW6] [test-4.lox] [0m  for (var baz = 0; baz < 1; baz = baz + 1) {
-[33m[tester::#BW6] [test-4.lox] [0m    print baz;
-[33m[tester::#BW6] [test-4.lox] [0m    var baz = -1;
-[33m[tester::#BW6] [test-4.lox] [0m    print baz;
-[33m[tester::#BW6] [test-4.lox] [0m  }
-[33m[tester::#BW6] [test-4.lox] [0m}
-[33m[tester::#BW6] [test-4.lox] [0m
-[33m[tester::#BW6] [test-4.lox] [0m{
-[33m[tester::#BW6] [test-4.lox] [0m  for (var baz = 0; baz > 0; baz = baz + 1) {}
-[33m[tester::#BW6] [test-4.lox] [0m
-[33m[tester::#BW6] [test-4.lox] [0m  var baz = "after";
-[33m[tester::#BW6] [test-4.lox] [0m  print baz;
-[33m[tester::#BW6] [test-4.lox] [0m
-[33m[tester::#BW6] [test-4.lox] [0m  for (baz = 0; baz < 1; baz = baz + 1) {
-[33m[tester::#BW6] [test-4.lox] [0m    print baz;
-[33m[tester::#BW6] [test-4.lox] [0m  }
-[33m[tester::#BW6] [test-4.lox] [0m}
+[33m[tester::#BW6] [test-4.lox] [0m[0m[33m// This program uses for loops and block scopes[0m[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m[33m// to print the updates to the same variable[0m[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0mvar baz = "after";[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m{[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m  var baz = "before";[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m  for (var baz = 0; baz < 1; baz = baz + 1) {[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m    print baz;[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m    var baz = -1;[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m    print baz;[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m}[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m{[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m  for (var baz = 0; baz > 0; baz = baz + 1) {}[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m  var baz = "after";[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m  print baz;[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m  for (baz = 0; baz < 1; baz = baz + 1) {[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m    print baz;[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#BW6] [test-4.lox] [0m[0m}[0m
 [33m[tester::#BW6] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m0
-[33m[your_program] [0m-1
-[33m[your_program] [0mafter
-[33m[your_program] [0m0
+[33m[your_program] [0m[0m0[0m
+[33m[your_program] [0m[0m-1[0m
+[33m[your_program] [0m[0mafter[0m
+[33m[your_program] [0m[0m0[0m
 [33m[tester::#BW6] [test-4] [0m[92m✓ 4 line(s) match on stdout[0m
 [33m[tester::#BW6] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#BW6] [0m[92mTest passed.[0m
@@ -622,41 +622,41 @@ Debug = true
 [33m[tester::#VT1] [0m[94mRunning tests for Stage #VT1 (vt1)[0m
 [33m[tester::#VT1] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#VT1] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#VT1] [test-1.lox] [0m[33m// This program would give a compile error[0m
-[33m[tester::#VT1] [test-1.lox] [0m[33m// because the variable declaration is not[0m
-[33m[tester::#VT1] [test-1.lox] [0m[33m// inside a block[0m
-[33m[tester::#VT1] [test-1.lox] [0mfor (;;) var foo;
+[33m[tester::#VT1] [test-1.lox] [0m[0m[33m// This program would give a compile error[0m[0m
+[33m[tester::#VT1] [test-1.lox] [0m[0m[33m// because the variable declaration is not[0m[0m
+[33m[tester::#VT1] [test-1.lox] [0m[0m[33m// inside a block[0m[0m
+[33m[tester::#VT1] [test-1.lox] [0m[0mfor (;;) var foo;[0m
 [33m[tester::#VT1] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 4] Error at 'var': Expect expression.
+[33m[your_program] [0m[0m[line 4] Error at 'var': Expect expression.[0m
 [33m[tester::#VT1] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#VT1] [test-1] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#VT1] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#VT1] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#VT1] [test-2.lox] [0m[33m// This program would give a compile error[0m
-[33m[tester::#VT1] [test-2.lox] [0m[33m// because the condition is not valid[0m
-[33m[tester::#VT1] [test-2.lox] [0mfor (var a = 1; {}; a = a + 1) {}
+[33m[tester::#VT1] [test-2.lox] [0m[0m[33m// This program would give a compile error[0m[0m
+[33m[tester::#VT1] [test-2.lox] [0m[0m[33m// because the condition is not valid[0m[0m
+[33m[tester::#VT1] [test-2.lox] [0m[0mfor (var a = 1; {}; a = a + 1) {}[0m
 [33m[tester::#VT1] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 3] Error at '{': Expect expression.
-[33m[your_program] [0m[line 3] Error at ')': Expect ';' after expression.
+[33m[your_program] [0m[0m[line 3] Error at '{': Expect expression.[0m
+[33m[your_program] [0m[0m[line 3] Error at ')': Expect ';' after expression.[0m
 [33m[tester::#VT1] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#VT1] [test-2] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#VT1] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#VT1] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#VT1] [test-3.lox] [0m[33m// This program would give a compile error[0m
-[33m[tester::#VT1] [test-3.lox] [0m[33m// because the increment clause is not valid[0m
-[33m[tester::#VT1] [test-3.lox] [0mfor (var a = 1; a < 2; {}) {}
+[33m[tester::#VT1] [test-3.lox] [0m[0m[33m// This program would give a compile error[0m[0m
+[33m[tester::#VT1] [test-3.lox] [0m[0m[33m// because the increment clause is not valid[0m[0m
+[33m[tester::#VT1] [test-3.lox] [0m[0mfor (var a = 1; a < 2; {}) {}[0m
 [33m[tester::#VT1] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 3] Error at '{': Expect expression.
+[33m[your_program] [0m[0m[line 3] Error at '{': Expect expression.[0m
 [33m[tester::#VT1] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#VT1] [test-3] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#VT1] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#VT1] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#VT1] [test-4.lox] [0m[33m// This program would give a compile error[0m
-[33m[tester::#VT1] [test-4.lox] [0m[33m// because the initialization clause is not valid[0m
-[33m[tester::#VT1] [test-4.lox] [0mfor ({}; a < 2; a = a + 1) {}
+[33m[tester::#VT1] [test-4.lox] [0m[0m[33m// This program would give a compile error[0m[0m
+[33m[tester::#VT1] [test-4.lox] [0m[0m[33m// because the initialization clause is not valid[0m[0m
+[33m[tester::#VT1] [test-4.lox] [0m[0mfor ({}; a < 2; a = a + 1) {}[0m
 [33m[tester::#VT1] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 3] Error at '{': Expect expression.
-[33m[your_program] [0m[line 3] Error at ')': Expect ';' after expression.
+[33m[your_program] [0m[0m[line 3] Error at '{': Expect expression.[0m
+[33m[your_program] [0m[0m[line 3] Error at ')': Expect ';' after expression.[0m
 [33m[tester::#VT1] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#VT1] [test-4] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#VT1] [0m[92mTest passed.[0m

--- a/internal/test_helpers/fixtures/pass_evaluating
+++ b/internal/test_helpers/fixtures/pass_evaluating
@@ -3,34 +3,34 @@ Debug = true
 [33m[tester::#IB5] [0m[94mRunning tests for Stage #IB5 (ib5)[0m
 [33m[tester::#IB5] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#IB5] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#IB5] [test-1.lox] [0m"foo" < false
+[33m[tester::#IB5] [test-1.lox] [0m[0m"foo" < false[0m
 [33m[tester::#IB5] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mOperands must be numbers.
-[33m[your_program] [0m[line 1]
+[33m[your_program] [0m[0mOperands must be numbers.[0m
+[33m[your_program] [0m[0m[line 1][0m
 [33m[tester::#IB5] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#IB5] [test-1] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#IB5] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#IB5] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#IB5] [test-2.lox] [0mtrue <= (44 + 54)
+[33m[tester::#IB5] [test-2.lox] [0m[0mtrue <= (44 + 54)[0m
 [33m[tester::#IB5] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mOperands must be numbers.
-[33m[your_program] [0m[line 1]
+[33m[your_program] [0m[0mOperands must be numbers.[0m
+[33m[your_program] [0m[0m[line 1][0m
 [33m[tester::#IB5] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#IB5] [test-2] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#IB5] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#IB5] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#IB5] [test-3.lox] [0m80 > ("quz" + "foo")
+[33m[tester::#IB5] [test-3.lox] [0m[0m80 > ("quz" + "foo")[0m
 [33m[tester::#IB5] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mOperands must be numbers.
-[33m[your_program] [0m[line 1]
+[33m[your_program] [0m[0mOperands must be numbers.[0m
+[33m[your_program] [0m[0m[line 1][0m
 [33m[tester::#IB5] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#IB5] [test-3] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#IB5] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#IB5] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#IB5] [test-4.lox] [0mfalse >= true
+[33m[tester::#IB5] [test-4.lox] [0m[0mfalse >= true[0m
 [33m[tester::#IB5] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mOperands must be numbers.
-[33m[your_program] [0m[line 1]
+[33m[your_program] [0m[0mOperands must be numbers.[0m
+[33m[your_program] [0m[0m[line 1][0m
 [33m[tester::#IB5] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#IB5] [test-4] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#IB5] [0m[92mTest passed.[0m
@@ -38,34 +38,34 @@ Debug = true
 [33m[tester::#CQ1] [0m[94mRunning tests for Stage #CQ1 (cq1)[0m
 [33m[tester::#CQ1] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#CQ1] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#CQ1] [test-1.lox] [0m"foo" + true
+[33m[tester::#CQ1] [test-1.lox] [0m[0m"foo" + true[0m
 [33m[tester::#CQ1] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mOperands must be two numbers or two strings.
-[33m[your_program] [0m[line 1]
+[33m[your_program] [0m[0mOperands must be two numbers or two strings.[0m
+[33m[your_program] [0m[0m[line 1][0m
 [33m[tester::#CQ1] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#CQ1] [test-1] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#CQ1] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#CQ1] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#CQ1] [test-2.lox] [0m70 + "baz" + 95
+[33m[tester::#CQ1] [test-2.lox] [0m[0m70 + "baz" + 95[0m
 [33m[tester::#CQ1] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mOperands must be two numbers or two strings.
-[33m[your_program] [0m[line 1]
+[33m[your_program] [0m[0mOperands must be two numbers or two strings.[0m
+[33m[your_program] [0m[0m[line 1][0m
 [33m[tester::#CQ1] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#CQ1] [test-2] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#CQ1] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#CQ1] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#CQ1] [test-3.lox] [0m89 - false
+[33m[tester::#CQ1] [test-3.lox] [0m[0m89 - false[0m
 [33m[tester::#CQ1] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mOperands must be numbers.
-[33m[your_program] [0m[line 1]
+[33m[your_program] [0m[0mOperands must be numbers.[0m
+[33m[your_program] [0m[0m[line 1][0m
 [33m[tester::#CQ1] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#CQ1] [test-3] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#CQ1] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#CQ1] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#CQ1] [test-4.lox] [0mtrue - ("bar" + "hello")
+[33m[tester::#CQ1] [test-4.lox] [0m[0mtrue - ("bar" + "hello")[0m
 [33m[tester::#CQ1] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mOperands must be numbers.
-[33m[your_program] [0m[line 1]
+[33m[your_program] [0m[0mOperands must be numbers.[0m
+[33m[your_program] [0m[0m[line 1][0m
 [33m[tester::#CQ1] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#CQ1] [test-4] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#CQ1] [0m[92mTest passed.[0m
@@ -73,34 +73,34 @@ Debug = true
 [33m[tester::#YU6] [0m[94mRunning tests for Stage #YU6 (yu6)[0m
 [33m[tester::#YU6] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#YU6] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YU6] [test-1.lox] [0m82 * "foo"
+[33m[tester::#YU6] [test-1.lox] [0m[0m82 * "foo"[0m
 [33m[tester::#YU6] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mOperands must be numbers.
-[33m[your_program] [0m[line 1]
+[33m[your_program] [0m[0mOperands must be numbers.[0m
+[33m[your_program] [0m[0m[line 1][0m
 [33m[tester::#YU6] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#YU6] [test-1] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#YU6] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#YU6] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YU6] [test-2.lox] [0m"quz" / 17
+[33m[tester::#YU6] [test-2.lox] [0m[0m"quz" / 17[0m
 [33m[tester::#YU6] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mOperands must be numbers.
-[33m[your_program] [0m[line 1]
+[33m[your_program] [0m[0mOperands must be numbers.[0m
+[33m[your_program] [0m[0m[line 1][0m
 [33m[tester::#YU6] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#YU6] [test-2] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#YU6] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#YU6] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YU6] [test-3.lox] [0mtrue / false
+[33m[tester::#YU6] [test-3.lox] [0m[0mtrue / false[0m
 [33m[tester::#YU6] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mOperands must be numbers.
-[33m[your_program] [0m[line 1]
+[33m[your_program] [0m[0mOperands must be numbers.[0m
+[33m[your_program] [0m[0m[line 1][0m
 [33m[tester::#YU6] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#YU6] [test-3] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#YU6] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#YU6] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YU6] [test-4.lox] [0m("foo" + "world") * ("foo" + "hello")
+[33m[tester::#YU6] [test-4.lox] [0m[0m("foo" + "world") * ("foo" + "hello")[0m
 [33m[tester::#YU6] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mOperands must be numbers.
-[33m[your_program] [0m[line 1]
+[33m[your_program] [0m[0mOperands must be numbers.[0m
+[33m[your_program] [0m[0m[line 1][0m
 [33m[tester::#YU6] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#YU6] [test-4] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#YU6] [0m[92mTest passed.[0m
@@ -108,34 +108,34 @@ Debug = true
 [33m[tester::#GJ9] [0m[94mRunning tests for Stage #GJ9 (gj9)[0m
 [33m[tester::#GJ9] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#GJ9] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#GJ9] [test-1.lox] [0m-"foo"
+[33m[tester::#GJ9] [test-1.lox] [0m[0m-"foo"[0m
 [33m[tester::#GJ9] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mOperand must be a number.
-[33m[your_program] [0m[line 1]
+[33m[your_program] [0m[0mOperand must be a number.[0m
+[33m[your_program] [0m[0m[line 1][0m
 [33m[tester::#GJ9] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#GJ9] [test-1] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#GJ9] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#GJ9] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#GJ9] [test-2.lox] [0m-true
+[33m[tester::#GJ9] [test-2.lox] [0m[0m-true[0m
 [33m[tester::#GJ9] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mOperand must be a number.
-[33m[your_program] [0m[line 1]
+[33m[your_program] [0m[0mOperand must be a number.[0m
+[33m[your_program] [0m[0m[line 1][0m
 [33m[tester::#GJ9] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#GJ9] [test-2] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#GJ9] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#GJ9] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#GJ9] [test-3.lox] [0m-false
+[33m[tester::#GJ9] [test-3.lox] [0m[0m-false[0m
 [33m[tester::#GJ9] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mOperand must be a number.
-[33m[your_program] [0m[line 1]
+[33m[your_program] [0m[0mOperand must be a number.[0m
+[33m[your_program] [0m[0m[line 1][0m
 [33m[tester::#GJ9] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#GJ9] [test-3] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#GJ9] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#GJ9] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#GJ9] [test-4.lox] [0m-("foo" + "world")
+[33m[tester::#GJ9] [test-4.lox] [0m[0m-("foo" + "world")[0m
 [33m[tester::#GJ9] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mOperand must be a number.
-[33m[your_program] [0m[line 1]
+[33m[your_program] [0m[0mOperand must be a number.[0m
+[33m[your_program] [0m[0m[line 1][0m
 [33m[tester::#GJ9] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#GJ9] [test-4] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#GJ9] [0m[92mTest passed.[0m
@@ -143,30 +143,30 @@ Debug = true
 [33m[tester::#HW7] [0m[94mRunning tests for Stage #HW7 (hw7)[0m
 [33m[tester::#HW7] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#HW7] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#HW7] [test-1.lox] [0m"baz" != "bar"
+[33m[tester::#HW7] [test-1.lox] [0m[0m"baz" != "bar"[0m
 [33m[tester::#HW7] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mtrue
+[33m[your_program] [0m[0mtrue[0m
 [33m[tester::#HW7] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#HW7] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#HW7] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#HW7] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#HW7] [test-2.lox] [0m"baz" == "baz"
+[33m[tester::#HW7] [test-2.lox] [0m[0m"baz" == "baz"[0m
 [33m[tester::#HW7] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mtrue
+[33m[your_program] [0m[0mtrue[0m
 [33m[tester::#HW7] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#HW7] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#HW7] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#HW7] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#HW7] [test-3.lox] [0m82 == "82"
+[33m[tester::#HW7] [test-3.lox] [0m[0m82 == "82"[0m
 [33m[tester::#HW7] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mfalse
+[33m[your_program] [0m[0mfalse[0m
 [33m[tester::#HW7] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#HW7] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#HW7] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#HW7] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#HW7] [test-4.lox] [0m129 == (35 + 94)
+[33m[tester::#HW7] [test-4.lox] [0m[0m129 == (35 + 94)[0m
 [33m[tester::#HW7] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mtrue
+[33m[your_program] [0m[0mtrue[0m
 [33m[tester::#HW7] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#HW7] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#HW7] [0m[92mTest passed.[0m
@@ -174,30 +174,30 @@ Debug = true
 [33m[tester::#ET4] [0m[94mRunning tests for Stage #ET4 (et4)[0m
 [33m[tester::#ET4] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#ET4] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#ET4] [test-1.lox] [0m58 > -116
+[33m[tester::#ET4] [test-1.lox] [0m[0m58 > -116[0m
 [33m[tester::#ET4] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mtrue
+[33m[your_program] [0m[0mtrue[0m
 [33m[tester::#ET4] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#ET4] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#ET4] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#ET4] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#ET4] [test-2.lox] [0m58 <= 134
+[33m[tester::#ET4] [test-2.lox] [0m[0m58 <= 134[0m
 [33m[tester::#ET4] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mtrue
+[33m[your_program] [0m[0mtrue[0m
 [33m[tester::#ET4] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#ET4] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#ET4] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#ET4] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#ET4] [test-3.lox] [0m18 >= 18
+[33m[tester::#ET4] [test-3.lox] [0m[0m18 >= 18[0m
 [33m[tester::#ET4] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mtrue
+[33m[your_program] [0m[0mtrue[0m
 [33m[tester::#ET4] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#ET4] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#ET4] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#ET4] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#ET4] [test-4.lox] [0m(49 - 98) >= -(116 / 58 + 65)
+[33m[tester::#ET4] [test-4.lox] [0m[0m(49 - 98) >= -(116 / 58 + 65)[0m
 [33m[tester::#ET4] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mtrue
+[33m[your_program] [0m[0mtrue[0m
 [33m[tester::#ET4] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#ET4] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#ET4] [0m[92mTest passed.[0m
@@ -205,30 +205,30 @@ Debug = true
 [33m[tester::#JX8] [0m[94mRunning tests for Stage #JX8 (jx8)[0m
 [33m[tester::#JX8] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#JX8] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#JX8] [test-1.lox] [0m"world" + "foo"
+[33m[tester::#JX8] [test-1.lox] [0m[0m"world" + "foo"[0m
 [33m[tester::#JX8] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mworldfoo
+[33m[your_program] [0m[0mworldfoo[0m
 [33m[tester::#JX8] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#JX8] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#JX8] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#JX8] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#JX8] [test-2.lox] [0m"foo" + "37"
+[33m[tester::#JX8] [test-2.lox] [0m[0m"foo" + "37"[0m
 [33m[tester::#JX8] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mfoo37
+[33m[your_program] [0m[0mfoo37[0m
 [33m[tester::#JX8] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#JX8] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#JX8] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#JX8] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#JX8] [test-3.lox] [0m"quz" + "world" + "quz"
+[33m[tester::#JX8] [test-3.lox] [0m[0m"quz" + "world" + "quz"[0m
 [33m[tester::#JX8] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mquzworldquz
+[33m[your_program] [0m[0mquzworldquz[0m
 [33m[tester::#JX8] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#JX8] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#JX8] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#JX8] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#JX8] [test-4.lox] [0m("baz" + "hello") + ("baz" + "baz")
+[33m[tester::#JX8] [test-4.lox] [0m[0m("baz" + "hello") + ("baz" + "baz")[0m
 [33m[tester::#JX8] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mbazhellobazbaz
+[33m[your_program] [0m[0mbazhellobazbaz[0m
 [33m[tester::#JX8] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#JX8] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#JX8] [0m[92mTest passed.[0m
@@ -236,30 +236,30 @@ Debug = true
 [33m[tester::#JY2] [0m[94mRunning tests for Stage #JY2 (jy2)[0m
 [33m[tester::#JY2] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#JY2] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#JY2] [test-1.lox] [0m64 - 68
+[33m[tester::#JY2] [test-1.lox] [0m[0m64 - 68[0m
 [33m[tester::#JY2] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m-4
+[33m[your_program] [0m[0m-4[0m
 [33m[tester::#JY2] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#JY2] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#JY2] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#JY2] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#JY2] [test-2.lox] [0m92 + 53 - 75
+[33m[tester::#JY2] [test-2.lox] [0m[0m92 + 53 - 75[0m
 [33m[tester::#JY2] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m70
+[33m[your_program] [0m[0m70[0m
 [33m[tester::#JY2] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#JY2] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#JY2] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#JY2] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#JY2] [test-3.lox] [0m57 + 93 - (-(67 - 57))
+[33m[tester::#JY2] [test-3.lox] [0m[0m57 + 93 - (-(67 - 57))[0m
 [33m[tester::#JY2] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m160
+[33m[your_program] [0m[0m160[0m
 [33m[tester::#JY2] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#JY2] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#JY2] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#JY2] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#JY2] [test-4.lox] [0m(-97 + 97) * (34 * 77) / (1 + 4)
+[33m[tester::#JY2] [test-4.lox] [0m[0m(-97 + 97) * (34 * 77) / (1 + 4)[0m
 [33m[tester::#JY2] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m0
+[33m[your_program] [0m[0m0[0m
 [33m[tester::#JY2] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#JY2] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#JY2] [0m[92mTest passed.[0m
@@ -267,30 +267,30 @@ Debug = true
 [33m[tester::#BP3] [0m[94mRunning tests for Stage #BP3 (bp3)[0m
 [33m[tester::#BP3] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#BP3] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#BP3] [test-1.lox] [0m52 * 29
+[33m[tester::#BP3] [test-1.lox] [0m[0m52 * 29[0m
 [33m[tester::#BP3] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m1508
+[33m[your_program] [0m[0m1508[0m
 [33m[tester::#BP3] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#BP3] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#BP3] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#BP3] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#BP3] [test-2.lox] [0m75 / 5
+[33m[tester::#BP3] [test-2.lox] [0m[0m75 / 5[0m
 [33m[tester::#BP3] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m15
+[33m[your_program] [0m[0m15[0m
 [33m[tester::#BP3] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#BP3] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#BP3] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#BP3] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#BP3] [test-3.lox] [0m7 * 4 / 7 / 1
+[33m[tester::#BP3] [test-3.lox] [0m[0m7 * 4 / 7 / 1[0m
 [33m[tester::#BP3] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m4
+[33m[your_program] [0m[0m4[0m
 [33m[tester::#BP3] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#BP3] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#BP3] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#BP3] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#BP3] [test-4.lox] [0m(18 * 4 / (3 * 6))
+[33m[tester::#BP3] [test-4.lox] [0m[0m(18 * 4 / (3 * 6))[0m
 [33m[tester::#BP3] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m4
+[33m[your_program] [0m[0m4[0m
 [33m[tester::#BP3] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#BP3] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#BP3] [0m[92mTest passed.[0m
@@ -298,30 +298,30 @@ Debug = true
 [33m[tester::#DC1] [0m[94mRunning tests for Stage #DC1 (dc1)[0m
 [33m[tester::#DC1] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#DC1] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#DC1] [test-1.lox] [0m-75
+[33m[tester::#DC1] [test-1.lox] [0m[0m-75[0m
 [33m[tester::#DC1] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m-75
+[33m[your_program] [0m[0m-75[0m
 [33m[tester::#DC1] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#DC1] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#DC1] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#DC1] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#DC1] [test-2.lox] [0m!true
+[33m[tester::#DC1] [test-2.lox] [0m[0m!true[0m
 [33m[tester::#DC1] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mfalse
+[33m[your_program] [0m[0mfalse[0m
 [33m[tester::#DC1] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#DC1] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#DC1] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#DC1] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#DC1] [test-3.lox] [0m!nil
+[33m[tester::#DC1] [test-3.lox] [0m[0m!nil[0m
 [33m[tester::#DC1] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mtrue
+[33m[your_program] [0m[0mtrue[0m
 [33m[tester::#DC1] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#DC1] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#DC1] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#DC1] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#DC1] [test-4.lox] [0m(!!61)
+[33m[tester::#DC1] [test-4.lox] [0m[0m(!!61)[0m
 [33m[tester::#DC1] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mtrue
+[33m[your_program] [0m[0mtrue[0m
 [33m[tester::#DC1] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#DC1] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#DC1] [0m[92mTest passed.[0m
@@ -329,30 +329,30 @@ Debug = true
 [33m[tester::#OQ9] [0m[94mRunning tests for Stage #OQ9 (oq9)[0m
 [33m[tester::#OQ9] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#OQ9] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#OQ9] [test-1.lox] [0m(true)
+[33m[tester::#OQ9] [test-1.lox] [0m[0m(true)[0m
 [33m[tester::#OQ9] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mtrue
+[33m[your_program] [0m[0mtrue[0m
 [33m[tester::#OQ9] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#OQ9] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#OQ9] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#OQ9] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#OQ9] [test-2.lox] [0m(95)
+[33m[tester::#OQ9] [test-2.lox] [0m[0m(95)[0m
 [33m[tester::#OQ9] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m95
+[33m[your_program] [0m[0m95[0m
 [33m[tester::#OQ9] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#OQ9] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#OQ9] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#OQ9] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#OQ9] [test-3.lox] [0m("world bar")
+[33m[tester::#OQ9] [test-3.lox] [0m[0m("world bar")[0m
 [33m[tester::#OQ9] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mworld bar
+[33m[your_program] [0m[0mworld bar[0m
 [33m[tester::#OQ9] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#OQ9] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#OQ9] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#OQ9] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#OQ9] [test-4.lox] [0m((false))
+[33m[tester::#OQ9] [test-4.lox] [0m[0m((false))[0m
 [33m[tester::#OQ9] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mfalse
+[33m[your_program] [0m[0mfalse[0m
 [33m[tester::#OQ9] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#OQ9] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#OQ9] [0m[92mTest passed.[0m
@@ -360,30 +360,30 @@ Debug = true
 [33m[tester::#LV1] [0m[94mRunning tests for Stage #LV1 (lv1)[0m
 [33m[tester::#LV1] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#LV1] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#LV1] [test-1.lox] [0m51
+[33m[tester::#LV1] [test-1.lox] [0m[0m51[0m
 [33m[tester::#LV1] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m51
+[33m[your_program] [0m[0m51[0m
 [33m[tester::#LV1] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#LV1] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#LV1] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#LV1] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#LV1] [test-2.lox] [0m51.96
+[33m[tester::#LV1] [test-2.lox] [0m[0m51.96[0m
 [33m[tester::#LV1] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m51.96
+[33m[your_program] [0m[0m51.96[0m
 [33m[tester::#LV1] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#LV1] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#LV1] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#LV1] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#LV1] [test-3.lox] [0m"quz hello"
+[33m[tester::#LV1] [test-3.lox] [0m[0m"quz hello"[0m
 [33m[tester::#LV1] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mquz hello
+[33m[your_program] [0m[0mquz hello[0m
 [33m[tester::#LV1] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#LV1] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#LV1] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#LV1] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#LV1] [test-4.lox] [0m"71"
+[33m[tester::#LV1] [test-4.lox] [0m[0m"71"[0m
 [33m[tester::#LV1] [test-4] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0m71
+[33m[your_program] [0m[0m71[0m
 [33m[tester::#LV1] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#LV1] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#LV1] [0m[92mTest passed.[0m
@@ -391,23 +391,23 @@ Debug = true
 [33m[tester::#IZ6] [0m[94mRunning tests for Stage #IZ6 (iz6)[0m
 [33m[tester::#IZ6] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#IZ6] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#IZ6] [test-1.lox] [0mtrue
+[33m[tester::#IZ6] [test-1.lox] [0m[0mtrue[0m
 [33m[tester::#IZ6] [test-1] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mtrue
+[33m[your_program] [0m[0mtrue[0m
 [33m[tester::#IZ6] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#IZ6] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#IZ6] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#IZ6] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#IZ6] [test-2.lox] [0mfalse
+[33m[tester::#IZ6] [test-2.lox] [0m[0mfalse[0m
 [33m[tester::#IZ6] [test-2] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mfalse
+[33m[your_program] [0m[0mfalse[0m
 [33m[tester::#IZ6] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#IZ6] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#IZ6] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#IZ6] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#IZ6] [test-3.lox] [0mnil
+[33m[tester::#IZ6] [test-3.lox] [0m[0mnil[0m
 [33m[tester::#IZ6] [test-3] [0m[94m$ ./your_program.sh evaluate test.lox[0m
-[33m[your_program] [0mnil
+[33m[your_program] [0m[0mnil[0m
 [33m[tester::#IZ6] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#IZ6] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#IZ6] [0m[92mTest passed.[0m

--- a/internal/test_helpers/fixtures/pass_functions
+++ b/internal/test_helpers/fixtures/pass_functions
@@ -3,63 +3,63 @@ Debug = true
 [33m[tester::#AV4] [0m[94mRunning tests for Stage #AV4 (av4)[0m
 [33m[tester::#AV4] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#AV4] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#AV4] [test-1.lox] [0mprint clock() + 23;
+[33m[tester::#AV4] [test-1.lox] [0m[0mprint clock() + 23;[0m
 [33m[tester::#AV4] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m1.75019176479E9
-[33m[tester::#AV4] [test-1] [0m[92m✓ 1750191764.790000[0m
+[33m[your_program] [0m[0m1.767707888092E9[0m
+[33m[tester::#AV4] [test-1] [0m[92m✓ 1767707888.092000[0m
 [33m[tester::#AV4] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#AV4] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#AV4] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#AV4] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#AV4] [test-2.lox] [0mprint clock() / 1000;
+[33m[tester::#AV4] [test-2.lox] [0m[0mprint clock() / 1000;[0m
 [33m[tester::#AV4] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m1750191.741841
-[33m[tester::#AV4] [test-2] [0m[92m✓ 1750191.741841[0m
+[33m[your_program] [0m[0m1767707.8651440002[0m
+[33m[tester::#AV4] [test-2] [0m[92m✓ 1767707.865144[0m
 [33m[tester::#AV4] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#AV4] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#AV4] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#AV4] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#AV4] [test-3.lox] [0m[33m// This program utilizes the built-in clock()[0m
-[33m[tester::#AV4] [test-3.lox] [0m[33m// function[0m
-[33m[tester::#AV4] [test-3.lox] [0m[33m// and runs a check to see if the operation has[0m
-[33m[tester::#AV4] [test-3.lox] [0m[33m// timed out[0m
-[33m[tester::#AV4] [test-3.lox] [0mvar startTime = clock();
-[33m[tester::#AV4] [test-3.lox] [0mvar timeoutSeconds = 2;
-[33m[tester::#AV4] [test-3.lox] [0m
-[33m[tester::#AV4] [test-3.lox] [0m[33m// Check if less than 2 seconds have elapsed[0m
-[33m[tester::#AV4] [test-3.lox] [0mvar c1 = clock() >= startTime;
-[33m[tester::#AV4] [test-3.lox] [0mvar c2 = clock() <= (startTime + timeoutSeconds);
-[33m[tester::#AV4] [test-3.lox] [0m
-[33m[tester::#AV4] [test-3.lox] [0mif (c1 and c2) {
-[33m[tester::#AV4] [test-3.lox] [0m  print "Operation in progress...";
-[33m[tester::#AV4] [test-3.lox] [0m} else {
-[33m[tester::#AV4] [test-3.lox] [0m  print "Operation timed out!";
-[33m[tester::#AV4] [test-3.lox] [0m}
+[33m[tester::#AV4] [test-3.lox] [0m[0m[33m// This program utilizes the built-in clock()[0m[0m
+[33m[tester::#AV4] [test-3.lox] [0m[0m[33m// function[0m[0m
+[33m[tester::#AV4] [test-3.lox] [0m[0m[33m// and runs a check to see if the operation has[0m[0m
+[33m[tester::#AV4] [test-3.lox] [0m[0m[33m// timed out[0m[0m
+[33m[tester::#AV4] [test-3.lox] [0m[0mvar startTime = clock();[0m
+[33m[tester::#AV4] [test-3.lox] [0m[0mvar timeoutSeconds = 2;[0m
+[33m[tester::#AV4] [test-3.lox] [0m[0m[0m
+[33m[tester::#AV4] [test-3.lox] [0m[0m[33m// Check if less than 2 seconds have elapsed[0m[0m
+[33m[tester::#AV4] [test-3.lox] [0m[0mvar c1 = clock() >= startTime;[0m
+[33m[tester::#AV4] [test-3.lox] [0m[0mvar c2 = clock() <= (startTime + timeoutSeconds);[0m
+[33m[tester::#AV4] [test-3.lox] [0m[0m[0m
+[33m[tester::#AV4] [test-3.lox] [0m[0mif (c1 and c2) {[0m
+[33m[tester::#AV4] [test-3.lox] [0m[0m  print "Operation in progress...";[0m
+[33m[tester::#AV4] [test-3.lox] [0m[0m} else {[0m
+[33m[tester::#AV4] [test-3.lox] [0m[0m  print "Operation timed out!";[0m
+[33m[tester::#AV4] [test-3.lox] [0m[0m}[0m
 [33m[tester::#AV4] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mOperation in progress...
+[33m[your_program] [0m[0mOperation in progress...[0m
 [33m[tester::#AV4] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#AV4] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#AV4] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#AV4] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#AV4] [test-4.lox] [0m[33m// This program utilizes the built-in clock()[0m
-[33m[tester::#AV4] [test-4.lox] [0m[33m// function[0m
-[33m[tester::#AV4] [test-4.lox] [0m[33m// to create a timer that runs for 0.2 seconds[0m
-[33m[tester::#AV4] [test-4.lox] [0mvar startTime = clock();
-[33m[tester::#AV4] [test-4.lox] [0mvar lastCheck = startTime;
-[33m[tester::#AV4] [test-4.lox] [0mvar running = true;
-[33m[tester::#AV4] [test-4.lox] [0m
-[33m[tester::#AV4] [test-4.lox] [0mprint "Starting timer for 0.2 seconds";
-[33m[tester::#AV4] [test-4.lox] [0mvar startTime = clock();
-[33m[tester::#AV4] [test-4.lox] [0m
-[33m[tester::#AV4] [test-4.lox] [0mwhile (running) {
-[33m[tester::#AV4] [test-4.lox] [0m  if (clock() > startTime + 0.2) {
-[33m[tester::#AV4] [test-4.lox] [0m    print "Timer ended";
-[33m[tester::#AV4] [test-4.lox] [0m    running = false;
-[33m[tester::#AV4] [test-4.lox] [0m  }
-[33m[tester::#AV4] [test-4.lox] [0m}
+[33m[tester::#AV4] [test-4.lox] [0m[0m[33m// This program utilizes the built-in clock()[0m[0m
+[33m[tester::#AV4] [test-4.lox] [0m[0m[33m// function[0m[0m
+[33m[tester::#AV4] [test-4.lox] [0m[0m[33m// to create a timer that runs for 0.2 seconds[0m[0m
+[33m[tester::#AV4] [test-4.lox] [0m[0mvar startTime = clock();[0m
+[33m[tester::#AV4] [test-4.lox] [0m[0mvar lastCheck = startTime;[0m
+[33m[tester::#AV4] [test-4.lox] [0m[0mvar running = true;[0m
+[33m[tester::#AV4] [test-4.lox] [0m[0m[0m
+[33m[tester::#AV4] [test-4.lox] [0m[0mprint "Starting timer for 0.2 seconds";[0m
+[33m[tester::#AV4] [test-4.lox] [0m[0mvar startTime = clock();[0m
+[33m[tester::#AV4] [test-4.lox] [0m[0m[0m
+[33m[tester::#AV4] [test-4.lox] [0m[0mwhile (running) {[0m
+[33m[tester::#AV4] [test-4.lox] [0m[0m  if (clock() > startTime + 0.2) {[0m
+[33m[tester::#AV4] [test-4.lox] [0m[0m    print "Timer ended";[0m
+[33m[tester::#AV4] [test-4.lox] [0m[0m    running = false;[0m
+[33m[tester::#AV4] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#AV4] [test-4.lox] [0m[0m}[0m
 [33m[tester::#AV4] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mStarting timer for 0.2 seconds
-[33m[your_program] [0mTimer ended
+[33m[your_program] [0m[0mStarting timer for 0.2 seconds[0m
+[33m[your_program] [0m[0mTimer ended[0m
 [33m[tester::#AV4] [test-4] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#AV4] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#AV4] [0m[92mTest passed.[0m
@@ -67,53 +67,53 @@ Debug = true
 [33m[tester::#PG8] [0m[94mRunning tests for Stage #PG8 (pg8)[0m
 [33m[tester::#PG8] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#PG8] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PG8] [test-1.lox] [0m[33m// This program defines a simple function that[0m
-[33m[tester::#PG8] [test-1.lox] [0m[33m// doesn't take any arguments[0m
-[33m[tester::#PG8] [test-1.lox] [0m[33m// and then invokes the function[0m
-[33m[tester::#PG8] [test-1.lox] [0mfun hello() { print 55; }
-[33m[tester::#PG8] [test-1.lox] [0mhello();
+[33m[tester::#PG8] [test-1.lox] [0m[0m[33m// This program defines a simple function that[0m[0m
+[33m[tester::#PG8] [test-1.lox] [0m[0m[33m// doesn't take any arguments[0m[0m
+[33m[tester::#PG8] [test-1.lox] [0m[0m[33m// and then invokes the function[0m[0m
+[33m[tester::#PG8] [test-1.lox] [0m[0mfun hello() { print 55; }[0m
+[33m[tester::#PG8] [test-1.lox] [0m[0mhello();[0m
 [33m[tester::#PG8] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m55
+[33m[your_program] [0m[0m55[0m
 [33m[tester::#PG8] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#PG8] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#PG8] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#PG8] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PG8] [test-2.lox] [0m[33m// This function, when invoked should not return[0m
-[33m[tester::#PG8] [test-2.lox] [0m[33m// or print anything[0m
-[33m[tester::#PG8] [test-2.lox] [0mfun f() {}
-[33m[tester::#PG8] [test-2.lox] [0mf();
+[33m[tester::#PG8] [test-2.lox] [0m[0m[33m// This function, when invoked should not return[0m[0m
+[33m[tester::#PG8] [test-2.lox] [0m[0m[33m// or print anything[0m[0m
+[33m[tester::#PG8] [test-2.lox] [0m[0mfun f() {}[0m
+[33m[tester::#PG8] [test-2.lox] [0m[0mf();[0m
 [33m[tester::#PG8] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
 [33m[tester::#PG8] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#PG8] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#PG8] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#PG8] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PG8] [test-3.lox] [0m[33m// This program should print <fn foo>[0m
-[33m[tester::#PG8] [test-3.lox] [0mfun foo() {}
-[33m[tester::#PG8] [test-3.lox] [0mprint foo;
+[33m[tester::#PG8] [test-3.lox] [0m[0m[33m// This program should print <fn foo>[0m[0m
+[33m[tester::#PG8] [test-3.lox] [0m[0mfun foo() {}[0m
+[33m[tester::#PG8] [test-3.lox] [0m[0mprint foo;[0m
 [33m[tester::#PG8] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m<fn foo>
+[33m[your_program] [0m[0m<fn foo>[0m
 [33m[tester::#PG8] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#PG8] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#PG8] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#PG8] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PG8] [test-4.lox] [0m[33m// This program calculates the cumulative sum of[0m
-[33m[tester::#PG8] [test-4.lox] [0m[33m// numbers from 1 to n.[0m
-[33m[tester::#PG8] [test-4.lox] [0mfun cumulative_sum() {
-[33m[tester::#PG8] [test-4.lox] [0m    var n = 10;  [33m// Fixed value[0m
-[33m[tester::#PG8] [test-4.lox] [0m    var total = 0;
-[33m[tester::#PG8] [test-4.lox] [0m    var i = 1;
-[33m[tester::#PG8] [test-4.lox] [0m    while (i <= n) {
-[33m[tester::#PG8] [test-4.lox] [0m        total = total + i;
-[33m[tester::#PG8] [test-4.lox] [0m        i = i + 1;
-[33m[tester::#PG8] [test-4.lox] [0m    }
-[33m[tester::#PG8] [test-4.lox] [0m    print "The cumulative sum from 1 to 10 is: ";
-[33m[tester::#PG8] [test-4.lox] [0m    print total;
-[33m[tester::#PG8] [test-4.lox] [0m}
-[33m[tester::#PG8] [test-4.lox] [0m
-[33m[tester::#PG8] [test-4.lox] [0mcumulative_sum();
+[33m[tester::#PG8] [test-4.lox] [0m[0m[33m// This program calculates the cumulative sum of[0m[0m
+[33m[tester::#PG8] [test-4.lox] [0m[0m[33m// numbers from 1 to n.[0m[0m
+[33m[tester::#PG8] [test-4.lox] [0m[0mfun cumulative_sum() {[0m
+[33m[tester::#PG8] [test-4.lox] [0m[0m    var n = 10;  [33m// Fixed value[0m[0m
+[33m[tester::#PG8] [test-4.lox] [0m[0m    var total = 0;[0m
+[33m[tester::#PG8] [test-4.lox] [0m[0m    var i = 1;[0m
+[33m[tester::#PG8] [test-4.lox] [0m[0m    while (i <= n) {[0m
+[33m[tester::#PG8] [test-4.lox] [0m[0m        total = total + i;[0m
+[33m[tester::#PG8] [test-4.lox] [0m[0m        i = i + 1;[0m
+[33m[tester::#PG8] [test-4.lox] [0m[0m    }[0m
+[33m[tester::#PG8] [test-4.lox] [0m[0m    print "The cumulative sum from 1 to 10 is: ";[0m
+[33m[tester::#PG8] [test-4.lox] [0m[0m    print total;[0m
+[33m[tester::#PG8] [test-4.lox] [0m[0m}[0m
+[33m[tester::#PG8] [test-4.lox] [0m[0m[0m
+[33m[tester::#PG8] [test-4.lox] [0m[0mcumulative_sum();[0m
 [33m[tester::#PG8] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mThe cumulative sum from 1 to 10 is: 
-[33m[your_program] [0m55
+[33m[your_program] [0m[0mThe cumulative sum from 1 to 10 is: [0m
+[33m[your_program] [0m[0m55[0m
 [33m[tester::#PG8] [test-4] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#PG8] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#PG8] [0m[92mTest passed.[0m
@@ -121,63 +121,63 @@ Debug = true
 [33m[tester::#LB6] [0m[94mRunning tests for Stage #LB6 (lb6)[0m
 [33m[tester::#LB6] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#LB6] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#LB6] [test-1.lox] [0m[33m// This is a simple function that takes one[0m
-[33m[tester::#LB6] [test-1.lox] [0m[33m// argument and prints it[0m
-[33m[tester::#LB6] [test-1.lox] [0mfun f1(a) { print a; }
-[33m[tester::#LB6] [test-1.lox] [0mf1(45);
+[33m[tester::#LB6] [test-1.lox] [0m[0m[33m// This is a simple function that takes one[0m[0m
+[33m[tester::#LB6] [test-1.lox] [0m[0m[33m// argument and prints it[0m[0m
+[33m[tester::#LB6] [test-1.lox] [0m[0mfun f1(a) { print a; }[0m
+[33m[tester::#LB6] [test-1.lox] [0m[0mf1(45);[0m
 [33m[tester::#LB6] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m45
+[33m[your_program] [0m[0m45[0m
 [33m[tester::#LB6] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#LB6] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#LB6] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#LB6] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#LB6] [test-2.lox] [0m[33m// This function takes three arguments and prints[0m
-[33m[tester::#LB6] [test-2.lox] [0m[33m// their sum[0m
-[33m[tester::#LB6] [test-2.lox] [0mfun f3(a, b, c) { print a + b + c; }
-[33m[tester::#LB6] [test-2.lox] [0mf3(67, 67, 67);
+[33m[tester::#LB6] [test-2.lox] [0m[0m[33m// This function takes three arguments and prints[0m[0m
+[33m[tester::#LB6] [test-2.lox] [0m[0m[33m// their sum[0m[0m
+[33m[tester::#LB6] [test-2.lox] [0m[0mfun f3(a, b, c) { print a + b + c; }[0m
+[33m[tester::#LB6] [test-2.lox] [0m[0mf3(67, 67, 67);[0m
 [33m[tester::#LB6] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m201
+[33m[your_program] [0m[0m201[0m
 [33m[tester::#LB6] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#LB6] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#LB6] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#LB6] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#LB6] [test-3.lox] [0m[33m// This function takes eight arguments and prints[0m
-[33m[tester::#LB6] [test-3.lox] [0m[33m// their sum[0m
-[33m[tester::#LB6] [test-3.lox] [0mfun f8(a, b, c, d, e, f, g, h) {
-[33m[tester::#LB6] [test-3.lox] [0m  print a - b + c * d + e - f + g - h;
-[33m[tester::#LB6] [test-3.lox] [0m}
-[33m[tester::#LB6] [test-3.lox] [0mf8(29, 29, 29, 29, 29, 29, 29, 29);
+[33m[tester::#LB6] [test-3.lox] [0m[0m[33m// This function takes eight arguments and prints[0m[0m
+[33m[tester::#LB6] [test-3.lox] [0m[0m[33m// their sum[0m[0m
+[33m[tester::#LB6] [test-3.lox] [0m[0mfun f8(a, b, c, d, e, f, g, h) {[0m
+[33m[tester::#LB6] [test-3.lox] [0m[0m  print a - b + c * d + e - f + g - h;[0m
+[33m[tester::#LB6] [test-3.lox] [0m[0m}[0m
+[33m[tester::#LB6] [test-3.lox] [0m[0mf8(29, 29, 29, 29, 29, 29, 29, 29);[0m
 [33m[tester::#LB6] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m841
+[33m[your_program] [0m[0m841[0m
 [33m[tester::#LB6] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#LB6] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#LB6] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#LB6] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#LB6] [test-4.lox] [0m[33m// This function takes two arguments and prints[0m
-[33m[tester::#LB6] [test-4.lox] [0m[33m// the grade based on the score and bonus[0m
-[33m[tester::#LB6] [test-4.lox] [0mfun calculateGrade(score, bonus) {
-[33m[tester::#LB6] [test-4.lox] [0m  var finalScore = score + bonus;
-[33m[tester::#LB6] [test-4.lox] [0m
-[33m[tester::#LB6] [test-4.lox] [0m  if (finalScore >= 90) {
-[33m[tester::#LB6] [test-4.lox] [0m    print "A";
-[33m[tester::#LB6] [test-4.lox] [0m  } else if (finalScore >= 80) {
-[33m[tester::#LB6] [test-4.lox] [0m    print "B";
-[33m[tester::#LB6] [test-4.lox] [0m  } else if (finalScore >= 70) {
-[33m[tester::#LB6] [test-4.lox] [0m    print "C";
-[33m[tester::#LB6] [test-4.lox] [0m  } else if (finalScore >= 60) {
-[33m[tester::#LB6] [test-4.lox] [0m    print "D";
-[33m[tester::#LB6] [test-4.lox] [0m  } else {
-[33m[tester::#LB6] [test-4.lox] [0m    print "F";
-[33m[tester::#LB6] [test-4.lox] [0m  }
-[33m[tester::#LB6] [test-4.lox] [0m}
-[33m[tester::#LB6] [test-4.lox] [0m
-[33m[tester::#LB6] [test-4.lox] [0mvar score = 64;
-[33m[tester::#LB6] [test-4.lox] [0mvar bonus = 3;
-[33m[tester::#LB6] [test-4.lox] [0mprint "Grade for given score is: ";
-[33m[tester::#LB6] [test-4.lox] [0mcalculateGrade(score, bonus);
+[33m[tester::#LB6] [test-4.lox] [0m[0m[33m// This function takes two arguments and prints[0m[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0m[33m// the grade based on the score and bonus[0m[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0mfun calculateGrade(score, bonus) {[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0m  var finalScore = score + bonus;[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0m[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0m  if (finalScore >= 90) {[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0m    print "A";[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0m  } else if (finalScore >= 80) {[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0m    print "B";[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0m  } else if (finalScore >= 70) {[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0m    print "C";[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0m  } else if (finalScore >= 60) {[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0m    print "D";[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0m  } else {[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0m    print "F";[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0m}[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0m[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0mvar score = 64;[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0mvar bonus = 3;[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0mprint "Grade for given score is: ";[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0mcalculateGrade(score, bonus);[0m
 [33m[tester::#LB6] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mGrade for given score is: 
-[33m[your_program] [0mD
+[33m[your_program] [0m[0mGrade for given score is: [0m
+[33m[your_program] [0m[0mD[0m
 [33m[tester::#LB6] [test-4] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#LB6] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#LB6] [0m[92mTest passed.[0m
@@ -185,46 +185,46 @@ Debug = true
 [33m[tester::#PX4] [0m[94mRunning tests for Stage #PX4 (px4)[0m
 [33m[tester::#PX4] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#PX4] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PX4] [test-1.lox] [0m[33m// This program is missing the closing parenthesis[0m
-[33m[tester::#PX4] [test-1.lox] [0m[33m// for the function call[0m
-[33m[tester::#PX4] [test-1.lox] [0m[33m// Hence the compiler error[0m
-[33m[tester::#PX4] [test-1.lox] [0mprint clock(;
+[33m[tester::#PX4] [test-1.lox] [0m[0m[33m// This program is missing the closing parenthesis[0m[0m
+[33m[tester::#PX4] [test-1.lox] [0m[0m[33m// for the function call[0m[0m
+[33m[tester::#PX4] [test-1.lox] [0m[0m[33m// Hence the compiler error[0m[0m
+[33m[tester::#PX4] [test-1.lox] [0m[0mprint clock(;[0m
 [33m[tester::#PX4] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 4] Error at ';': Expect expression.
+[33m[your_program] [0m[0m[line 4] Error at ';': Expect expression.[0m
 [33m[tester::#PX4] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#PX4] [test-1] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#PX4] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#PX4] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PX4] [test-2.lox] [0m[33m// This program is missing the opening parenthesis[0m
-[33m[tester::#PX4] [test-2.lox] [0m[33m// for the function call,[0m
-[33m[tester::#PX4] [test-2.lox] [0m[33m// and has extra closing parentheses[0m
-[33m[tester::#PX4] [test-2.lox] [0m[33m// Hence the compiler error[0m
-[33m[tester::#PX4] [test-2.lox] [0mprint clock)));
+[33m[tester::#PX4] [test-2.lox] [0m[0m[33m// This program is missing the opening parenthesis[0m[0m
+[33m[tester::#PX4] [test-2.lox] [0m[0m[33m// for the function call,[0m[0m
+[33m[tester::#PX4] [test-2.lox] [0m[0m[33m// and has extra closing parentheses[0m[0m
+[33m[tester::#PX4] [test-2.lox] [0m[0m[33m// Hence the compiler error[0m[0m
+[33m[tester::#PX4] [test-2.lox] [0m[0mprint clock)));[0m
 [33m[tester::#PX4] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 5] Error at ')': Expect ';' after value.
+[33m[your_program] [0m[0m[line 5] Error at ')': Expect ';' after value.[0m
 [33m[tester::#PX4] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#PX4] [test-2] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#PX4] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#PX4] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PX4] [test-3.lox] [0m[33m// This function declaration is missing the[0m
-[33m[tester::#PX4] [test-3.lox] [0m[33m// opening and closing braces[0m
-[33m[tester::#PX4] [test-3.lox] [0m[33m// The body should always be inside a block[0m
-[33m[tester::#PX4] [test-3.lox] [0m[33m// Hence the compiler error[0m
-[33m[tester::#PX4] [test-3.lox] [0mfun f() 27;
-[33m[tester::#PX4] [test-3.lox] [0mprint f();
+[33m[tester::#PX4] [test-3.lox] [0m[0m[33m// This function declaration is missing the[0m[0m
+[33m[tester::#PX4] [test-3.lox] [0m[0m[33m// opening and closing braces[0m[0m
+[33m[tester::#PX4] [test-3.lox] [0m[0m[33m// The body should always be inside a block[0m[0m
+[33m[tester::#PX4] [test-3.lox] [0m[0m[33m// Hence the compiler error[0m[0m
+[33m[tester::#PX4] [test-3.lox] [0m[0mfun f() 27;[0m
+[33m[tester::#PX4] [test-3.lox] [0m[0mprint f();[0m
 [33m[tester::#PX4] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 5] Error at '27': Expect '{' before function body.
+[33m[your_program] [0m[0m[line 5] Error at '27': Expect '{' before function body.[0m
 [33m[tester::#PX4] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#PX4] [test-3] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#PX4] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#PX4] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PX4] [test-4.lox] [0m[33m// This function declaration is missing a comma[0m
-[33m[tester::#PX4] [test-4.lox] [0m[33m// between b and c[0m
-[33m[tester::#PX4] [test-4.lox] [0m[33m// Hence the compiler error[0m
-[33m[tester::#PX4] [test-4.lox] [0mfun foo(a, b c, d, e, f) {}
-[33m[tester::#PX4] [test-4.lox] [0mfoo();
+[33m[tester::#PX4] [test-4.lox] [0m[0m[33m// This function declaration is missing a comma[0m[0m
+[33m[tester::#PX4] [test-4.lox] [0m[0m[33m// between b and c[0m[0m
+[33m[tester::#PX4] [test-4.lox] [0m[0m[33m// Hence the compiler error[0m[0m
+[33m[tester::#PX4] [test-4.lox] [0m[0mfun foo(a, b c, d, e, f) {}[0m
+[33m[tester::#PX4] [test-4.lox] [0m[0mfoo();[0m
 [33m[tester::#PX4] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 4] Error at 'c': Expect ')' after parameters.
+[33m[your_program] [0m[0m[line 4] Error at 'c': Expect ')' after parameters.[0m
 [33m[tester::#PX4] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#PX4] [test-4] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#PX4] [0m[92mTest passed.[0m
@@ -232,60 +232,60 @@ Debug = true
 [33m[tester::#RD2] [0m[94mRunning tests for Stage #RD2 (rd2)[0m
 [33m[tester::#RD2] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#RD2] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#RD2] [test-1.lox] [0m[33m// This program computes the 35th Fibonacci number[0m
-[33m[tester::#RD2] [test-1.lox] [0mfun fib(n) {
-[33m[tester::#RD2] [test-1.lox] [0m  if (n < 2) return n;
-[33m[tester::#RD2] [test-1.lox] [0m  return fib(n - 2) + fib(n - 1);
-[33m[tester::#RD2] [test-1.lox] [0m}
-[33m[tester::#RD2] [test-1.lox] [0m
-[33m[tester::#RD2] [test-1.lox] [0mvar start = clock();
-[33m[tester::#RD2] [test-1.lox] [0mprint fib(10) == 55;
-[33m[tester::#RD2] [test-1.lox] [0mprint (clock() - start) < 5; [33m// 5 seconds[0m
+[33m[tester::#RD2] [test-1.lox] [0m[0m[33m// This program computes the 35th Fibonacci number[0m[0m
+[33m[tester::#RD2] [test-1.lox] [0m[0mfun fib(n) {[0m
+[33m[tester::#RD2] [test-1.lox] [0m[0m  if (n < 2) return n;[0m
+[33m[tester::#RD2] [test-1.lox] [0m[0m  return fib(n - 2) + fib(n - 1);[0m
+[33m[tester::#RD2] [test-1.lox] [0m[0m}[0m
+[33m[tester::#RD2] [test-1.lox] [0m[0m[0m
+[33m[tester::#RD2] [test-1.lox] [0m[0mvar start = clock();[0m
+[33m[tester::#RD2] [test-1.lox] [0m[0mprint fib(10) == 55;[0m
+[33m[tester::#RD2] [test-1.lox] [0m[0mprint (clock() - start) < 5; [33m// 5 seconds[0m[0m
 [33m[tester::#RD2] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mtrue
-[33m[your_program] [0mtrue
+[33m[your_program] [0m[0mtrue[0m
+[33m[your_program] [0m[0mtrue[0m
 [33m[tester::#RD2] [test-1] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#RD2] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#RD2] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#RD2] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#RD2] [test-2.lox] [0m[33m// This program uses a return statement inside an[0m
-[33m[tester::#RD2] [test-2.lox] [0m[33m// if statement[0m
-[33m[tester::#RD2] [test-2.lox] [0m[33m// to return "ok" if the condition is false[0m
-[33m[tester::#RD2] [test-2.lox] [0mfun f() {
-[33m[tester::#RD2] [test-2.lox] [0m  if (true) return "no"; else return "ok";
-[33m[tester::#RD2] [test-2.lox] [0m}
-[33m[tester::#RD2] [test-2.lox] [0m
-[33m[tester::#RD2] [test-2.lox] [0mprint f();
+[33m[tester::#RD2] [test-2.lox] [0m[0m[33m// This program uses a return statement inside an[0m[0m
+[33m[tester::#RD2] [test-2.lox] [0m[0m[33m// if statement[0m[0m
+[33m[tester::#RD2] [test-2.lox] [0m[0m[33m// to return "ok" if the condition is false[0m[0m
+[33m[tester::#RD2] [test-2.lox] [0m[0mfun f() {[0m
+[33m[tester::#RD2] [test-2.lox] [0m[0m  if (true) return "no"; else return "ok";[0m
+[33m[tester::#RD2] [test-2.lox] [0m[0m}[0m
+[33m[tester::#RD2] [test-2.lox] [0m[0m[0m
+[33m[tester::#RD2] [test-2.lox] [0m[0mprint f();[0m
 [33m[tester::#RD2] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mno
+[33m[your_program] [0m[0mno[0m
 [33m[tester::#RD2] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#RD2] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#RD2] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#RD2] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#RD2] [test-3.lox] [0m[33m// This program uses a return statement inside a[0m
-[33m[tester::#RD2] [test-3.lox] [0m[33m// while loop[0m
-[33m[tester::#RD2] [test-3.lox] [0m[33m// to return "ok" if the condition is false[0m
-[33m[tester::#RD2] [test-3.lox] [0mfun f() {
-[33m[tester::#RD2] [test-3.lox] [0m  while (!false) return "ok";
-[33m[tester::#RD2] [test-3.lox] [0m}
-[33m[tester::#RD2] [test-3.lox] [0m
-[33m[tester::#RD2] [test-3.lox] [0mprint f();
+[33m[tester::#RD2] [test-3.lox] [0m[0m[33m// This program uses a return statement inside a[0m[0m
+[33m[tester::#RD2] [test-3.lox] [0m[0m[33m// while loop[0m[0m
+[33m[tester::#RD2] [test-3.lox] [0m[0m[33m// to return "ok" if the condition is false[0m[0m
+[33m[tester::#RD2] [test-3.lox] [0m[0mfun f() {[0m
+[33m[tester::#RD2] [test-3.lox] [0m[0m  while (!false) return "ok";[0m
+[33m[tester::#RD2] [test-3.lox] [0m[0m}[0m
+[33m[tester::#RD2] [test-3.lox] [0m[0m[0m
+[33m[tester::#RD2] [test-3.lox] [0m[0mprint f();[0m
 [33m[tester::#RD2] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mok
+[33m[your_program] [0m[0mok[0m
 [33m[tester::#RD2] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#RD2] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#RD2] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#RD2] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#RD2] [test-4.lox] [0m[33m// This program relies on the return statement[0m
-[33m[tester::#RD2] [test-4.lox] [0m[33m// returning nil by default[0m
-[33m[tester::#RD2] [test-4.lox] [0mfun f() {
-[33m[tester::#RD2] [test-4.lox] [0m  return;
-[33m[tester::#RD2] [test-4.lox] [0m  print "bad";
-[33m[tester::#RD2] [test-4.lox] [0m}
-[33m[tester::#RD2] [test-4.lox] [0m
-[33m[tester::#RD2] [test-4.lox] [0mprint f();
+[33m[tester::#RD2] [test-4.lox] [0m[0m[33m// This program relies on the return statement[0m[0m
+[33m[tester::#RD2] [test-4.lox] [0m[0m[33m// returning nil by default[0m[0m
+[33m[tester::#RD2] [test-4.lox] [0m[0mfun f() {[0m
+[33m[tester::#RD2] [test-4.lox] [0m[0m  return;[0m
+[33m[tester::#RD2] [test-4.lox] [0m[0m  print "bad";[0m
+[33m[tester::#RD2] [test-4.lox] [0m[0m}[0m
+[33m[tester::#RD2] [test-4.lox] [0m[0m[0m
+[33m[tester::#RD2] [test-4.lox] [0m[0mprint f();[0m
 [33m[tester::#RD2] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mnil
+[33m[your_program] [0m[0mnil[0m
 [33m[tester::#RD2] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#RD2] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#RD2] [0m[92mTest passed.[0m
@@ -293,119 +293,119 @@ Debug = true
 [33m[tester::#EY3] [0m[94mRunning tests for Stage #EY3 (ey3)[0m
 [33m[tester::#EY3] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#EY3] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#EY3] [test-1.lox] [0m[33m// This program creates a function that returns[0m
-[33m[tester::#EY3] [test-1.lox] [0m[33m// another function[0m
-[33m[tester::#EY3] [test-1.lox] [0m[33m// and uses it to greet two different people with[0m
-[33m[tester::#EY3] [test-1.lox] [0m[33m// two different greetings[0m
-[33m[tester::#EY3] [test-1.lox] [0mfun makeGreeter() {
-[33m[tester::#EY3] [test-1.lox] [0m  fun greet(name) {
-[33m[tester::#EY3] [test-1.lox] [0m    print "Hello " + name;
-[33m[tester::#EY3] [test-1.lox] [0m  }
-[33m[tester::#EY3] [test-1.lox] [0m  return greet;
-[33m[tester::#EY3] [test-1.lox] [0m}
-[33m[tester::#EY3] [test-1.lox] [0m
-[33m[tester::#EY3] [test-1.lox] [0mvar sayHello = makeGreeter();
-[33m[tester::#EY3] [test-1.lox] [0m
-[33m[tester::#EY3] [test-1.lox] [0msayHello("Bob");
-[33m[tester::#EY3] [test-1.lox] [0msayHello("Alice");
-[33m[tester::#EY3] [test-1.lox] [0msayHello("Eve");
+[33m[tester::#EY3] [test-1.lox] [0m[0m[33m// This program creates a function that returns[0m[0m
+[33m[tester::#EY3] [test-1.lox] [0m[0m[33m// another function[0m[0m
+[33m[tester::#EY3] [test-1.lox] [0m[0m[33m// and uses it to greet two different people with[0m[0m
+[33m[tester::#EY3] [test-1.lox] [0m[0m[33m// two different greetings[0m[0m
+[33m[tester::#EY3] [test-1.lox] [0m[0mfun makeGreeter() {[0m
+[33m[tester::#EY3] [test-1.lox] [0m[0m  fun greet(name) {[0m
+[33m[tester::#EY3] [test-1.lox] [0m[0m    print "Hello " + name;[0m
+[33m[tester::#EY3] [test-1.lox] [0m[0m  }[0m
+[33m[tester::#EY3] [test-1.lox] [0m[0m  return greet;[0m
+[33m[tester::#EY3] [test-1.lox] [0m[0m}[0m
+[33m[tester::#EY3] [test-1.lox] [0m[0m[0m
+[33m[tester::#EY3] [test-1.lox] [0m[0mvar sayHello = makeGreeter();[0m
+[33m[tester::#EY3] [test-1.lox] [0m[0m[0m
+[33m[tester::#EY3] [test-1.lox] [0m[0msayHello("Bob");[0m
+[33m[tester::#EY3] [test-1.lox] [0m[0msayHello("Alice");[0m
+[33m[tester::#EY3] [test-1.lox] [0m[0msayHello("Eve");[0m
 [33m[tester::#EY3] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mHello Bob
-[33m[your_program] [0mHello Alice
-[33m[your_program] [0mHello Eve
+[33m[your_program] [0m[0mHello Bob[0m
+[33m[your_program] [0m[0mHello Alice[0m
+[33m[your_program] [0m[0mHello Eve[0m
 [33m[tester::#EY3] [test-1] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#EY3] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#EY3] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#EY3] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#EY3] [test-2.lox] [0m[33m// This program defines a function that takes in a[0m
-[33m[tester::#EY3] [test-2.lox] [0m[33m// function and an argument[0m
-[33m[tester::#EY3] [test-2.lox] [0m[33m// and returns the result of calling the function[0m
-[33m[tester::#EY3] [test-2.lox] [0m[33m// with the argument[0m
-[33m[tester::#EY3] [test-2.lox] [0mfun returnArg(arg) {
-[33m[tester::#EY3] [test-2.lox] [0m  return arg;
-[33m[tester::#EY3] [test-2.lox] [0m}
-[33m[tester::#EY3] [test-2.lox] [0m
-[33m[tester::#EY3] [test-2.lox] [0mfun returnFunCallWithArg(func, arg) {
-[33m[tester::#EY3] [test-2.lox] [0m  return returnArg(func)(arg);
-[33m[tester::#EY3] [test-2.lox] [0m}
-[33m[tester::#EY3] [test-2.lox] [0m
-[33m[tester::#EY3] [test-2.lox] [0mfun printArg(arg) {
-[33m[tester::#EY3] [test-2.lox] [0m  print arg;
-[33m[tester::#EY3] [test-2.lox] [0m}
-[33m[tester::#EY3] [test-2.lox] [0m
-[33m[tester::#EY3] [test-2.lox] [0mreturnFunCallWithArg(printArg, "world");
+[33m[tester::#EY3] [test-2.lox] [0m[0m[33m// This program defines a function that takes in a[0m[0m
+[33m[tester::#EY3] [test-2.lox] [0m[0m[33m// function and an argument[0m[0m
+[33m[tester::#EY3] [test-2.lox] [0m[0m[33m// and returns the result of calling the function[0m[0m
+[33m[tester::#EY3] [test-2.lox] [0m[0m[33m// with the argument[0m[0m
+[33m[tester::#EY3] [test-2.lox] [0m[0mfun returnArg(arg) {[0m
+[33m[tester::#EY3] [test-2.lox] [0m[0m  return arg;[0m
+[33m[tester::#EY3] [test-2.lox] [0m[0m}[0m
+[33m[tester::#EY3] [test-2.lox] [0m[0m[0m
+[33m[tester::#EY3] [test-2.lox] [0m[0mfun returnFunCallWithArg(func, arg) {[0m
+[33m[tester::#EY3] [test-2.lox] [0m[0m  return returnArg(func)(arg);[0m
+[33m[tester::#EY3] [test-2.lox] [0m[0m}[0m
+[33m[tester::#EY3] [test-2.lox] [0m[0m[0m
+[33m[tester::#EY3] [test-2.lox] [0m[0mfun printArg(arg) {[0m
+[33m[tester::#EY3] [test-2.lox] [0m[0m  print arg;[0m
+[33m[tester::#EY3] [test-2.lox] [0m[0m}[0m
+[33m[tester::#EY3] [test-2.lox] [0m[0m[0m
+[33m[tester::#EY3] [test-2.lox] [0m[0mreturnFunCallWithArg(printArg, "world");[0m
 [33m[tester::#EY3] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mworld
+[33m[your_program] [0m[0mworld[0m
 [33m[tester::#EY3] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#EY3] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#EY3] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#EY3] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#EY3] [test-3.lox] [0mfun square(x) {
-[33m[tester::#EY3] [test-3.lox] [0m  return x * x;
-[33m[tester::#EY3] [test-3.lox] [0m}
-[33m[tester::#EY3] [test-3.lox] [0m
-[33m[tester::#EY3] [test-3.lox] [0m[33m// This higher-order function applies a[0m
-[33m[tester::#EY3] [test-3.lox] [0m[33m// function N times to a starting value x.[0m
-[33m[tester::#EY3] [test-3.lox] [0mfun applyTimesN(N, f, x) {
-[33m[tester::#EY3] [test-3.lox] [0m  var i = 0;
-[33m[tester::#EY3] [test-3.lox] [0m  while (i < N) {
-[33m[tester::#EY3] [test-3.lox] [0m    x = f(x);
-[33m[tester::#EY3] [test-3.lox] [0m    i = i + 1;
-[33m[tester::#EY3] [test-3.lox] [0m  }
-[33m[tester::#EY3] [test-3.lox] [0m  return x;
-[33m[tester::#EY3] [test-3.lox] [0m}
-[33m[tester::#EY3] [test-3.lox] [0m
-[33m[tester::#EY3] [test-3.lox] [0m[33m// 2 is squared once[0m
-[33m[tester::#EY3] [test-3.lox] [0mprint applyTimesN(1, square, 2);
-[33m[tester::#EY3] [test-3.lox] [0m[33m// 2 is squared twice[0m
-[33m[tester::#EY3] [test-3.lox] [0mprint applyTimesN(2, square, 2);
-[33m[tester::#EY3] [test-3.lox] [0m[33m// 2 is squared thrice[0m
-[33m[tester::#EY3] [test-3.lox] [0mprint applyTimesN(3, square, 2);
+[33m[tester::#EY3] [test-3.lox] [0m[0mfun square(x) {[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0m  return x * x;[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0m}[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0m[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0m[33m// This higher-order function applies a[0m[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0m[33m// function N times to a starting value x.[0m[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0mfun applyTimesN(N, f, x) {[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0m  var i = 0;[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0m  while (i < N) {[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0m    x = f(x);[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0m    i = i + 1;[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0m  }[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0m  return x;[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0m}[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0m[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0m[33m// 2 is squared once[0m[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0mprint applyTimesN(1, square, 2);[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0m[33m// 2 is squared twice[0m[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0mprint applyTimesN(2, square, 2);[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0m[33m// 2 is squared thrice[0m[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0mprint applyTimesN(3, square, 2);[0m
 [33m[tester::#EY3] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m4
-[33m[your_program] [0m16
-[33m[your_program] [0m256
+[33m[your_program] [0m[0m4[0m
+[33m[your_program] [0m[0m16[0m
+[33m[your_program] [0m[0m256[0m
 [33m[tester::#EY3] [test-3] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#EY3] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#EY3] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#EY3] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#EY3] [test-4.lox] [0m[33m// This program creates a function that returns[0m
-[33m[tester::#EY3] [test-4.lox] [0m[33m// another function[0m
-[33m[tester::#EY3] [test-4.lox] [0m[33m// and uses it to filter a list of numbers[0m
-[33m[tester::#EY3] [test-4.lox] [0mfun makeFilter() {
-[33m[tester::#EY3] [test-4.lox] [0m  fun filter(n) {
-[33m[tester::#EY3] [test-4.lox] [0m    if (n < 54) {
-[33m[tester::#EY3] [test-4.lox] [0m      return false;
-[33m[tester::#EY3] [test-4.lox] [0m    }
-[33m[tester::#EY3] [test-4.lox] [0m    return true;
-[33m[tester::#EY3] [test-4.lox] [0m  }
-[33m[tester::#EY3] [test-4.lox] [0m  return filter;
-[33m[tester::#EY3] [test-4.lox] [0m}
-[33m[tester::#EY3] [test-4.lox] [0m
-[33m[tester::#EY3] [test-4.lox] [0m[33m// This function applies a function to a list of[0m
-[33m[tester::#EY3] [test-4.lox] [0m[33m// numbers[0m
-[33m[tester::#EY3] [test-4.lox] [0mfun applyToNumbers(f, count) {
-[33m[tester::#EY3] [test-4.lox] [0m  var n = 0;
-[33m[tester::#EY3] [test-4.lox] [0m  while (n < count) {
-[33m[tester::#EY3] [test-4.lox] [0m    if (f(n)) {
-[33m[tester::#EY3] [test-4.lox] [0m      print n;
-[33m[tester::#EY3] [test-4.lox] [0m    }
-[33m[tester::#EY3] [test-4.lox] [0m    n = n + 1;
-[33m[tester::#EY3] [test-4.lox] [0m  }
-[33m[tester::#EY3] [test-4.lox] [0m}
-[33m[tester::#EY3] [test-4.lox] [0m
-[33m[tester::#EY3] [test-4.lox] [0mvar greaterThanX = makeFilter();
-[33m[tester::#EY3] [test-4.lox] [0m
-[33m[tester::#EY3] [test-4.lox] [0mprint "Numbers >= 54:";
-[33m[tester::#EY3] [test-4.lox] [0mapplyToNumbers(greaterThanX, 54 + 6);
+[33m[tester::#EY3] [test-4.lox] [0m[0m[33m// This program creates a function that returns[0m[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m[33m// another function[0m[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m[33m// and uses it to filter a list of numbers[0m[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0mfun makeFilter() {[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m  fun filter(n) {[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m    if (n < 54) {[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m      return false;[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m    }[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m    return true;[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m  return filter;[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m}[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m[33m// This function applies a function to a list of[0m[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m[33m// numbers[0m[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0mfun applyToNumbers(f, count) {[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m  var n = 0;[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m  while (n < count) {[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m    if (f(n)) {[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m      print n;[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m    }[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m    n = n + 1;[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m}[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0mvar greaterThanX = makeFilter();[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0mprint "Numbers >= 54:";[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0mapplyToNumbers(greaterThanX, 54 + 6);[0m
 [33m[tester::#EY3] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mNumbers >= 54:
-[33m[your_program] [0m54
-[33m[your_program] [0m55
-[33m[your_program] [0m56
-[33m[your_program] [0m57
-[33m[your_program] [0m58
-[33m[your_program] [0m59
+[33m[your_program] [0m[0mNumbers >= 54:[0m
+[33m[your_program] [0m[0m54[0m
+[33m[your_program] [0m[0m55[0m
+[33m[your_program] [0m[0m56[0m
+[33m[your_program] [0m[0m57[0m
+[33m[your_program] [0m[0m58[0m
+[33m[your_program] [0m[0m59[0m
 [33m[tester::#EY3] [test-4] [0m[92m✓ 7 line(s) match on stdout[0m
 [33m[tester::#EY3] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#EY3] [0m[92mTest passed.[0m
@@ -413,51 +413,51 @@ Debug = true
 [33m[tester::#FJ7] [0m[94mRunning tests for Stage #FJ7 (fj7)[0m
 [33m[tester::#FJ7] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#FJ7] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#FJ7] [test-1.lox] [0m[33m// This program tries to execute an integer as a[0m
-[33m[tester::#FJ7] [test-1.lox] [0m[33m// function[0m
-[33m[tester::#FJ7] [test-1.lox] [0m25();
+[33m[tester::#FJ7] [test-1.lox] [0m[0m[33m// This program tries to execute an integer as a[0m[0m
+[33m[tester::#FJ7] [test-1.lox] [0m[0m[33m// function[0m[0m
+[33m[tester::#FJ7] [test-1.lox] [0m[0m25();[0m
 [33m[tester::#FJ7] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mCan only call functions and classes.
-[33m[your_program] [0m[line 3]
+[33m[your_program] [0m[0mCan only call functions and classes.[0m
+[33m[your_program] [0m[0m[line 3][0m
 [33m[tester::#FJ7] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#FJ7] [test-1] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#FJ7] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#FJ7] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#FJ7] [test-2.lox] [0m[33m// This program tries to call a function with too[0m
-[33m[tester::#FJ7] [test-2.lox] [0m[33m// many arguments[0m
-[33m[tester::#FJ7] [test-2.lox] [0mfun f(a, b) {
-[33m[tester::#FJ7] [test-2.lox] [0m  print a;
-[33m[tester::#FJ7] [test-2.lox] [0m  print b;
-[33m[tester::#FJ7] [test-2.lox] [0m}
-[33m[tester::#FJ7] [test-2.lox] [0m
-[33m[tester::#FJ7] [test-2.lox] [0mf(1, 2, 3, 4);
-[33m[tester::#FJ7] [test-2.lox] [0m[33m// expect runtime error: Expected 2 arguments[0m
+[33m[tester::#FJ7] [test-2.lox] [0m[0m[33m// This program tries to call a function with too[0m[0m
+[33m[tester::#FJ7] [test-2.lox] [0m[0m[33m// many arguments[0m[0m
+[33m[tester::#FJ7] [test-2.lox] [0m[0mfun f(a, b) {[0m
+[33m[tester::#FJ7] [test-2.lox] [0m[0m  print a;[0m
+[33m[tester::#FJ7] [test-2.lox] [0m[0m  print b;[0m
+[33m[tester::#FJ7] [test-2.lox] [0m[0m}[0m
+[33m[tester::#FJ7] [test-2.lox] [0m[0m[0m
+[33m[tester::#FJ7] [test-2.lox] [0m[0mf(1, 2, 3, 4);[0m
+[33m[tester::#FJ7] [test-2.lox] [0m[0m[33m// expect runtime error: Expected 2 arguments[0m[0m
 [33m[tester::#FJ7] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mExpected 2 arguments but got 4.
-[33m[your_program] [0m[line 8]
+[33m[your_program] [0m[0mExpected 2 arguments but got 4.[0m
+[33m[your_program] [0m[0m[line 8][0m
 [33m[tester::#FJ7] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#FJ7] [test-2] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#FJ7] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#FJ7] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#FJ7] [test-3.lox] [0m[33m// This program tries to call a function with too[0m
-[33m[tester::#FJ7] [test-3.lox] [0m[33m// few arguments[0m
-[33m[tester::#FJ7] [test-3.lox] [0mfun f(a, b) {}
-[33m[tester::#FJ7] [test-3.lox] [0m
-[33m[tester::#FJ7] [test-3.lox] [0m[33m// expect runtime error: Expected 2 arguments[0m
-[33m[tester::#FJ7] [test-3.lox] [0mf(1);
+[33m[tester::#FJ7] [test-3.lox] [0m[0m[33m// This program tries to call a function with too[0m[0m
+[33m[tester::#FJ7] [test-3.lox] [0m[0m[33m// few arguments[0m[0m
+[33m[tester::#FJ7] [test-3.lox] [0m[0mfun f(a, b) {}[0m
+[33m[tester::#FJ7] [test-3.lox] [0m[0m[0m
+[33m[tester::#FJ7] [test-3.lox] [0m[0m[33m// expect runtime error: Expected 2 arguments[0m[0m
+[33m[tester::#FJ7] [test-3.lox] [0m[0mf(1);[0m
 [33m[tester::#FJ7] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mExpected 2 arguments but got 1.
-[33m[your_program] [0m[line 6]
+[33m[your_program] [0m[0mExpected 2 arguments but got 1.[0m
+[33m[your_program] [0m[0m[line 6][0m
 [33m[tester::#FJ7] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#FJ7] [test-3] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#FJ7] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#FJ7] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#FJ7] [test-4.lox] [0m[33m// This program tries to execute a boolean as a[0m
-[33m[tester::#FJ7] [test-4.lox] [0m[33m// function[0m
-[33m[tester::#FJ7] [test-4.lox] [0m(false == false)();
+[33m[tester::#FJ7] [test-4.lox] [0m[0m[33m// This program tries to execute a boolean as a[0m[0m
+[33m[tester::#FJ7] [test-4.lox] [0m[0m[33m// function[0m[0m
+[33m[tester::#FJ7] [test-4.lox] [0m[0m(false == false)();[0m
 [33m[tester::#FJ7] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mCan only call functions and classes.
-[33m[your_program] [0m[line 3]
+[33m[your_program] [0m[0mCan only call functions and classes.[0m
+[33m[your_program] [0m[0m[line 3][0m
 [33m[tester::#FJ7] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#FJ7] [test-4] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#FJ7] [0m[92mTest passed.[0m
@@ -465,153 +465,153 @@ Debug = true
 [33m[tester::#BZ4] [0m[94mRunning tests for Stage #BZ4 (bz4)[0m
 [33m[tester::#BZ4] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#BZ4] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#BZ4] [test-1.lox] [0m[33m// This program demonstrates global and local[0m
-[33m[tester::#BZ4] [test-1.lox] [0m[33m// variable shadowing in Lox.[0m
-[33m[tester::#BZ4] [test-1.lox] [0mvar a = 81;
-[33m[tester::#BZ4] [test-1.lox] [0m
-[33m[tester::#BZ4] [test-1.lox] [0mfun printAndModify() {
-[33m[tester::#BZ4] [test-1.lox] [0m  print a;
-[33m[tester::#BZ4] [test-1.lox] [0m  var a = 89;
-[33m[tester::#BZ4] [test-1.lox] [0m  print a;
-[33m[tester::#BZ4] [test-1.lox] [0m}
-[33m[tester::#BZ4] [test-1.lox] [0m
-[33m[tester::#BZ4] [test-1.lox] [0mprint a;
-[33m[tester::#BZ4] [test-1.lox] [0ma = 59;
-[33m[tester::#BZ4] [test-1.lox] [0mprintAndModify();
+[33m[tester::#BZ4] [test-1.lox] [0m[0m[33m// This program demonstrates global and local[0m[0m
+[33m[tester::#BZ4] [test-1.lox] [0m[0m[33m// variable shadowing in Lox.[0m[0m
+[33m[tester::#BZ4] [test-1.lox] [0m[0mvar a = 81;[0m
+[33m[tester::#BZ4] [test-1.lox] [0m[0m[0m
+[33m[tester::#BZ4] [test-1.lox] [0m[0mfun printAndModify() {[0m
+[33m[tester::#BZ4] [test-1.lox] [0m[0m  print a;[0m
+[33m[tester::#BZ4] [test-1.lox] [0m[0m  var a = 89;[0m
+[33m[tester::#BZ4] [test-1.lox] [0m[0m  print a;[0m
+[33m[tester::#BZ4] [test-1.lox] [0m[0m}[0m
+[33m[tester::#BZ4] [test-1.lox] [0m[0m[0m
+[33m[tester::#BZ4] [test-1.lox] [0m[0mprint a;[0m
+[33m[tester::#BZ4] [test-1.lox] [0m[0ma = 59;[0m
+[33m[tester::#BZ4] [test-1.lox] [0m[0mprintAndModify();[0m
 [33m[tester::#BZ4] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m81
-[33m[your_program] [0m59
-[33m[your_program] [0m89
+[33m[your_program] [0m[0m81[0m
+[33m[your_program] [0m[0m59[0m
+[33m[your_program] [0m[0m89[0m
 [33m[tester::#BZ4] [test-1] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#BZ4] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#BZ4] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#BZ4] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#BZ4] [test-2.lox] [0m[33m// This program uses a while loop to count down[0m
-[33m[tester::#BZ4] [test-2.lox] [0m[33m// from 3 to 1, printing each[0m
-[33m[tester::#BZ4] [test-2.lox] [0m[33m// number[0m
-[33m[tester::#BZ4] [test-2.lox] [0m[33m// and then decrementing the count until it[0m
-[33m[tester::#BZ4] [test-2.lox] [0m[33m// reaches 0, at which point it prints[0m
-[33m[tester::#BZ4] [test-2.lox] [0m[33m// "Blast off!"[0m
-[33m[tester::#BZ4] [test-2.lox] [0mvar count = 3;
-[33m[tester::#BZ4] [test-2.lox] [0m
-[33m[tester::#BZ4] [test-2.lox] [0mfun tick() {
-[33m[tester::#BZ4] [test-2.lox] [0m  if (count > 0) {
-[33m[tester::#BZ4] [test-2.lox] [0m    print count;
-[33m[tester::#BZ4] [test-2.lox] [0m    count = count - 1;
-[33m[tester::#BZ4] [test-2.lox] [0m    return false;
-[33m[tester::#BZ4] [test-2.lox] [0m  }
-[33m[tester::#BZ4] [test-2.lox] [0m  print "Blast off!";
-[33m[tester::#BZ4] [test-2.lox] [0m  return true;
-[33m[tester::#BZ4] [test-2.lox] [0m}
-[33m[tester::#BZ4] [test-2.lox] [0m
-[33m[tester::#BZ4] [test-2.lox] [0mwhile (!tick()) {}
+[33m[tester::#BZ4] [test-2.lox] [0m[0m[33m// This program uses a while loop to count down[0m[0m
+[33m[tester::#BZ4] [test-2.lox] [0m[0m[33m// from 3 to 1, printing each[0m[0m
+[33m[tester::#BZ4] [test-2.lox] [0m[0m[33m// number[0m[0m
+[33m[tester::#BZ4] [test-2.lox] [0m[0m[33m// and then decrementing the count until it[0m[0m
+[33m[tester::#BZ4] [test-2.lox] [0m[0m[33m// reaches 0, at which point it prints[0m[0m
+[33m[tester::#BZ4] [test-2.lox] [0m[0m[33m// "Blast off!"[0m[0m
+[33m[tester::#BZ4] [test-2.lox] [0m[0mvar count = 3;[0m
+[33m[tester::#BZ4] [test-2.lox] [0m[0m[0m
+[33m[tester::#BZ4] [test-2.lox] [0m[0mfun tick() {[0m
+[33m[tester::#BZ4] [test-2.lox] [0m[0m  if (count > 0) {[0m
+[33m[tester::#BZ4] [test-2.lox] [0m[0m    print count;[0m
+[33m[tester::#BZ4] [test-2.lox] [0m[0m    count = count - 1;[0m
+[33m[tester::#BZ4] [test-2.lox] [0m[0m    return false;[0m
+[33m[tester::#BZ4] [test-2.lox] [0m[0m  }[0m
+[33m[tester::#BZ4] [test-2.lox] [0m[0m  print "Blast off!";[0m
+[33m[tester::#BZ4] [test-2.lox] [0m[0m  return true;[0m
+[33m[tester::#BZ4] [test-2.lox] [0m[0m}[0m
+[33m[tester::#BZ4] [test-2.lox] [0m[0m[0m
+[33m[tester::#BZ4] [test-2.lox] [0m[0mwhile (!tick()) {}[0m
 [33m[tester::#BZ4] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m3
-[33m[your_program] [0m2
-[33m[your_program] [0m1
-[33m[your_program] [0mBlast off!
+[33m[your_program] [0m[0m3[0m
+[33m[your_program] [0m[0m2[0m
+[33m[your_program] [0m[0m1[0m
+[33m[your_program] [0m[0mBlast off![0m
 [33m[tester::#BZ4] [test-2] [0m[92m✓ 4 line(s) match on stdout[0m
 [33m[tester::#BZ4] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#BZ4] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#BZ4] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#BZ4] [test-3.lox] [0m[33m// This program demonstrates variable shadowing in[0m
-[33m[tester::#BZ4] [test-3.lox] [0m[33m// Lox with functions.[0m
-[33m[tester::#BZ4] [test-3.lox] [0m[33m// The first counter is a global variable that is[0m
-[33m[tester::#BZ4] [test-3.lox] [0m[33m// modified by the inner block.[0m
-[33m[tester::#BZ4] [test-3.lox] [0m[33m// The second counter is a local variable that[0m
-[33m[tester::#BZ4] [test-3.lox] [0m[33m// shadows the global variable.[0m
-[33m[tester::#BZ4] [test-3.lox] [0mvar counter = 93;
-[33m[tester::#BZ4] [test-3.lox] [0m
-[33m[tester::#BZ4] [test-3.lox] [0mfun incrementCounter(amount) {
-[33m[tester::#BZ4] [test-3.lox] [0m  counter = counter + amount;
-[33m[tester::#BZ4] [test-3.lox] [0m  print counter;
-[33m[tester::#BZ4] [test-3.lox] [0m}
-[33m[tester::#BZ4] [test-3.lox] [0m
-[33m[tester::#BZ4] [test-3.lox] [0m{
-[33m[tester::#BZ4] [test-3.lox] [0m  counter = 97;
-[33m[tester::#BZ4] [test-3.lox] [0m  incrementCounter(5);
-[33m[tester::#BZ4] [test-3.lox] [0m  print counter;
-[33m[tester::#BZ4] [test-3.lox] [0m}
-[33m[tester::#BZ4] [test-3.lox] [0mprint counter;
+[33m[tester::#BZ4] [test-3.lox] [0m[0m[33m// This program demonstrates variable shadowing in[0m[0m
+[33m[tester::#BZ4] [test-3.lox] [0m[0m[33m// Lox with functions.[0m[0m
+[33m[tester::#BZ4] [test-3.lox] [0m[0m[33m// The first counter is a global variable that is[0m[0m
+[33m[tester::#BZ4] [test-3.lox] [0m[0m[33m// modified by the inner block.[0m[0m
+[33m[tester::#BZ4] [test-3.lox] [0m[0m[33m// The second counter is a local variable that[0m[0m
+[33m[tester::#BZ4] [test-3.lox] [0m[0m[33m// shadows the global variable.[0m[0m
+[33m[tester::#BZ4] [test-3.lox] [0m[0mvar counter = 93;[0m
+[33m[tester::#BZ4] [test-3.lox] [0m[0m[0m
+[33m[tester::#BZ4] [test-3.lox] [0m[0mfun incrementCounter(amount) {[0m
+[33m[tester::#BZ4] [test-3.lox] [0m[0m  counter = counter + amount;[0m
+[33m[tester::#BZ4] [test-3.lox] [0m[0m  print counter;[0m
+[33m[tester::#BZ4] [test-3.lox] [0m[0m}[0m
+[33m[tester::#BZ4] [test-3.lox] [0m[0m[0m
+[33m[tester::#BZ4] [test-3.lox] [0m[0m{[0m
+[33m[tester::#BZ4] [test-3.lox] [0m[0m  counter = 97;[0m
+[33m[tester::#BZ4] [test-3.lox] [0m[0m  incrementCounter(5);[0m
+[33m[tester::#BZ4] [test-3.lox] [0m[0m  print counter;[0m
+[33m[tester::#BZ4] [test-3.lox] [0m[0m}[0m
+[33m[tester::#BZ4] [test-3.lox] [0m[0mprint counter;[0m
 [33m[tester::#BZ4] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m102
-[33m[your_program] [0m102
-[33m[your_program] [0m102
+[33m[your_program] [0m[0m102[0m
+[33m[your_program] [0m[0m102[0m
+[33m[your_program] [0m[0m102[0m
 [33m[tester::#BZ4] [test-3] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#BZ4] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#BZ4] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#BZ4] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#BZ4] [test-4.lox] [0m[33m// This program tests variable scoping and[0m
-[33m[tester::#BZ4] [test-4.lox] [0m[33m// shadowing in Lox. It demonstrates:[0m
-[33m[tester::#BZ4] [test-4.lox] [0m[33m// Global variable declarations[0m
-[33m[tester::#BZ4] [test-4.lox] [0m[33m// Function scope access to global variables[0m
-[33m[tester::#BZ4] [test-4.lox] [0m[33m// Block scoping with local variables shadowing[0m
-[33m[tester::#BZ4] [test-4.lox] [0m[33m// outer variables[0m
-[33m[tester::#BZ4] [test-4.lox] [0m[33m// Verification that global variables remain[0m
-[33m[tester::#BZ4] [test-4.lox] [0m[33m// unchanged after shadowing[0m
-[33m[tester::#BZ4] [test-4.lox] [0mvar x = 1;
-[33m[tester::#BZ4] [test-4.lox] [0mvar y = 2;
-[33m[tester::#BZ4] [test-4.lox] [0m
-[33m[tester::#BZ4] [test-4.lox] [0mfun printBoth() {
-[33m[tester::#BZ4] [test-4.lox] [0m  if (x < y) {
-[33m[tester::#BZ4] [test-4.lox] [0m    print "x is less than y:";
-[33m[tester::#BZ4] [test-4.lox] [0m    print x;
-[33m[tester::#BZ4] [test-4.lox] [0m    print y;
-[33m[tester::#BZ4] [test-4.lox] [0m  } else {
-[33m[tester::#BZ4] [test-4.lox] [0m    print "x is not less than y:";
-[33m[tester::#BZ4] [test-4.lox] [0m    print x;
-[33m[tester::#BZ4] [test-4.lox] [0m    print y;
-[33m[tester::#BZ4] [test-4.lox] [0m  }
-[33m[tester::#BZ4] [test-4.lox] [0m}
-[33m[tester::#BZ4] [test-4.lox] [0m
-[33m[tester::#BZ4] [test-4.lox] [0m{
-[33m[tester::#BZ4] [test-4.lox] [0m  var x = 10;
-[33m[tester::#BZ4] [test-4.lox] [0m  {
-[33m[tester::#BZ4] [test-4.lox] [0m    var y = 20;
-[33m[tester::#BZ4] [test-4.lox] [0m
-[33m[tester::#BZ4] [test-4.lox] [0m    var i = 0;
-[33m[tester::#BZ4] [test-4.lox] [0m    while (i < 3) {
-[33m[tester::#BZ4] [test-4.lox] [0m      x = x + 1;
-[33m[tester::#BZ4] [test-4.lox] [0m      y = y - 1;
-[33m[tester::#BZ4] [test-4.lox] [0m      print "Local x: ";
-[33m[tester::#BZ4] [test-4.lox] [0m      print x;
-[33m[tester::#BZ4] [test-4.lox] [0m      print "Local y: ";
-[33m[tester::#BZ4] [test-4.lox] [0m      print y;
-[33m[tester::#BZ4] [test-4.lox] [0m      i = i + 1;
-[33m[tester::#BZ4] [test-4.lox] [0m    }
-[33m[tester::#BZ4] [test-4.lox] [0m
-[33m[tester::#BZ4] [test-4.lox] [0m    if (x > y) {
-[33m[tester::#BZ4] [test-4.lox] [0m      print "Local x > y";
-[33m[tester::#BZ4] [test-4.lox] [0m    }
-[33m[tester::#BZ4] [test-4.lox] [0m
-[33m[tester::#BZ4] [test-4.lox] [0m    printBoth();
-[33m[tester::#BZ4] [test-4.lox] [0m  }
-[33m[tester::#BZ4] [test-4.lox] [0m}
-[33m[tester::#BZ4] [test-4.lox] [0m
-[33m[tester::#BZ4] [test-4.lox] [0mif (x == 1 and y == 2) {
-[33m[tester::#BZ4] [test-4.lox] [0m  print "Globals unchanged:";
-[33m[tester::#BZ4] [test-4.lox] [0m  printBoth();
-[33m[tester::#BZ4] [test-4.lox] [0m}
+[33m[tester::#BZ4] [test-4.lox] [0m[0m[33m// This program tests variable scoping and[0m[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m[33m// shadowing in Lox. It demonstrates:[0m[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m[33m// Global variable declarations[0m[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m[33m// Function scope access to global variables[0m[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m[33m// Block scoping with local variables shadowing[0m[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m[33m// outer variables[0m[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m[33m// Verification that global variables remain[0m[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m[33m// unchanged after shadowing[0m[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0mvar x = 1;[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0mvar y = 2;[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0mfun printBoth() {[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m  if (x < y) {[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m    print "x is less than y:";[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m    print x;[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m    print y;[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m  } else {[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m    print "x is not less than y:";[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m    print x;[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m    print y;[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m}[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m{[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m  var x = 10;[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m  {[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m    var y = 20;[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m    var i = 0;[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m    while (i < 3) {[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m      x = x + 1;[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m      y = y - 1;[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m      print "Local x: ";[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m      print x;[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m      print "Local y: ";[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m      print y;[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m      i = i + 1;[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m    }[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m    if (x > y) {[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m      print "Local x > y";[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m    }[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m    printBoth();[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m}[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0mif (x == 1 and y == 2) {[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m  print "Globals unchanged:";[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m  printBoth();[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m}[0m
 [33m[tester::#BZ4] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mLocal x: 
-[33m[your_program] [0m11
-[33m[your_program] [0mLocal y: 
-[33m[your_program] [0m19
-[33m[your_program] [0mLocal x: 
-[33m[your_program] [0m12
-[33m[your_program] [0mLocal y: 
-[33m[your_program] [0m18
-[33m[your_program] [0mLocal x: 
-[33m[your_program] [0m13
-[33m[your_program] [0mLocal y: 
-[33m[your_program] [0m17
-[33m[your_program] [0mx is less than y:
-[33m[your_program] [0m1
-[33m[your_program] [0m2
-[33m[your_program] [0mGlobals unchanged:
-[33m[your_program] [0mx is less than y:
-[33m[your_program] [0m1
-[33m[your_program] [0m2
+[33m[your_program] [0m[0mLocal x: [0m
+[33m[your_program] [0m[0m11[0m
+[33m[your_program] [0m[0mLocal y: [0m
+[33m[your_program] [0m[0m19[0m
+[33m[your_program] [0m[0mLocal x: [0m
+[33m[your_program] [0m[0m12[0m
+[33m[your_program] [0m[0mLocal y: [0m
+[33m[your_program] [0m[0m18[0m
+[33m[your_program] [0m[0mLocal x: [0m
+[33m[your_program] [0m[0m13[0m
+[33m[your_program] [0m[0mLocal y: [0m
+[33m[your_program] [0m[0m17[0m
+[33m[your_program] [0m[0mx is less than y:[0m
+[33m[your_program] [0m[0m1[0m
+[33m[your_program] [0m[0m2[0m
+[33m[your_program] [0m[0mGlobals unchanged:[0m
+[33m[your_program] [0m[0mx is less than y:[0m
+[33m[your_program] [0m[0m1[0m
+[33m[your_program] [0m[0m2[0m
 [33m[tester::#BZ4] [test-4] [0m[92m✓ 19 line(s) match on stdout[0m
 [33m[tester::#BZ4] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#BZ4] [0m[92mTest passed.[0m
@@ -619,171 +619,171 @@ Debug = true
 [33m[tester::#GG6] [0m[94mRunning tests for Stage #GG6 (gg6)[0m
 [33m[tester::#GG6] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#GG6] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#GG6] [test-1.lox] [0m[33m// This program demonstrates the use of closures[0m
-[33m[tester::#GG6] [test-1.lox] [0m[33m// to create a counter function.[0m
-[33m[tester::#GG6] [test-1.lox] [0m[33m// The inner function count() needs access to the[0m
-[33m[tester::#GG6] [test-1.lox] [0m[33m// outer function's local variable i.[0m
-[33m[tester::#GG6] [test-1.lox] [0m[33m// This can be achieved using closures.[0m
-[33m[tester::#GG6] [test-1.lox] [0mfun makeCounter() {
-[33m[tester::#GG6] [test-1.lox] [0m  var i = 0;
-[33m[tester::#GG6] [test-1.lox] [0m  fun count() {
-[33m[tester::#GG6] [test-1.lox] [0m    i = i + 4;
-[33m[tester::#GG6] [test-1.lox] [0m    print i;
-[33m[tester::#GG6] [test-1.lox] [0m  }
-[33m[tester::#GG6] [test-1.lox] [0m
-[33m[tester::#GG6] [test-1.lox] [0m  return count;
-[33m[tester::#GG6] [test-1.lox] [0m}
-[33m[tester::#GG6] [test-1.lox] [0m
-[33m[tester::#GG6] [test-1.lox] [0mvar counter = makeCounter();
-[33m[tester::#GG6] [test-1.lox] [0mcounter();
-[33m[tester::#GG6] [test-1.lox] [0mcounter();
+[33m[tester::#GG6] [test-1.lox] [0m[0m[33m// This program demonstrates the use of closures[0m[0m
+[33m[tester::#GG6] [test-1.lox] [0m[0m[33m// to create a counter function.[0m[0m
+[33m[tester::#GG6] [test-1.lox] [0m[0m[33m// The inner function count() needs access to the[0m[0m
+[33m[tester::#GG6] [test-1.lox] [0m[0m[33m// outer function's local variable i.[0m[0m
+[33m[tester::#GG6] [test-1.lox] [0m[0m[33m// This can be achieved using closures.[0m[0m
+[33m[tester::#GG6] [test-1.lox] [0m[0mfun makeCounter() {[0m
+[33m[tester::#GG6] [test-1.lox] [0m[0m  var i = 0;[0m
+[33m[tester::#GG6] [test-1.lox] [0m[0m  fun count() {[0m
+[33m[tester::#GG6] [test-1.lox] [0m[0m    i = i + 4;[0m
+[33m[tester::#GG6] [test-1.lox] [0m[0m    print i;[0m
+[33m[tester::#GG6] [test-1.lox] [0m[0m  }[0m
+[33m[tester::#GG6] [test-1.lox] [0m[0m[0m
+[33m[tester::#GG6] [test-1.lox] [0m[0m  return count;[0m
+[33m[tester::#GG6] [test-1.lox] [0m[0m}[0m
+[33m[tester::#GG6] [test-1.lox] [0m[0m[0m
+[33m[tester::#GG6] [test-1.lox] [0m[0mvar counter = makeCounter();[0m
+[33m[tester::#GG6] [test-1.lox] [0m[0mcounter();[0m
+[33m[tester::#GG6] [test-1.lox] [0m[0mcounter();[0m
 [33m[tester::#GG6] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m4
-[33m[your_program] [0m8
+[33m[your_program] [0m[0m4[0m
+[33m[your_program] [0m[0m8[0m
 [33m[tester::#GG6] [test-1] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#GG6] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#GG6] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#GG6] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#GG6] [test-2.lox] [0m[33m// This program uses mutual recursion to determine[0m
-[33m[tester::#GG6] [test-2.lox] [0m[33m// if a number is even or odd.[0m
-[33m[tester::#GG6] [test-2.lox] [0m[33m// It also uses a shared threshold variable that[0m
-[33m[tester::#GG6] [test-2.lox] [0m[33m// is used to determine if a number is too large[0m
-[33m[tester::#GG6] [test-2.lox] [0m[33m//to be processed.[0m
-[33m[tester::#GG6] [test-2.lox] [0m{
-[33m[tester::#GG6] [test-2.lox] [0m  var threshold = 50;
-[33m[tester::#GG6] [test-2.lox] [0m
-[33m[tester::#GG6] [test-2.lox] [0m  fun isEven(n) {
-[33m[tester::#GG6] [test-2.lox] [0m    if (n == 0) return true;
-[33m[tester::#GG6] [test-2.lox] [0m    if (n > threshold) return false;
-[33m[tester::#GG6] [test-2.lox] [0m    return isOdd(n - 1);
-[33m[tester::#GG6] [test-2.lox] [0m  }
-[33m[tester::#GG6] [test-2.lox] [0m
-[33m[tester::#GG6] [test-2.lox] [0m  fun isOdd(n) {
-[33m[tester::#GG6] [test-2.lox] [0m    if (n == 0) return false;
-[33m[tester::#GG6] [test-2.lox] [0m    if (n > threshold) return false;
-[33m[tester::#GG6] [test-2.lox] [0m    return isEven(n - 1);
-[33m[tester::#GG6] [test-2.lox] [0m  }
-[33m[tester::#GG6] [test-2.lox] [0m
-[33m[tester::#GG6] [test-2.lox] [0m  print isEven(75);
-[33m[tester::#GG6] [test-2.lox] [0m}
+[33m[tester::#GG6] [test-2.lox] [0m[0m[33m// This program uses mutual recursion to determine[0m[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m[33m// if a number is even or odd.[0m[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m[33m// It also uses a shared threshold variable that[0m[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m[33m// is used to determine if a number is too large[0m[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m[33m//to be processed.[0m[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m{[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m  var threshold = 50;[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m  fun isEven(n) {[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m    if (n == 0) return true;[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m    if (n > threshold) return false;[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m    return isOdd(n - 1);[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m  }[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m  fun isOdd(n) {[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m    if (n == 0) return false;[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m    if (n > threshold) return false;[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m    return isEven(n - 1);[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m  }[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m  print isEven(75);[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m}[0m
 [33m[tester::#GG6] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mfalse
+[33m[your_program] [0m[0mfalse[0m
 [33m[tester::#GG6] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#GG6] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#GG6] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#GG6] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#GG6] [test-3.lox] [0m[33m// This program demonstrates the use of closures[0m
-[33m[tester::#GG6] [test-3.lox] [0m[33m// to create a logger function.[0m
-[33m[tester::#GG6] [test-3.lox] [0m[33m// The inner function log() has access to the[0m
-[33m[tester::#GG6] [test-3.lox] [0m[33m// outer function's local variable logCount.[0m
-[33m[tester::#GG6] [test-3.lox] [0m[33m// This is an example of how closures can be used[0m
-[33m[tester::#GG6] [test-3.lox] [0m[33m// to create private variables and methods.[0m
-[33m[tester::#GG6] [test-3.lox] [0mfun makeLogger(prefix) {
-[33m[tester::#GG6] [test-3.lox] [0m  var logCount = 0;
-[33m[tester::#GG6] [test-3.lox] [0m
-[33m[tester::#GG6] [test-3.lox] [0m  fun log(message) {
-[33m[tester::#GG6] [test-3.lox] [0m    logCount = logCount + 1;
-[33m[tester::#GG6] [test-3.lox] [0m    print prefix + ": " + message;
-[33m[tester::#GG6] [test-3.lox] [0m
-[33m[tester::#GG6] [test-3.lox] [0m    if (logCount > 3) {
-[33m[tester::#GG6] [test-3.lox] [0m      print prefix + ": Too many log lines!";
-[33m[tester::#GG6] [test-3.lox] [0m      logCount = 0;
-[33m[tester::#GG6] [test-3.lox] [0m    }
-[33m[tester::#GG6] [test-3.lox] [0m  }
-[33m[tester::#GG6] [test-3.lox] [0m
-[33m[tester::#GG6] [test-3.lox] [0m  return log;
-[33m[tester::#GG6] [test-3.lox] [0m}
-[33m[tester::#GG6] [test-3.lox] [0m
-[33m[tester::#GG6] [test-3.lox] [0mvar debugLog = makeLogger("baz");
-[33m[tester::#GG6] [test-3.lox] [0mvar errorLog = makeLogger("hello");
-[33m[tester::#GG6] [test-3.lox] [0m
-[33m[tester::#GG6] [test-3.lox] [0mdebugLog("Starting");
-[33m[tester::#GG6] [test-3.lox] [0mdebugLog("Processing");
-[33m[tester::#GG6] [test-3.lox] [0mdebugLog("Finishing");
-[33m[tester::#GG6] [test-3.lox] [0mdebugLog("Extra line");
-[33m[tester::#GG6] [test-3.lox] [0m
-[33m[tester::#GG6] [test-3.lox] [0merrorLog("Failed!");
-[33m[tester::#GG6] [test-3.lox] [0merrorLog("Retrying...");
+[33m[tester::#GG6] [test-3.lox] [0m[0m[33m// This program demonstrates the use of closures[0m[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m[33m// to create a logger function.[0m[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m[33m// The inner function log() has access to the[0m[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m[33m// outer function's local variable logCount.[0m[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m[33m// This is an example of how closures can be used[0m[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m[33m// to create private variables and methods.[0m[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0mfun makeLogger(prefix) {[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m  var logCount = 0;[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m  fun log(message) {[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m    logCount = logCount + 1;[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m    print prefix + ": " + message;[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m    if (logCount > 3) {[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m      print prefix + ": Too many log lines!";[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m      logCount = 0;[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m    }[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m  }[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m  return log;[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m}[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0mvar debugLog = makeLogger("baz");[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0mvar errorLog = makeLogger("hello");[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0mdebugLog("Starting");[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0mdebugLog("Processing");[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0mdebugLog("Finishing");[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0mdebugLog("Extra line");[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0merrorLog("Failed!");[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0merrorLog("Retrying...");[0m
 [33m[tester::#GG6] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mbaz: Starting
-[33m[your_program] [0mbaz: Processing
-[33m[your_program] [0mbaz: Finishing
-[33m[your_program] [0mbaz: Extra line
-[33m[your_program] [0mbaz: Too many log lines!
-[33m[your_program] [0mhello: Failed!
-[33m[your_program] [0mhello: Retrying...
+[33m[your_program] [0m[0mbaz: Starting[0m
+[33m[your_program] [0m[0mbaz: Processing[0m
+[33m[your_program] [0m[0mbaz: Finishing[0m
+[33m[your_program] [0m[0mbaz: Extra line[0m
+[33m[your_program] [0m[0mbaz: Too many log lines![0m
+[33m[your_program] [0m[0mhello: Failed![0m
+[33m[your_program] [0m[0mhello: Retrying...[0m
 [33m[tester::#GG6] [test-3] [0m[92m✓ 7 line(s) match on stdout[0m
 [33m[tester::#GG6] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#GG6] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#GG6] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#GG6] [test-4.lox] [0m[33m// This program demonstrates the use of closures[0m
-[33m[tester::#GG6] [test-4.lox] [0m[33m// to create an accumulator function.[0m
-[33m[tester::#GG6] [test-4.lox] [0m[33m// The inner function accumulate() has access to[0m
-[33m[tester::#GG6] [test-4.lox] [0m[33m// the outer function's local variables sum and[0m
-[33m[tester::#GG6] [test-4.lox] [0m[33m// count.[0m
-[33m[tester::#GG6] [test-4.lox] [0m[33m// This is an example of how closures can be used[0m
-[33m[tester::#GG6] [test-4.lox] [0m[33m// to create private variables and methods.[0m
-[33m[tester::#GG6] [test-4.lox] [0mfun makeAccumulator(label) {
-[33m[tester::#GG6] [test-4.lox] [0m  var sum = 0;
-[33m[tester::#GG6] [test-4.lox] [0m  var count = 0;
-[33m[tester::#GG6] [test-4.lox] [0m
-[33m[tester::#GG6] [test-4.lox] [0m  fun accumulate(value) {
-[33m[tester::#GG6] [test-4.lox] [0m    sum = sum + value;
-[33m[tester::#GG6] [test-4.lox] [0m    count = count + 1;
-[33m[tester::#GG6] [test-4.lox] [0m
-[33m[tester::#GG6] [test-4.lox] [0m    print label;
-[33m[tester::#GG6] [test-4.lox] [0m    print count;
-[33m[tester::#GG6] [test-4.lox] [0m    print sum;
-[33m[tester::#GG6] [test-4.lox] [0m    print sum;
-[33m[tester::#GG6] [test-4.lox] [0m
-[33m[tester::#GG6] [test-4.lox] [0m    if (count > 3) {
-[33m[tester::#GG6] [test-4.lox] [0m      print "reset";
-[33m[tester::#GG6] [test-4.lox] [0m      sum = 0;
-[33m[tester::#GG6] [test-4.lox] [0m      count = 0;
-[33m[tester::#GG6] [test-4.lox] [0m    }
-[33m[tester::#GG6] [test-4.lox] [0m
-[33m[tester::#GG6] [test-4.lox] [0m    return sum;
-[33m[tester::#GG6] [test-4.lox] [0m  }
-[33m[tester::#GG6] [test-4.lox] [0m
-[33m[tester::#GG6] [test-4.lox] [0m  return accumulate;
-[33m[tester::#GG6] [test-4.lox] [0m}
-[33m[tester::#GG6] [test-4.lox] [0m
-[33m[tester::#GG6] [test-4.lox] [0mvar acc1 = makeAccumulator("First:");
-[33m[tester::#GG6] [test-4.lox] [0mvar acc2 = makeAccumulator("Second:");
-[33m[tester::#GG6] [test-4.lox] [0m
-[33m[tester::#GG6] [test-4.lox] [0macc1(6);
-[33m[tester::#GG6] [test-4.lox] [0macc1(4);
-[33m[tester::#GG6] [test-4.lox] [0macc1(3);
-[33m[tester::#GG6] [test-4.lox] [0macc1(5);
-[33m[tester::#GG6] [test-4.lox] [0m
-[33m[tester::#GG6] [test-4.lox] [0macc2(4);
-[33m[tester::#GG6] [test-4.lox] [0macc2(5);
+[33m[tester::#GG6] [test-4.lox] [0m[0m[33m// This program demonstrates the use of closures[0m[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m[33m// to create an accumulator function.[0m[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m[33m// The inner function accumulate() has access to[0m[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m[33m// the outer function's local variables sum and[0m[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m[33m// count.[0m[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m[33m// This is an example of how closures can be used[0m[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m[33m// to create private variables and methods.[0m[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0mfun makeAccumulator(label) {[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m  var sum = 0;[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m  var count = 0;[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m  fun accumulate(value) {[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m    sum = sum + value;[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m    count = count + 1;[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m    print label;[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m    print count;[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m    print sum;[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m    print sum;[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m    if (count > 3) {[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m      print "reset";[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m      sum = 0;[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m      count = 0;[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m    }[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m    return sum;[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m  return accumulate;[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m}[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0mvar acc1 = makeAccumulator("First:");[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0mvar acc2 = makeAccumulator("Second:");[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0macc1(6);[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0macc1(4);[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0macc1(3);[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0macc1(5);[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0macc2(4);[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0macc2(5);[0m
 [33m[tester::#GG6] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mFirst:
-[33m[your_program] [0m1
-[33m[your_program] [0m6
-[33m[your_program] [0m6
-[33m[your_program] [0mFirst:
-[33m[your_program] [0m2
-[33m[your_program] [0m10
-[33m[your_program] [0m10
-[33m[your_program] [0mFirst:
-[33m[your_program] [0m3
-[33m[your_program] [0m13
-[33m[your_program] [0m13
-[33m[your_program] [0mFirst:
-[33m[your_program] [0m4
-[33m[your_program] [0m18
-[33m[your_program] [0m18
-[33m[your_program] [0mreset
-[33m[your_program] [0mSecond:
-[33m[your_program] [0m1
-[33m[your_program] [0m4
-[33m[your_program] [0m4
-[33m[your_program] [0mSecond:
-[33m[your_program] [0m2
-[33m[your_program] [0m9
-[33m[your_program] [0m9
+[33m[your_program] [0m[0mFirst:[0m
+[33m[your_program] [0m[0m1[0m
+[33m[your_program] [0m[0m6[0m
+[33m[your_program] [0m[0m6[0m
+[33m[your_program] [0m[0mFirst:[0m
+[33m[your_program] [0m[0m2[0m
+[33m[your_program] [0m[0m10[0m
+[33m[your_program] [0m[0m10[0m
+[33m[your_program] [0m[0mFirst:[0m
+[33m[your_program] [0m[0m3[0m
+[33m[your_program] [0m[0m13[0m
+[33m[your_program] [0m[0m13[0m
+[33m[your_program] [0m[0mFirst:[0m
+[33m[your_program] [0m[0m4[0m
+[33m[your_program] [0m[0m18[0m
+[33m[your_program] [0m[0m18[0m
+[33m[your_program] [0m[0mreset[0m
+[33m[your_program] [0m[0mSecond:[0m
+[33m[your_program] [0m[0m1[0m
+[33m[your_program] [0m[0m4[0m
+[33m[your_program] [0m[0m4[0m
+[33m[your_program] [0m[0mSecond:[0m
+[33m[your_program] [0m[0m2[0m
+[33m[your_program] [0m[0m9[0m
+[33m[your_program] [0m[0m9[0m
 [33m[tester::#GG6] [test-4] [0m[92m✓ 25 line(s) match on stdout[0m
 [33m[tester::#GG6] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#GG6] [0m[92mTest passed.[0m

--- a/internal/test_helpers/fixtures/pass_functions_final
+++ b/internal/test_helpers/fixtures/pass_functions_final
@@ -3,63 +3,63 @@ Debug = true
 [33m[tester::#AV4] [0m[94mRunning tests for Stage #AV4 (av4)[0m
 [33m[tester::#AV4] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#AV4] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#AV4] [test-1.lox] [0mprint clock() + 23;
+[33m[tester::#AV4] [test-1.lox] [0m[0mprint clock() + 23;[0m
 [33m[tester::#AV4] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m1.750191785202E9
-[33m[tester::#AV4] [test-1] [0m[92m✓ 1750191785.202000[0m
+[33m[your_program] [0m[0m1.767707899378E9[0m
+[33m[tester::#AV4] [test-1] [0m[92m✓ 1767707899.378000[0m
 [33m[tester::#AV4] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#AV4] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#AV4] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#AV4] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#AV4] [test-2.lox] [0mprint clock() / 1000;
+[33m[tester::#AV4] [test-2.lox] [0m[0mprint clock() / 1000;[0m
 [33m[tester::#AV4] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m1750191.762257
-[33m[tester::#AV4] [test-2] [0m[92m✓ 1750191.762257[0m
+[33m[your_program] [0m[0m1767707.8764360002[0m
+[33m[tester::#AV4] [test-2] [0m[92m✓ 1767707.876436[0m
 [33m[tester::#AV4] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#AV4] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#AV4] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#AV4] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#AV4] [test-3.lox] [0m[33m// This program utilizes the built-in clock()[0m
-[33m[tester::#AV4] [test-3.lox] [0m[33m// function[0m
-[33m[tester::#AV4] [test-3.lox] [0m[33m// and runs a check to see if the operation has[0m
-[33m[tester::#AV4] [test-3.lox] [0m[33m// timed out[0m
-[33m[tester::#AV4] [test-3.lox] [0mvar startTime = clock();
-[33m[tester::#AV4] [test-3.lox] [0mvar timeoutSeconds = 2;
-[33m[tester::#AV4] [test-3.lox] [0m
-[33m[tester::#AV4] [test-3.lox] [0m[33m// Check if less than 2 seconds have elapsed[0m
-[33m[tester::#AV4] [test-3.lox] [0mvar c1 = clock() >= startTime;
-[33m[tester::#AV4] [test-3.lox] [0mvar c2 = clock() <= (startTime + timeoutSeconds);
-[33m[tester::#AV4] [test-3.lox] [0m
-[33m[tester::#AV4] [test-3.lox] [0mif (c1 and c2) {
-[33m[tester::#AV4] [test-3.lox] [0m  print "Operation in progress...";
-[33m[tester::#AV4] [test-3.lox] [0m} else {
-[33m[tester::#AV4] [test-3.lox] [0m  print "Operation timed out!";
-[33m[tester::#AV4] [test-3.lox] [0m}
+[33m[tester::#AV4] [test-3.lox] [0m[0m[33m// This program utilizes the built-in clock()[0m[0m
+[33m[tester::#AV4] [test-3.lox] [0m[0m[33m// function[0m[0m
+[33m[tester::#AV4] [test-3.lox] [0m[0m[33m// and runs a check to see if the operation has[0m[0m
+[33m[tester::#AV4] [test-3.lox] [0m[0m[33m// timed out[0m[0m
+[33m[tester::#AV4] [test-3.lox] [0m[0mvar startTime = clock();[0m
+[33m[tester::#AV4] [test-3.lox] [0m[0mvar timeoutSeconds = 2;[0m
+[33m[tester::#AV4] [test-3.lox] [0m[0m[0m
+[33m[tester::#AV4] [test-3.lox] [0m[0m[33m// Check if less than 2 seconds have elapsed[0m[0m
+[33m[tester::#AV4] [test-3.lox] [0m[0mvar c1 = clock() >= startTime;[0m
+[33m[tester::#AV4] [test-3.lox] [0m[0mvar c2 = clock() <= (startTime + timeoutSeconds);[0m
+[33m[tester::#AV4] [test-3.lox] [0m[0m[0m
+[33m[tester::#AV4] [test-3.lox] [0m[0mif (c1 and c2) {[0m
+[33m[tester::#AV4] [test-3.lox] [0m[0m  print "Operation in progress...";[0m
+[33m[tester::#AV4] [test-3.lox] [0m[0m} else {[0m
+[33m[tester::#AV4] [test-3.lox] [0m[0m  print "Operation timed out!";[0m
+[33m[tester::#AV4] [test-3.lox] [0m[0m}[0m
 [33m[tester::#AV4] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mOperation in progress...
+[33m[your_program] [0m[0mOperation in progress...[0m
 [33m[tester::#AV4] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#AV4] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#AV4] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#AV4] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#AV4] [test-4.lox] [0m[33m// This program utilizes the built-in clock()[0m
-[33m[tester::#AV4] [test-4.lox] [0m[33m// function[0m
-[33m[tester::#AV4] [test-4.lox] [0m[33m// to create a timer that runs for 0.2 seconds[0m
-[33m[tester::#AV4] [test-4.lox] [0mvar startTime = clock();
-[33m[tester::#AV4] [test-4.lox] [0mvar lastCheck = startTime;
-[33m[tester::#AV4] [test-4.lox] [0mvar running = true;
-[33m[tester::#AV4] [test-4.lox] [0m
-[33m[tester::#AV4] [test-4.lox] [0mprint "Starting timer for 0.2 seconds";
-[33m[tester::#AV4] [test-4.lox] [0mvar startTime = clock();
-[33m[tester::#AV4] [test-4.lox] [0m
-[33m[tester::#AV4] [test-4.lox] [0mwhile (running) {
-[33m[tester::#AV4] [test-4.lox] [0m  if (clock() > startTime + 0.2) {
-[33m[tester::#AV4] [test-4.lox] [0m    print "Timer ended";
-[33m[tester::#AV4] [test-4.lox] [0m    running = false;
-[33m[tester::#AV4] [test-4.lox] [0m  }
-[33m[tester::#AV4] [test-4.lox] [0m}
+[33m[tester::#AV4] [test-4.lox] [0m[0m[33m// This program utilizes the built-in clock()[0m[0m
+[33m[tester::#AV4] [test-4.lox] [0m[0m[33m// function[0m[0m
+[33m[tester::#AV4] [test-4.lox] [0m[0m[33m// to create a timer that runs for 0.2 seconds[0m[0m
+[33m[tester::#AV4] [test-4.lox] [0m[0mvar startTime = clock();[0m
+[33m[tester::#AV4] [test-4.lox] [0m[0mvar lastCheck = startTime;[0m
+[33m[tester::#AV4] [test-4.lox] [0m[0mvar running = true;[0m
+[33m[tester::#AV4] [test-4.lox] [0m[0m[0m
+[33m[tester::#AV4] [test-4.lox] [0m[0mprint "Starting timer for 0.2 seconds";[0m
+[33m[tester::#AV4] [test-4.lox] [0m[0mvar startTime = clock();[0m
+[33m[tester::#AV4] [test-4.lox] [0m[0m[0m
+[33m[tester::#AV4] [test-4.lox] [0m[0mwhile (running) {[0m
+[33m[tester::#AV4] [test-4.lox] [0m[0m  if (clock() > startTime + 0.2) {[0m
+[33m[tester::#AV4] [test-4.lox] [0m[0m    print "Timer ended";[0m
+[33m[tester::#AV4] [test-4.lox] [0m[0m    running = false;[0m
+[33m[tester::#AV4] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#AV4] [test-4.lox] [0m[0m}[0m
 [33m[tester::#AV4] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mStarting timer for 0.2 seconds
-[33m[your_program] [0mTimer ended
+[33m[your_program] [0m[0mStarting timer for 0.2 seconds[0m
+[33m[your_program] [0m[0mTimer ended[0m
 [33m[tester::#AV4] [test-4] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#AV4] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#AV4] [0m[92mTest passed.[0m
@@ -67,53 +67,53 @@ Debug = true
 [33m[tester::#PG8] [0m[94mRunning tests for Stage #PG8 (pg8)[0m
 [33m[tester::#PG8] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#PG8] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PG8] [test-1.lox] [0m[33m// This program defines a simple function that[0m
-[33m[tester::#PG8] [test-1.lox] [0m[33m// doesn't take any arguments[0m
-[33m[tester::#PG8] [test-1.lox] [0m[33m// and then invokes the function[0m
-[33m[tester::#PG8] [test-1.lox] [0mfun hello() { print 55; }
-[33m[tester::#PG8] [test-1.lox] [0mhello();
+[33m[tester::#PG8] [test-1.lox] [0m[0m[33m// This program defines a simple function that[0m[0m
+[33m[tester::#PG8] [test-1.lox] [0m[0m[33m// doesn't take any arguments[0m[0m
+[33m[tester::#PG8] [test-1.lox] [0m[0m[33m// and then invokes the function[0m[0m
+[33m[tester::#PG8] [test-1.lox] [0m[0mfun hello() { print 55; }[0m
+[33m[tester::#PG8] [test-1.lox] [0m[0mhello();[0m
 [33m[tester::#PG8] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m55
+[33m[your_program] [0m[0m55[0m
 [33m[tester::#PG8] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#PG8] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#PG8] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#PG8] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PG8] [test-2.lox] [0m[33m// This function, when invoked should not return[0m
-[33m[tester::#PG8] [test-2.lox] [0m[33m// or print anything[0m
-[33m[tester::#PG8] [test-2.lox] [0mfun f() {}
-[33m[tester::#PG8] [test-2.lox] [0mf();
+[33m[tester::#PG8] [test-2.lox] [0m[0m[33m// This function, when invoked should not return[0m[0m
+[33m[tester::#PG8] [test-2.lox] [0m[0m[33m// or print anything[0m[0m
+[33m[tester::#PG8] [test-2.lox] [0m[0mfun f() {}[0m
+[33m[tester::#PG8] [test-2.lox] [0m[0mf();[0m
 [33m[tester::#PG8] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
 [33m[tester::#PG8] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#PG8] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#PG8] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#PG8] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PG8] [test-3.lox] [0m[33m// This program should print <fn foo>[0m
-[33m[tester::#PG8] [test-3.lox] [0mfun foo() {}
-[33m[tester::#PG8] [test-3.lox] [0mprint foo;
+[33m[tester::#PG8] [test-3.lox] [0m[0m[33m// This program should print <fn foo>[0m[0m
+[33m[tester::#PG8] [test-3.lox] [0m[0mfun foo() {}[0m
+[33m[tester::#PG8] [test-3.lox] [0m[0mprint foo;[0m
 [33m[tester::#PG8] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m<fn foo>
+[33m[your_program] [0m[0m<fn foo>[0m
 [33m[tester::#PG8] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#PG8] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#PG8] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#PG8] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PG8] [test-4.lox] [0m[33m// This program calculates the cumulative sum of[0m
-[33m[tester::#PG8] [test-4.lox] [0m[33m// numbers from 1 to n.[0m
-[33m[tester::#PG8] [test-4.lox] [0mfun cumulative_sum() {
-[33m[tester::#PG8] [test-4.lox] [0m    var n = 10;  [33m// Fixed value[0m
-[33m[tester::#PG8] [test-4.lox] [0m    var total = 0;
-[33m[tester::#PG8] [test-4.lox] [0m    var i = 1;
-[33m[tester::#PG8] [test-4.lox] [0m    while (i <= n) {
-[33m[tester::#PG8] [test-4.lox] [0m        total = total + i;
-[33m[tester::#PG8] [test-4.lox] [0m        i = i + 1;
-[33m[tester::#PG8] [test-4.lox] [0m    }
-[33m[tester::#PG8] [test-4.lox] [0m    print "The cumulative sum from 1 to 10 is: ";
-[33m[tester::#PG8] [test-4.lox] [0m    print total;
-[33m[tester::#PG8] [test-4.lox] [0m}
-[33m[tester::#PG8] [test-4.lox] [0m
-[33m[tester::#PG8] [test-4.lox] [0mcumulative_sum();
+[33m[tester::#PG8] [test-4.lox] [0m[0m[33m// This program calculates the cumulative sum of[0m[0m
+[33m[tester::#PG8] [test-4.lox] [0m[0m[33m// numbers from 1 to n.[0m[0m
+[33m[tester::#PG8] [test-4.lox] [0m[0mfun cumulative_sum() {[0m
+[33m[tester::#PG8] [test-4.lox] [0m[0m    var n = 10;  [33m// Fixed value[0m[0m
+[33m[tester::#PG8] [test-4.lox] [0m[0m    var total = 0;[0m
+[33m[tester::#PG8] [test-4.lox] [0m[0m    var i = 1;[0m
+[33m[tester::#PG8] [test-4.lox] [0m[0m    while (i <= n) {[0m
+[33m[tester::#PG8] [test-4.lox] [0m[0m        total = total + i;[0m
+[33m[tester::#PG8] [test-4.lox] [0m[0m        i = i + 1;[0m
+[33m[tester::#PG8] [test-4.lox] [0m[0m    }[0m
+[33m[tester::#PG8] [test-4.lox] [0m[0m    print "The cumulative sum from 1 to 10 is: ";[0m
+[33m[tester::#PG8] [test-4.lox] [0m[0m    print total;[0m
+[33m[tester::#PG8] [test-4.lox] [0m[0m}[0m
+[33m[tester::#PG8] [test-4.lox] [0m[0m[0m
+[33m[tester::#PG8] [test-4.lox] [0m[0mcumulative_sum();[0m
 [33m[tester::#PG8] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mThe cumulative sum from 1 to 10 is: 
-[33m[your_program] [0m55
+[33m[your_program] [0m[0mThe cumulative sum from 1 to 10 is: [0m
+[33m[your_program] [0m[0m55[0m
 [33m[tester::#PG8] [test-4] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#PG8] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#PG8] [0m[92mTest passed.[0m
@@ -121,63 +121,63 @@ Debug = true
 [33m[tester::#LB6] [0m[94mRunning tests for Stage #LB6 (lb6)[0m
 [33m[tester::#LB6] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#LB6] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#LB6] [test-1.lox] [0m[33m// This is a simple function that takes one[0m
-[33m[tester::#LB6] [test-1.lox] [0m[33m// argument and prints it[0m
-[33m[tester::#LB6] [test-1.lox] [0mfun f1(a) { print a; }
-[33m[tester::#LB6] [test-1.lox] [0mf1(45);
+[33m[tester::#LB6] [test-1.lox] [0m[0m[33m// This is a simple function that takes one[0m[0m
+[33m[tester::#LB6] [test-1.lox] [0m[0m[33m// argument and prints it[0m[0m
+[33m[tester::#LB6] [test-1.lox] [0m[0mfun f1(a) { print a; }[0m
+[33m[tester::#LB6] [test-1.lox] [0m[0mf1(45);[0m
 [33m[tester::#LB6] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m45
+[33m[your_program] [0m[0m45[0m
 [33m[tester::#LB6] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#LB6] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#LB6] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#LB6] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#LB6] [test-2.lox] [0m[33m// This function takes three arguments and prints[0m
-[33m[tester::#LB6] [test-2.lox] [0m[33m// their sum[0m
-[33m[tester::#LB6] [test-2.lox] [0mfun f3(a, b, c) { print a + b + c; }
-[33m[tester::#LB6] [test-2.lox] [0mf3(67, 67, 67);
+[33m[tester::#LB6] [test-2.lox] [0m[0m[33m// This function takes three arguments and prints[0m[0m
+[33m[tester::#LB6] [test-2.lox] [0m[0m[33m// their sum[0m[0m
+[33m[tester::#LB6] [test-2.lox] [0m[0mfun f3(a, b, c) { print a + b + c; }[0m
+[33m[tester::#LB6] [test-2.lox] [0m[0mf3(67, 67, 67);[0m
 [33m[tester::#LB6] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m201
+[33m[your_program] [0m[0m201[0m
 [33m[tester::#LB6] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#LB6] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#LB6] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#LB6] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#LB6] [test-3.lox] [0m[33m// This function takes eight arguments and prints[0m
-[33m[tester::#LB6] [test-3.lox] [0m[33m// their sum[0m
-[33m[tester::#LB6] [test-3.lox] [0mfun f8(a, b, c, d, e, f, g, h) {
-[33m[tester::#LB6] [test-3.lox] [0m  print a - b + c * d + e - f + g - h;
-[33m[tester::#LB6] [test-3.lox] [0m}
-[33m[tester::#LB6] [test-3.lox] [0mf8(29, 29, 29, 29, 29, 29, 29, 29);
+[33m[tester::#LB6] [test-3.lox] [0m[0m[33m// This function takes eight arguments and prints[0m[0m
+[33m[tester::#LB6] [test-3.lox] [0m[0m[33m// their sum[0m[0m
+[33m[tester::#LB6] [test-3.lox] [0m[0mfun f8(a, b, c, d, e, f, g, h) {[0m
+[33m[tester::#LB6] [test-3.lox] [0m[0m  print a - b + c * d + e - f + g - h;[0m
+[33m[tester::#LB6] [test-3.lox] [0m[0m}[0m
+[33m[tester::#LB6] [test-3.lox] [0m[0mf8(29, 29, 29, 29, 29, 29, 29, 29);[0m
 [33m[tester::#LB6] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m841
+[33m[your_program] [0m[0m841[0m
 [33m[tester::#LB6] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#LB6] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#LB6] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#LB6] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#LB6] [test-4.lox] [0m[33m// This function takes two arguments and prints[0m
-[33m[tester::#LB6] [test-4.lox] [0m[33m// the grade based on the score and bonus[0m
-[33m[tester::#LB6] [test-4.lox] [0mfun calculateGrade(score, bonus) {
-[33m[tester::#LB6] [test-4.lox] [0m  var finalScore = score + bonus;
-[33m[tester::#LB6] [test-4.lox] [0m
-[33m[tester::#LB6] [test-4.lox] [0m  if (finalScore >= 90) {
-[33m[tester::#LB6] [test-4.lox] [0m    print "A";
-[33m[tester::#LB6] [test-4.lox] [0m  } else if (finalScore >= 80) {
-[33m[tester::#LB6] [test-4.lox] [0m    print "B";
-[33m[tester::#LB6] [test-4.lox] [0m  } else if (finalScore >= 70) {
-[33m[tester::#LB6] [test-4.lox] [0m    print "C";
-[33m[tester::#LB6] [test-4.lox] [0m  } else if (finalScore >= 60) {
-[33m[tester::#LB6] [test-4.lox] [0m    print "D";
-[33m[tester::#LB6] [test-4.lox] [0m  } else {
-[33m[tester::#LB6] [test-4.lox] [0m    print "F";
-[33m[tester::#LB6] [test-4.lox] [0m  }
-[33m[tester::#LB6] [test-4.lox] [0m}
-[33m[tester::#LB6] [test-4.lox] [0m
-[33m[tester::#LB6] [test-4.lox] [0mvar score = 64;
-[33m[tester::#LB6] [test-4.lox] [0mvar bonus = 3;
-[33m[tester::#LB6] [test-4.lox] [0mprint "Grade for given score is: ";
-[33m[tester::#LB6] [test-4.lox] [0mcalculateGrade(score, bonus);
+[33m[tester::#LB6] [test-4.lox] [0m[0m[33m// This function takes two arguments and prints[0m[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0m[33m// the grade based on the score and bonus[0m[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0mfun calculateGrade(score, bonus) {[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0m  var finalScore = score + bonus;[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0m[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0m  if (finalScore >= 90) {[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0m    print "A";[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0m  } else if (finalScore >= 80) {[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0m    print "B";[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0m  } else if (finalScore >= 70) {[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0m    print "C";[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0m  } else if (finalScore >= 60) {[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0m    print "D";[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0m  } else {[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0m    print "F";[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0m}[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0m[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0mvar score = 64;[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0mvar bonus = 3;[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0mprint "Grade for given score is: ";[0m
+[33m[tester::#LB6] [test-4.lox] [0m[0mcalculateGrade(score, bonus);[0m
 [33m[tester::#LB6] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mGrade for given score is: 
-[33m[your_program] [0mD
+[33m[your_program] [0m[0mGrade for given score is: [0m
+[33m[your_program] [0m[0mD[0m
 [33m[tester::#LB6] [test-4] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#LB6] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#LB6] [0m[92mTest passed.[0m
@@ -185,46 +185,46 @@ Debug = true
 [33m[tester::#PX4] [0m[94mRunning tests for Stage #PX4 (px4)[0m
 [33m[tester::#PX4] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#PX4] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PX4] [test-1.lox] [0m[33m// This program is missing the closing parenthesis[0m
-[33m[tester::#PX4] [test-1.lox] [0m[33m// for the function call[0m
-[33m[tester::#PX4] [test-1.lox] [0m[33m// Hence the compiler error[0m
-[33m[tester::#PX4] [test-1.lox] [0mprint clock(;
+[33m[tester::#PX4] [test-1.lox] [0m[0m[33m// This program is missing the closing parenthesis[0m[0m
+[33m[tester::#PX4] [test-1.lox] [0m[0m[33m// for the function call[0m[0m
+[33m[tester::#PX4] [test-1.lox] [0m[0m[33m// Hence the compiler error[0m[0m
+[33m[tester::#PX4] [test-1.lox] [0m[0mprint clock(;[0m
 [33m[tester::#PX4] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 4] Error at ';': Expect expression.
+[33m[your_program] [0m[0m[line 4] Error at ';': Expect expression.[0m
 [33m[tester::#PX4] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#PX4] [test-1] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#PX4] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#PX4] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PX4] [test-2.lox] [0m[33m// This program is missing the opening parenthesis[0m
-[33m[tester::#PX4] [test-2.lox] [0m[33m// for the function call,[0m
-[33m[tester::#PX4] [test-2.lox] [0m[33m// and has extra closing parentheses[0m
-[33m[tester::#PX4] [test-2.lox] [0m[33m// Hence the compiler error[0m
-[33m[tester::#PX4] [test-2.lox] [0mprint clock)));
+[33m[tester::#PX4] [test-2.lox] [0m[0m[33m// This program is missing the opening parenthesis[0m[0m
+[33m[tester::#PX4] [test-2.lox] [0m[0m[33m// for the function call,[0m[0m
+[33m[tester::#PX4] [test-2.lox] [0m[0m[33m// and has extra closing parentheses[0m[0m
+[33m[tester::#PX4] [test-2.lox] [0m[0m[33m// Hence the compiler error[0m[0m
+[33m[tester::#PX4] [test-2.lox] [0m[0mprint clock)));[0m
 [33m[tester::#PX4] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 5] Error at ')': Expect ';' after value.
+[33m[your_program] [0m[0m[line 5] Error at ')': Expect ';' after value.[0m
 [33m[tester::#PX4] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#PX4] [test-2] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#PX4] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#PX4] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PX4] [test-3.lox] [0m[33m// This function declaration is missing the[0m
-[33m[tester::#PX4] [test-3.lox] [0m[33m// opening and closing braces[0m
-[33m[tester::#PX4] [test-3.lox] [0m[33m// The body should always be inside a block[0m
-[33m[tester::#PX4] [test-3.lox] [0m[33m// Hence the compiler error[0m
-[33m[tester::#PX4] [test-3.lox] [0mfun f() 27;
-[33m[tester::#PX4] [test-3.lox] [0mprint f();
+[33m[tester::#PX4] [test-3.lox] [0m[0m[33m// This function declaration is missing the[0m[0m
+[33m[tester::#PX4] [test-3.lox] [0m[0m[33m// opening and closing braces[0m[0m
+[33m[tester::#PX4] [test-3.lox] [0m[0m[33m// The body should always be inside a block[0m[0m
+[33m[tester::#PX4] [test-3.lox] [0m[0m[33m// Hence the compiler error[0m[0m
+[33m[tester::#PX4] [test-3.lox] [0m[0mfun f() 27;[0m
+[33m[tester::#PX4] [test-3.lox] [0m[0mprint f();[0m
 [33m[tester::#PX4] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 5] Error at '27': Expect '{' before function body.
+[33m[your_program] [0m[0m[line 5] Error at '27': Expect '{' before function body.[0m
 [33m[tester::#PX4] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#PX4] [test-3] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#PX4] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#PX4] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PX4] [test-4.lox] [0m[33m// This function declaration is missing a comma[0m
-[33m[tester::#PX4] [test-4.lox] [0m[33m// between b and c[0m
-[33m[tester::#PX4] [test-4.lox] [0m[33m// Hence the compiler error[0m
-[33m[tester::#PX4] [test-4.lox] [0mfun foo(a, b c, d, e, f) {}
-[33m[tester::#PX4] [test-4.lox] [0mfoo();
+[33m[tester::#PX4] [test-4.lox] [0m[0m[33m// This function declaration is missing a comma[0m[0m
+[33m[tester::#PX4] [test-4.lox] [0m[0m[33m// between b and c[0m[0m
+[33m[tester::#PX4] [test-4.lox] [0m[0m[33m// Hence the compiler error[0m[0m
+[33m[tester::#PX4] [test-4.lox] [0m[0mfun foo(a, b c, d, e, f) {}[0m
+[33m[tester::#PX4] [test-4.lox] [0m[0mfoo();[0m
 [33m[tester::#PX4] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 4] Error at 'c': Expect ')' after parameters.
+[33m[your_program] [0m[0m[line 4] Error at 'c': Expect ')' after parameters.[0m
 [33m[tester::#PX4] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#PX4] [test-4] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#PX4] [0m[92mTest passed.[0m
@@ -232,60 +232,60 @@ Debug = true
 [33m[tester::#RD2] [0m[94mRunning tests for Stage #RD2 (rd2)[0m
 [33m[tester::#RD2] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#RD2] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#RD2] [test-1.lox] [0m[33m// This program computes the 35th Fibonacci number[0m
-[33m[tester::#RD2] [test-1.lox] [0mfun fib(n) {
-[33m[tester::#RD2] [test-1.lox] [0m  if (n < 2) return n;
-[33m[tester::#RD2] [test-1.lox] [0m  return fib(n - 2) + fib(n - 1);
-[33m[tester::#RD2] [test-1.lox] [0m}
-[33m[tester::#RD2] [test-1.lox] [0m
-[33m[tester::#RD2] [test-1.lox] [0mvar start = clock();
-[33m[tester::#RD2] [test-1.lox] [0mprint fib(10) == 55;
-[33m[tester::#RD2] [test-1.lox] [0mprint (clock() - start) < 5; [33m// 5 seconds[0m
+[33m[tester::#RD2] [test-1.lox] [0m[0m[33m// This program computes the 35th Fibonacci number[0m[0m
+[33m[tester::#RD2] [test-1.lox] [0m[0mfun fib(n) {[0m
+[33m[tester::#RD2] [test-1.lox] [0m[0m  if (n < 2) return n;[0m
+[33m[tester::#RD2] [test-1.lox] [0m[0m  return fib(n - 2) + fib(n - 1);[0m
+[33m[tester::#RD2] [test-1.lox] [0m[0m}[0m
+[33m[tester::#RD2] [test-1.lox] [0m[0m[0m
+[33m[tester::#RD2] [test-1.lox] [0m[0mvar start = clock();[0m
+[33m[tester::#RD2] [test-1.lox] [0m[0mprint fib(10) == 55;[0m
+[33m[tester::#RD2] [test-1.lox] [0m[0mprint (clock() - start) < 5; [33m// 5 seconds[0m[0m
 [33m[tester::#RD2] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mtrue
-[33m[your_program] [0mtrue
+[33m[your_program] [0m[0mtrue[0m
+[33m[your_program] [0m[0mtrue[0m
 [33m[tester::#RD2] [test-1] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#RD2] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#RD2] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#RD2] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#RD2] [test-2.lox] [0m[33m// This program uses a return statement inside an[0m
-[33m[tester::#RD2] [test-2.lox] [0m[33m// if statement[0m
-[33m[tester::#RD2] [test-2.lox] [0m[33m// to return "ok" if the condition is false[0m
-[33m[tester::#RD2] [test-2.lox] [0mfun f() {
-[33m[tester::#RD2] [test-2.lox] [0m  if (true) return "no"; else return "ok";
-[33m[tester::#RD2] [test-2.lox] [0m}
-[33m[tester::#RD2] [test-2.lox] [0m
-[33m[tester::#RD2] [test-2.lox] [0mprint f();
+[33m[tester::#RD2] [test-2.lox] [0m[0m[33m// This program uses a return statement inside an[0m[0m
+[33m[tester::#RD2] [test-2.lox] [0m[0m[33m// if statement[0m[0m
+[33m[tester::#RD2] [test-2.lox] [0m[0m[33m// to return "ok" if the condition is false[0m[0m
+[33m[tester::#RD2] [test-2.lox] [0m[0mfun f() {[0m
+[33m[tester::#RD2] [test-2.lox] [0m[0m  if (true) return "no"; else return "ok";[0m
+[33m[tester::#RD2] [test-2.lox] [0m[0m}[0m
+[33m[tester::#RD2] [test-2.lox] [0m[0m[0m
+[33m[tester::#RD2] [test-2.lox] [0m[0mprint f();[0m
 [33m[tester::#RD2] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mno
+[33m[your_program] [0m[0mno[0m
 [33m[tester::#RD2] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#RD2] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#RD2] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#RD2] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#RD2] [test-3.lox] [0m[33m// This program uses a return statement inside a[0m
-[33m[tester::#RD2] [test-3.lox] [0m[33m// while loop[0m
-[33m[tester::#RD2] [test-3.lox] [0m[33m// to return "ok" if the condition is false[0m
-[33m[tester::#RD2] [test-3.lox] [0mfun f() {
-[33m[tester::#RD2] [test-3.lox] [0m  while (!false) return "ok";
-[33m[tester::#RD2] [test-3.lox] [0m}
-[33m[tester::#RD2] [test-3.lox] [0m
-[33m[tester::#RD2] [test-3.lox] [0mprint f();
+[33m[tester::#RD2] [test-3.lox] [0m[0m[33m// This program uses a return statement inside a[0m[0m
+[33m[tester::#RD2] [test-3.lox] [0m[0m[33m// while loop[0m[0m
+[33m[tester::#RD2] [test-3.lox] [0m[0m[33m// to return "ok" if the condition is false[0m[0m
+[33m[tester::#RD2] [test-3.lox] [0m[0mfun f() {[0m
+[33m[tester::#RD2] [test-3.lox] [0m[0m  while (!false) return "ok";[0m
+[33m[tester::#RD2] [test-3.lox] [0m[0m}[0m
+[33m[tester::#RD2] [test-3.lox] [0m[0m[0m
+[33m[tester::#RD2] [test-3.lox] [0m[0mprint f();[0m
 [33m[tester::#RD2] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mok
+[33m[your_program] [0m[0mok[0m
 [33m[tester::#RD2] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#RD2] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#RD2] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#RD2] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#RD2] [test-4.lox] [0m[33m// This program relies on the return statement[0m
-[33m[tester::#RD2] [test-4.lox] [0m[33m// returning nil by default[0m
-[33m[tester::#RD2] [test-4.lox] [0mfun f() {
-[33m[tester::#RD2] [test-4.lox] [0m  return;
-[33m[tester::#RD2] [test-4.lox] [0m  print "bad";
-[33m[tester::#RD2] [test-4.lox] [0m}
-[33m[tester::#RD2] [test-4.lox] [0m
-[33m[tester::#RD2] [test-4.lox] [0mprint f();
+[33m[tester::#RD2] [test-4.lox] [0m[0m[33m// This program relies on the return statement[0m[0m
+[33m[tester::#RD2] [test-4.lox] [0m[0m[33m// returning nil by default[0m[0m
+[33m[tester::#RD2] [test-4.lox] [0m[0mfun f() {[0m
+[33m[tester::#RD2] [test-4.lox] [0m[0m  return;[0m
+[33m[tester::#RD2] [test-4.lox] [0m[0m  print "bad";[0m
+[33m[tester::#RD2] [test-4.lox] [0m[0m}[0m
+[33m[tester::#RD2] [test-4.lox] [0m[0m[0m
+[33m[tester::#RD2] [test-4.lox] [0m[0mprint f();[0m
 [33m[tester::#RD2] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mnil
+[33m[your_program] [0m[0mnil[0m
 [33m[tester::#RD2] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#RD2] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#RD2] [0m[92mTest passed.[0m
@@ -293,119 +293,119 @@ Debug = true
 [33m[tester::#EY3] [0m[94mRunning tests for Stage #EY3 (ey3)[0m
 [33m[tester::#EY3] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#EY3] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#EY3] [test-1.lox] [0m[33m// This program creates a function that returns[0m
-[33m[tester::#EY3] [test-1.lox] [0m[33m// another function[0m
-[33m[tester::#EY3] [test-1.lox] [0m[33m// and uses it to greet two different people with[0m
-[33m[tester::#EY3] [test-1.lox] [0m[33m// two different greetings[0m
-[33m[tester::#EY3] [test-1.lox] [0mfun makeGreeter() {
-[33m[tester::#EY3] [test-1.lox] [0m  fun greet(name) {
-[33m[tester::#EY3] [test-1.lox] [0m    print "Hello " + name;
-[33m[tester::#EY3] [test-1.lox] [0m  }
-[33m[tester::#EY3] [test-1.lox] [0m  return greet;
-[33m[tester::#EY3] [test-1.lox] [0m}
-[33m[tester::#EY3] [test-1.lox] [0m
-[33m[tester::#EY3] [test-1.lox] [0mvar sayHello = makeGreeter();
-[33m[tester::#EY3] [test-1.lox] [0m
-[33m[tester::#EY3] [test-1.lox] [0msayHello("Bob");
-[33m[tester::#EY3] [test-1.lox] [0msayHello("Alice");
-[33m[tester::#EY3] [test-1.lox] [0msayHello("Eve");
+[33m[tester::#EY3] [test-1.lox] [0m[0m[33m// This program creates a function that returns[0m[0m
+[33m[tester::#EY3] [test-1.lox] [0m[0m[33m// another function[0m[0m
+[33m[tester::#EY3] [test-1.lox] [0m[0m[33m// and uses it to greet two different people with[0m[0m
+[33m[tester::#EY3] [test-1.lox] [0m[0m[33m// two different greetings[0m[0m
+[33m[tester::#EY3] [test-1.lox] [0m[0mfun makeGreeter() {[0m
+[33m[tester::#EY3] [test-1.lox] [0m[0m  fun greet(name) {[0m
+[33m[tester::#EY3] [test-1.lox] [0m[0m    print "Hello " + name;[0m
+[33m[tester::#EY3] [test-1.lox] [0m[0m  }[0m
+[33m[tester::#EY3] [test-1.lox] [0m[0m  return greet;[0m
+[33m[tester::#EY3] [test-1.lox] [0m[0m}[0m
+[33m[tester::#EY3] [test-1.lox] [0m[0m[0m
+[33m[tester::#EY3] [test-1.lox] [0m[0mvar sayHello = makeGreeter();[0m
+[33m[tester::#EY3] [test-1.lox] [0m[0m[0m
+[33m[tester::#EY3] [test-1.lox] [0m[0msayHello("Bob");[0m
+[33m[tester::#EY3] [test-1.lox] [0m[0msayHello("Alice");[0m
+[33m[tester::#EY3] [test-1.lox] [0m[0msayHello("Eve");[0m
 [33m[tester::#EY3] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mHello Bob
-[33m[your_program] [0mHello Alice
-[33m[your_program] [0mHello Eve
+[33m[your_program] [0m[0mHello Bob[0m
+[33m[your_program] [0m[0mHello Alice[0m
+[33m[your_program] [0m[0mHello Eve[0m
 [33m[tester::#EY3] [test-1] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#EY3] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#EY3] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#EY3] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#EY3] [test-2.lox] [0m[33m// This program defines a function that takes in a[0m
-[33m[tester::#EY3] [test-2.lox] [0m[33m// function and an argument[0m
-[33m[tester::#EY3] [test-2.lox] [0m[33m// and returns the result of calling the function[0m
-[33m[tester::#EY3] [test-2.lox] [0m[33m// with the argument[0m
-[33m[tester::#EY3] [test-2.lox] [0mfun returnArg(arg) {
-[33m[tester::#EY3] [test-2.lox] [0m  return arg;
-[33m[tester::#EY3] [test-2.lox] [0m}
-[33m[tester::#EY3] [test-2.lox] [0m
-[33m[tester::#EY3] [test-2.lox] [0mfun returnFunCallWithArg(func, arg) {
-[33m[tester::#EY3] [test-2.lox] [0m  return returnArg(func)(arg);
-[33m[tester::#EY3] [test-2.lox] [0m}
-[33m[tester::#EY3] [test-2.lox] [0m
-[33m[tester::#EY3] [test-2.lox] [0mfun printArg(arg) {
-[33m[tester::#EY3] [test-2.lox] [0m  print arg;
-[33m[tester::#EY3] [test-2.lox] [0m}
-[33m[tester::#EY3] [test-2.lox] [0m
-[33m[tester::#EY3] [test-2.lox] [0mreturnFunCallWithArg(printArg, "world");
+[33m[tester::#EY3] [test-2.lox] [0m[0m[33m// This program defines a function that takes in a[0m[0m
+[33m[tester::#EY3] [test-2.lox] [0m[0m[33m// function and an argument[0m[0m
+[33m[tester::#EY3] [test-2.lox] [0m[0m[33m// and returns the result of calling the function[0m[0m
+[33m[tester::#EY3] [test-2.lox] [0m[0m[33m// with the argument[0m[0m
+[33m[tester::#EY3] [test-2.lox] [0m[0mfun returnArg(arg) {[0m
+[33m[tester::#EY3] [test-2.lox] [0m[0m  return arg;[0m
+[33m[tester::#EY3] [test-2.lox] [0m[0m}[0m
+[33m[tester::#EY3] [test-2.lox] [0m[0m[0m
+[33m[tester::#EY3] [test-2.lox] [0m[0mfun returnFunCallWithArg(func, arg) {[0m
+[33m[tester::#EY3] [test-2.lox] [0m[0m  return returnArg(func)(arg);[0m
+[33m[tester::#EY3] [test-2.lox] [0m[0m}[0m
+[33m[tester::#EY3] [test-2.lox] [0m[0m[0m
+[33m[tester::#EY3] [test-2.lox] [0m[0mfun printArg(arg) {[0m
+[33m[tester::#EY3] [test-2.lox] [0m[0m  print arg;[0m
+[33m[tester::#EY3] [test-2.lox] [0m[0m}[0m
+[33m[tester::#EY3] [test-2.lox] [0m[0m[0m
+[33m[tester::#EY3] [test-2.lox] [0m[0mreturnFunCallWithArg(printArg, "world");[0m
 [33m[tester::#EY3] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mworld
+[33m[your_program] [0m[0mworld[0m
 [33m[tester::#EY3] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#EY3] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#EY3] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#EY3] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#EY3] [test-3.lox] [0mfun square(x) {
-[33m[tester::#EY3] [test-3.lox] [0m  return x * x;
-[33m[tester::#EY3] [test-3.lox] [0m}
-[33m[tester::#EY3] [test-3.lox] [0m
-[33m[tester::#EY3] [test-3.lox] [0m[33m// This higher-order function applies a[0m
-[33m[tester::#EY3] [test-3.lox] [0m[33m// function N times to a starting value x.[0m
-[33m[tester::#EY3] [test-3.lox] [0mfun applyTimesN(N, f, x) {
-[33m[tester::#EY3] [test-3.lox] [0m  var i = 0;
-[33m[tester::#EY3] [test-3.lox] [0m  while (i < N) {
-[33m[tester::#EY3] [test-3.lox] [0m    x = f(x);
-[33m[tester::#EY3] [test-3.lox] [0m    i = i + 1;
-[33m[tester::#EY3] [test-3.lox] [0m  }
-[33m[tester::#EY3] [test-3.lox] [0m  return x;
-[33m[tester::#EY3] [test-3.lox] [0m}
-[33m[tester::#EY3] [test-3.lox] [0m
-[33m[tester::#EY3] [test-3.lox] [0m[33m// 2 is squared once[0m
-[33m[tester::#EY3] [test-3.lox] [0mprint applyTimesN(1, square, 2);
-[33m[tester::#EY3] [test-3.lox] [0m[33m// 2 is squared twice[0m
-[33m[tester::#EY3] [test-3.lox] [0mprint applyTimesN(2, square, 2);
-[33m[tester::#EY3] [test-3.lox] [0m[33m// 2 is squared thrice[0m
-[33m[tester::#EY3] [test-3.lox] [0mprint applyTimesN(3, square, 2);
+[33m[tester::#EY3] [test-3.lox] [0m[0mfun square(x) {[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0m  return x * x;[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0m}[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0m[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0m[33m// This higher-order function applies a[0m[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0m[33m// function N times to a starting value x.[0m[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0mfun applyTimesN(N, f, x) {[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0m  var i = 0;[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0m  while (i < N) {[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0m    x = f(x);[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0m    i = i + 1;[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0m  }[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0m  return x;[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0m}[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0m[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0m[33m// 2 is squared once[0m[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0mprint applyTimesN(1, square, 2);[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0m[33m// 2 is squared twice[0m[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0mprint applyTimesN(2, square, 2);[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0m[33m// 2 is squared thrice[0m[0m
+[33m[tester::#EY3] [test-3.lox] [0m[0mprint applyTimesN(3, square, 2);[0m
 [33m[tester::#EY3] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m4
-[33m[your_program] [0m16
-[33m[your_program] [0m256
+[33m[your_program] [0m[0m4[0m
+[33m[your_program] [0m[0m16[0m
+[33m[your_program] [0m[0m256[0m
 [33m[tester::#EY3] [test-3] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#EY3] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#EY3] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#EY3] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#EY3] [test-4.lox] [0m[33m// This program creates a function that returns[0m
-[33m[tester::#EY3] [test-4.lox] [0m[33m// another function[0m
-[33m[tester::#EY3] [test-4.lox] [0m[33m// and uses it to filter a list of numbers[0m
-[33m[tester::#EY3] [test-4.lox] [0mfun makeFilter() {
-[33m[tester::#EY3] [test-4.lox] [0m  fun filter(n) {
-[33m[tester::#EY3] [test-4.lox] [0m    if (n < 54) {
-[33m[tester::#EY3] [test-4.lox] [0m      return false;
-[33m[tester::#EY3] [test-4.lox] [0m    }
-[33m[tester::#EY3] [test-4.lox] [0m    return true;
-[33m[tester::#EY3] [test-4.lox] [0m  }
-[33m[tester::#EY3] [test-4.lox] [0m  return filter;
-[33m[tester::#EY3] [test-4.lox] [0m}
-[33m[tester::#EY3] [test-4.lox] [0m
-[33m[tester::#EY3] [test-4.lox] [0m[33m// This function applies a function to a list of[0m
-[33m[tester::#EY3] [test-4.lox] [0m[33m// numbers[0m
-[33m[tester::#EY3] [test-4.lox] [0mfun applyToNumbers(f, count) {
-[33m[tester::#EY3] [test-4.lox] [0m  var n = 0;
-[33m[tester::#EY3] [test-4.lox] [0m  while (n < count) {
-[33m[tester::#EY3] [test-4.lox] [0m    if (f(n)) {
-[33m[tester::#EY3] [test-4.lox] [0m      print n;
-[33m[tester::#EY3] [test-4.lox] [0m    }
-[33m[tester::#EY3] [test-4.lox] [0m    n = n + 1;
-[33m[tester::#EY3] [test-4.lox] [0m  }
-[33m[tester::#EY3] [test-4.lox] [0m}
-[33m[tester::#EY3] [test-4.lox] [0m
-[33m[tester::#EY3] [test-4.lox] [0mvar greaterThanX = makeFilter();
-[33m[tester::#EY3] [test-4.lox] [0m
-[33m[tester::#EY3] [test-4.lox] [0mprint "Numbers >= 54:";
-[33m[tester::#EY3] [test-4.lox] [0mapplyToNumbers(greaterThanX, 54 + 6);
+[33m[tester::#EY3] [test-4.lox] [0m[0m[33m// This program creates a function that returns[0m[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m[33m// another function[0m[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m[33m// and uses it to filter a list of numbers[0m[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0mfun makeFilter() {[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m  fun filter(n) {[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m    if (n < 54) {[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m      return false;[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m    }[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m    return true;[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m  return filter;[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m}[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m[33m// This function applies a function to a list of[0m[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m[33m// numbers[0m[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0mfun applyToNumbers(f, count) {[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m  var n = 0;[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m  while (n < count) {[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m    if (f(n)) {[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m      print n;[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m    }[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m    n = n + 1;[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m}[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0mvar greaterThanX = makeFilter();[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0m[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0mprint "Numbers >= 54:";[0m
+[33m[tester::#EY3] [test-4.lox] [0m[0mapplyToNumbers(greaterThanX, 54 + 6);[0m
 [33m[tester::#EY3] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mNumbers >= 54:
-[33m[your_program] [0m54
-[33m[your_program] [0m55
-[33m[your_program] [0m56
-[33m[your_program] [0m57
-[33m[your_program] [0m58
-[33m[your_program] [0m59
+[33m[your_program] [0m[0mNumbers >= 54:[0m
+[33m[your_program] [0m[0m54[0m
+[33m[your_program] [0m[0m55[0m
+[33m[your_program] [0m[0m56[0m
+[33m[your_program] [0m[0m57[0m
+[33m[your_program] [0m[0m58[0m
+[33m[your_program] [0m[0m59[0m
 [33m[tester::#EY3] [test-4] [0m[92m✓ 7 line(s) match on stdout[0m
 [33m[tester::#EY3] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#EY3] [0m[92mTest passed.[0m
@@ -413,51 +413,51 @@ Debug = true
 [33m[tester::#FJ7] [0m[94mRunning tests for Stage #FJ7 (fj7)[0m
 [33m[tester::#FJ7] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#FJ7] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#FJ7] [test-1.lox] [0m[33m// This program tries to execute an integer as a[0m
-[33m[tester::#FJ7] [test-1.lox] [0m[33m// function[0m
-[33m[tester::#FJ7] [test-1.lox] [0m25();
+[33m[tester::#FJ7] [test-1.lox] [0m[0m[33m// This program tries to execute an integer as a[0m[0m
+[33m[tester::#FJ7] [test-1.lox] [0m[0m[33m// function[0m[0m
+[33m[tester::#FJ7] [test-1.lox] [0m[0m25();[0m
 [33m[tester::#FJ7] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mCan only call functions and classes.
-[33m[your_program] [0m[line 3]
+[33m[your_program] [0m[0mCan only call functions and classes.[0m
+[33m[your_program] [0m[0m[line 3][0m
 [33m[tester::#FJ7] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#FJ7] [test-1] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#FJ7] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#FJ7] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#FJ7] [test-2.lox] [0m[33m// This program tries to call a function with too[0m
-[33m[tester::#FJ7] [test-2.lox] [0m[33m// many arguments[0m
-[33m[tester::#FJ7] [test-2.lox] [0mfun f(a, b) {
-[33m[tester::#FJ7] [test-2.lox] [0m  print a;
-[33m[tester::#FJ7] [test-2.lox] [0m  print b;
-[33m[tester::#FJ7] [test-2.lox] [0m}
-[33m[tester::#FJ7] [test-2.lox] [0m
-[33m[tester::#FJ7] [test-2.lox] [0mf(1, 2, 3, 4);
-[33m[tester::#FJ7] [test-2.lox] [0m[33m// expect runtime error: Expected 2 arguments[0m
+[33m[tester::#FJ7] [test-2.lox] [0m[0m[33m// This program tries to call a function with too[0m[0m
+[33m[tester::#FJ7] [test-2.lox] [0m[0m[33m// many arguments[0m[0m
+[33m[tester::#FJ7] [test-2.lox] [0m[0mfun f(a, b) {[0m
+[33m[tester::#FJ7] [test-2.lox] [0m[0m  print a;[0m
+[33m[tester::#FJ7] [test-2.lox] [0m[0m  print b;[0m
+[33m[tester::#FJ7] [test-2.lox] [0m[0m}[0m
+[33m[tester::#FJ7] [test-2.lox] [0m[0m[0m
+[33m[tester::#FJ7] [test-2.lox] [0m[0mf(1, 2, 3, 4);[0m
+[33m[tester::#FJ7] [test-2.lox] [0m[0m[33m// expect runtime error: Expected 2 arguments[0m[0m
 [33m[tester::#FJ7] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mExpected 2 arguments but got 4.
-[33m[your_program] [0m[line 8]
+[33m[your_program] [0m[0mExpected 2 arguments but got 4.[0m
+[33m[your_program] [0m[0m[line 8][0m
 [33m[tester::#FJ7] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#FJ7] [test-2] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#FJ7] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#FJ7] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#FJ7] [test-3.lox] [0m[33m// This program tries to call a function with too[0m
-[33m[tester::#FJ7] [test-3.lox] [0m[33m// few arguments[0m
-[33m[tester::#FJ7] [test-3.lox] [0mfun f(a, b) {}
-[33m[tester::#FJ7] [test-3.lox] [0m
-[33m[tester::#FJ7] [test-3.lox] [0m[33m// expect runtime error: Expected 2 arguments[0m
-[33m[tester::#FJ7] [test-3.lox] [0mf(1);
+[33m[tester::#FJ7] [test-3.lox] [0m[0m[33m// This program tries to call a function with too[0m[0m
+[33m[tester::#FJ7] [test-3.lox] [0m[0m[33m// few arguments[0m[0m
+[33m[tester::#FJ7] [test-3.lox] [0m[0mfun f(a, b) {}[0m
+[33m[tester::#FJ7] [test-3.lox] [0m[0m[0m
+[33m[tester::#FJ7] [test-3.lox] [0m[0m[33m// expect runtime error: Expected 2 arguments[0m[0m
+[33m[tester::#FJ7] [test-3.lox] [0m[0mf(1);[0m
 [33m[tester::#FJ7] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mExpected 2 arguments but got 1.
-[33m[your_program] [0m[line 6]
+[33m[your_program] [0m[0mExpected 2 arguments but got 1.[0m
+[33m[your_program] [0m[0m[line 6][0m
 [33m[tester::#FJ7] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#FJ7] [test-3] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#FJ7] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#FJ7] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#FJ7] [test-4.lox] [0m[33m// This program tries to execute a boolean as a[0m
-[33m[tester::#FJ7] [test-4.lox] [0m[33m// function[0m
-[33m[tester::#FJ7] [test-4.lox] [0m(false == false)();
+[33m[tester::#FJ7] [test-4.lox] [0m[0m[33m// This program tries to execute a boolean as a[0m[0m
+[33m[tester::#FJ7] [test-4.lox] [0m[0m[33m// function[0m[0m
+[33m[tester::#FJ7] [test-4.lox] [0m[0m(false == false)();[0m
 [33m[tester::#FJ7] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mCan only call functions and classes.
-[33m[your_program] [0m[line 3]
+[33m[your_program] [0m[0mCan only call functions and classes.[0m
+[33m[your_program] [0m[0m[line 3][0m
 [33m[tester::#FJ7] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#FJ7] [test-4] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#FJ7] [0m[92mTest passed.[0m
@@ -465,153 +465,153 @@ Debug = true
 [33m[tester::#BZ4] [0m[94mRunning tests for Stage #BZ4 (bz4)[0m
 [33m[tester::#BZ4] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#BZ4] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#BZ4] [test-1.lox] [0m[33m// This program demonstrates global and local[0m
-[33m[tester::#BZ4] [test-1.lox] [0m[33m// variable shadowing in Lox.[0m
-[33m[tester::#BZ4] [test-1.lox] [0mvar a = 81;
-[33m[tester::#BZ4] [test-1.lox] [0m
-[33m[tester::#BZ4] [test-1.lox] [0mfun printAndModify() {
-[33m[tester::#BZ4] [test-1.lox] [0m  print a;
-[33m[tester::#BZ4] [test-1.lox] [0m  var a = 89;
-[33m[tester::#BZ4] [test-1.lox] [0m  print a;
-[33m[tester::#BZ4] [test-1.lox] [0m}
-[33m[tester::#BZ4] [test-1.lox] [0m
-[33m[tester::#BZ4] [test-1.lox] [0mprint a;
-[33m[tester::#BZ4] [test-1.lox] [0ma = 59;
-[33m[tester::#BZ4] [test-1.lox] [0mprintAndModify();
+[33m[tester::#BZ4] [test-1.lox] [0m[0m[33m// This program demonstrates global and local[0m[0m
+[33m[tester::#BZ4] [test-1.lox] [0m[0m[33m// variable shadowing in Lox.[0m[0m
+[33m[tester::#BZ4] [test-1.lox] [0m[0mvar a = 81;[0m
+[33m[tester::#BZ4] [test-1.lox] [0m[0m[0m
+[33m[tester::#BZ4] [test-1.lox] [0m[0mfun printAndModify() {[0m
+[33m[tester::#BZ4] [test-1.lox] [0m[0m  print a;[0m
+[33m[tester::#BZ4] [test-1.lox] [0m[0m  var a = 89;[0m
+[33m[tester::#BZ4] [test-1.lox] [0m[0m  print a;[0m
+[33m[tester::#BZ4] [test-1.lox] [0m[0m}[0m
+[33m[tester::#BZ4] [test-1.lox] [0m[0m[0m
+[33m[tester::#BZ4] [test-1.lox] [0m[0mprint a;[0m
+[33m[tester::#BZ4] [test-1.lox] [0m[0ma = 59;[0m
+[33m[tester::#BZ4] [test-1.lox] [0m[0mprintAndModify();[0m
 [33m[tester::#BZ4] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m81
-[33m[your_program] [0m59
-[33m[your_program] [0m89
+[33m[your_program] [0m[0m81[0m
+[33m[your_program] [0m[0m59[0m
+[33m[your_program] [0m[0m89[0m
 [33m[tester::#BZ4] [test-1] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#BZ4] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#BZ4] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#BZ4] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#BZ4] [test-2.lox] [0m[33m// This program uses a while loop to count down[0m
-[33m[tester::#BZ4] [test-2.lox] [0m[33m// from 3 to 1, printing each[0m
-[33m[tester::#BZ4] [test-2.lox] [0m[33m// number[0m
-[33m[tester::#BZ4] [test-2.lox] [0m[33m// and then decrementing the count until it[0m
-[33m[tester::#BZ4] [test-2.lox] [0m[33m// reaches 0, at which point it prints[0m
-[33m[tester::#BZ4] [test-2.lox] [0m[33m// "Blast off!"[0m
-[33m[tester::#BZ4] [test-2.lox] [0mvar count = 3;
-[33m[tester::#BZ4] [test-2.lox] [0m
-[33m[tester::#BZ4] [test-2.lox] [0mfun tick() {
-[33m[tester::#BZ4] [test-2.lox] [0m  if (count > 0) {
-[33m[tester::#BZ4] [test-2.lox] [0m    print count;
-[33m[tester::#BZ4] [test-2.lox] [0m    count = count - 1;
-[33m[tester::#BZ4] [test-2.lox] [0m    return false;
-[33m[tester::#BZ4] [test-2.lox] [0m  }
-[33m[tester::#BZ4] [test-2.lox] [0m  print "Blast off!";
-[33m[tester::#BZ4] [test-2.lox] [0m  return true;
-[33m[tester::#BZ4] [test-2.lox] [0m}
-[33m[tester::#BZ4] [test-2.lox] [0m
-[33m[tester::#BZ4] [test-2.lox] [0mwhile (!tick()) {}
+[33m[tester::#BZ4] [test-2.lox] [0m[0m[33m// This program uses a while loop to count down[0m[0m
+[33m[tester::#BZ4] [test-2.lox] [0m[0m[33m// from 3 to 1, printing each[0m[0m
+[33m[tester::#BZ4] [test-2.lox] [0m[0m[33m// number[0m[0m
+[33m[tester::#BZ4] [test-2.lox] [0m[0m[33m// and then decrementing the count until it[0m[0m
+[33m[tester::#BZ4] [test-2.lox] [0m[0m[33m// reaches 0, at which point it prints[0m[0m
+[33m[tester::#BZ4] [test-2.lox] [0m[0m[33m// "Blast off!"[0m[0m
+[33m[tester::#BZ4] [test-2.lox] [0m[0mvar count = 3;[0m
+[33m[tester::#BZ4] [test-2.lox] [0m[0m[0m
+[33m[tester::#BZ4] [test-2.lox] [0m[0mfun tick() {[0m
+[33m[tester::#BZ4] [test-2.lox] [0m[0m  if (count > 0) {[0m
+[33m[tester::#BZ4] [test-2.lox] [0m[0m    print count;[0m
+[33m[tester::#BZ4] [test-2.lox] [0m[0m    count = count - 1;[0m
+[33m[tester::#BZ4] [test-2.lox] [0m[0m    return false;[0m
+[33m[tester::#BZ4] [test-2.lox] [0m[0m  }[0m
+[33m[tester::#BZ4] [test-2.lox] [0m[0m  print "Blast off!";[0m
+[33m[tester::#BZ4] [test-2.lox] [0m[0m  return true;[0m
+[33m[tester::#BZ4] [test-2.lox] [0m[0m}[0m
+[33m[tester::#BZ4] [test-2.lox] [0m[0m[0m
+[33m[tester::#BZ4] [test-2.lox] [0m[0mwhile (!tick()) {}[0m
 [33m[tester::#BZ4] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m3
-[33m[your_program] [0m2
-[33m[your_program] [0m1
-[33m[your_program] [0mBlast off!
+[33m[your_program] [0m[0m3[0m
+[33m[your_program] [0m[0m2[0m
+[33m[your_program] [0m[0m1[0m
+[33m[your_program] [0m[0mBlast off![0m
 [33m[tester::#BZ4] [test-2] [0m[92m✓ 4 line(s) match on stdout[0m
 [33m[tester::#BZ4] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#BZ4] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#BZ4] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#BZ4] [test-3.lox] [0m[33m// This program demonstrates variable shadowing in[0m
-[33m[tester::#BZ4] [test-3.lox] [0m[33m// Lox with functions.[0m
-[33m[tester::#BZ4] [test-3.lox] [0m[33m// The first counter is a global variable that is[0m
-[33m[tester::#BZ4] [test-3.lox] [0m[33m// modified by the inner block.[0m
-[33m[tester::#BZ4] [test-3.lox] [0m[33m// The second counter is a local variable that[0m
-[33m[tester::#BZ4] [test-3.lox] [0m[33m// shadows the global variable.[0m
-[33m[tester::#BZ4] [test-3.lox] [0mvar counter = 93;
-[33m[tester::#BZ4] [test-3.lox] [0m
-[33m[tester::#BZ4] [test-3.lox] [0mfun incrementCounter(amount) {
-[33m[tester::#BZ4] [test-3.lox] [0m  counter = counter + amount;
-[33m[tester::#BZ4] [test-3.lox] [0m  print counter;
-[33m[tester::#BZ4] [test-3.lox] [0m}
-[33m[tester::#BZ4] [test-3.lox] [0m
-[33m[tester::#BZ4] [test-3.lox] [0m{
-[33m[tester::#BZ4] [test-3.lox] [0m  counter = 97;
-[33m[tester::#BZ4] [test-3.lox] [0m  incrementCounter(5);
-[33m[tester::#BZ4] [test-3.lox] [0m  print counter;
-[33m[tester::#BZ4] [test-3.lox] [0m}
-[33m[tester::#BZ4] [test-3.lox] [0mprint counter;
+[33m[tester::#BZ4] [test-3.lox] [0m[0m[33m// This program demonstrates variable shadowing in[0m[0m
+[33m[tester::#BZ4] [test-3.lox] [0m[0m[33m// Lox with functions.[0m[0m
+[33m[tester::#BZ4] [test-3.lox] [0m[0m[33m// The first counter is a global variable that is[0m[0m
+[33m[tester::#BZ4] [test-3.lox] [0m[0m[33m// modified by the inner block.[0m[0m
+[33m[tester::#BZ4] [test-3.lox] [0m[0m[33m// The second counter is a local variable that[0m[0m
+[33m[tester::#BZ4] [test-3.lox] [0m[0m[33m// shadows the global variable.[0m[0m
+[33m[tester::#BZ4] [test-3.lox] [0m[0mvar counter = 93;[0m
+[33m[tester::#BZ4] [test-3.lox] [0m[0m[0m
+[33m[tester::#BZ4] [test-3.lox] [0m[0mfun incrementCounter(amount) {[0m
+[33m[tester::#BZ4] [test-3.lox] [0m[0m  counter = counter + amount;[0m
+[33m[tester::#BZ4] [test-3.lox] [0m[0m  print counter;[0m
+[33m[tester::#BZ4] [test-3.lox] [0m[0m}[0m
+[33m[tester::#BZ4] [test-3.lox] [0m[0m[0m
+[33m[tester::#BZ4] [test-3.lox] [0m[0m{[0m
+[33m[tester::#BZ4] [test-3.lox] [0m[0m  counter = 97;[0m
+[33m[tester::#BZ4] [test-3.lox] [0m[0m  incrementCounter(5);[0m
+[33m[tester::#BZ4] [test-3.lox] [0m[0m  print counter;[0m
+[33m[tester::#BZ4] [test-3.lox] [0m[0m}[0m
+[33m[tester::#BZ4] [test-3.lox] [0m[0mprint counter;[0m
 [33m[tester::#BZ4] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m102
-[33m[your_program] [0m102
-[33m[your_program] [0m102
+[33m[your_program] [0m[0m102[0m
+[33m[your_program] [0m[0m102[0m
+[33m[your_program] [0m[0m102[0m
 [33m[tester::#BZ4] [test-3] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#BZ4] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#BZ4] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#BZ4] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#BZ4] [test-4.lox] [0m[33m// This program tests variable scoping and[0m
-[33m[tester::#BZ4] [test-4.lox] [0m[33m// shadowing in Lox. It demonstrates:[0m
-[33m[tester::#BZ4] [test-4.lox] [0m[33m// Global variable declarations[0m
-[33m[tester::#BZ4] [test-4.lox] [0m[33m// Function scope access to global variables[0m
-[33m[tester::#BZ4] [test-4.lox] [0m[33m// Block scoping with local variables shadowing[0m
-[33m[tester::#BZ4] [test-4.lox] [0m[33m// outer variables[0m
-[33m[tester::#BZ4] [test-4.lox] [0m[33m// Verification that global variables remain[0m
-[33m[tester::#BZ4] [test-4.lox] [0m[33m// unchanged after shadowing[0m
-[33m[tester::#BZ4] [test-4.lox] [0mvar x = 1;
-[33m[tester::#BZ4] [test-4.lox] [0mvar y = 2;
-[33m[tester::#BZ4] [test-4.lox] [0m
-[33m[tester::#BZ4] [test-4.lox] [0mfun printBoth() {
-[33m[tester::#BZ4] [test-4.lox] [0m  if (x < y) {
-[33m[tester::#BZ4] [test-4.lox] [0m    print "x is less than y:";
-[33m[tester::#BZ4] [test-4.lox] [0m    print x;
-[33m[tester::#BZ4] [test-4.lox] [0m    print y;
-[33m[tester::#BZ4] [test-4.lox] [0m  } else {
-[33m[tester::#BZ4] [test-4.lox] [0m    print "x is not less than y:";
-[33m[tester::#BZ4] [test-4.lox] [0m    print x;
-[33m[tester::#BZ4] [test-4.lox] [0m    print y;
-[33m[tester::#BZ4] [test-4.lox] [0m  }
-[33m[tester::#BZ4] [test-4.lox] [0m}
-[33m[tester::#BZ4] [test-4.lox] [0m
-[33m[tester::#BZ4] [test-4.lox] [0m{
-[33m[tester::#BZ4] [test-4.lox] [0m  var x = 10;
-[33m[tester::#BZ4] [test-4.lox] [0m  {
-[33m[tester::#BZ4] [test-4.lox] [0m    var y = 20;
-[33m[tester::#BZ4] [test-4.lox] [0m
-[33m[tester::#BZ4] [test-4.lox] [0m    var i = 0;
-[33m[tester::#BZ4] [test-4.lox] [0m    while (i < 3) {
-[33m[tester::#BZ4] [test-4.lox] [0m      x = x + 1;
-[33m[tester::#BZ4] [test-4.lox] [0m      y = y - 1;
-[33m[tester::#BZ4] [test-4.lox] [0m      print "Local x: ";
-[33m[tester::#BZ4] [test-4.lox] [0m      print x;
-[33m[tester::#BZ4] [test-4.lox] [0m      print "Local y: ";
-[33m[tester::#BZ4] [test-4.lox] [0m      print y;
-[33m[tester::#BZ4] [test-4.lox] [0m      i = i + 1;
-[33m[tester::#BZ4] [test-4.lox] [0m    }
-[33m[tester::#BZ4] [test-4.lox] [0m
-[33m[tester::#BZ4] [test-4.lox] [0m    if (x > y) {
-[33m[tester::#BZ4] [test-4.lox] [0m      print "Local x > y";
-[33m[tester::#BZ4] [test-4.lox] [0m    }
-[33m[tester::#BZ4] [test-4.lox] [0m
-[33m[tester::#BZ4] [test-4.lox] [0m    printBoth();
-[33m[tester::#BZ4] [test-4.lox] [0m  }
-[33m[tester::#BZ4] [test-4.lox] [0m}
-[33m[tester::#BZ4] [test-4.lox] [0m
-[33m[tester::#BZ4] [test-4.lox] [0mif (x == 1 and y == 2) {
-[33m[tester::#BZ4] [test-4.lox] [0m  print "Globals unchanged:";
-[33m[tester::#BZ4] [test-4.lox] [0m  printBoth();
-[33m[tester::#BZ4] [test-4.lox] [0m}
+[33m[tester::#BZ4] [test-4.lox] [0m[0m[33m// This program tests variable scoping and[0m[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m[33m// shadowing in Lox. It demonstrates:[0m[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m[33m// Global variable declarations[0m[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m[33m// Function scope access to global variables[0m[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m[33m// Block scoping with local variables shadowing[0m[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m[33m// outer variables[0m[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m[33m// Verification that global variables remain[0m[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m[33m// unchanged after shadowing[0m[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0mvar x = 1;[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0mvar y = 2;[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0mfun printBoth() {[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m  if (x < y) {[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m    print "x is less than y:";[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m    print x;[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m    print y;[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m  } else {[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m    print "x is not less than y:";[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m    print x;[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m    print y;[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m}[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m{[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m  var x = 10;[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m  {[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m    var y = 20;[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m    var i = 0;[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m    while (i < 3) {[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m      x = x + 1;[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m      y = y - 1;[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m      print "Local x: ";[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m      print x;[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m      print "Local y: ";[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m      print y;[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m      i = i + 1;[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m    }[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m    if (x > y) {[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m      print "Local x > y";[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m    }[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m    printBoth();[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m}[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0mif (x == 1 and y == 2) {[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m  print "Globals unchanged:";[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m  printBoth();[0m
+[33m[tester::#BZ4] [test-4.lox] [0m[0m}[0m
 [33m[tester::#BZ4] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mLocal x: 
-[33m[your_program] [0m11
-[33m[your_program] [0mLocal y: 
-[33m[your_program] [0m19
-[33m[your_program] [0mLocal x: 
-[33m[your_program] [0m12
-[33m[your_program] [0mLocal y: 
-[33m[your_program] [0m18
-[33m[your_program] [0mLocal x: 
-[33m[your_program] [0m13
-[33m[your_program] [0mLocal y: 
-[33m[your_program] [0m17
-[33m[your_program] [0mx is less than y:
-[33m[your_program] [0m1
-[33m[your_program] [0m2
-[33m[your_program] [0mGlobals unchanged:
-[33m[your_program] [0mx is less than y:
-[33m[your_program] [0m1
-[33m[your_program] [0m2
+[33m[your_program] [0m[0mLocal x: [0m
+[33m[your_program] [0m[0m11[0m
+[33m[your_program] [0m[0mLocal y: [0m
+[33m[your_program] [0m[0m19[0m
+[33m[your_program] [0m[0mLocal x: [0m
+[33m[your_program] [0m[0m12[0m
+[33m[your_program] [0m[0mLocal y: [0m
+[33m[your_program] [0m[0m18[0m
+[33m[your_program] [0m[0mLocal x: [0m
+[33m[your_program] [0m[0m13[0m
+[33m[your_program] [0m[0mLocal y: [0m
+[33m[your_program] [0m[0m17[0m
+[33m[your_program] [0m[0mx is less than y:[0m
+[33m[your_program] [0m[0m1[0m
+[33m[your_program] [0m[0m2[0m
+[33m[your_program] [0m[0mGlobals unchanged:[0m
+[33m[your_program] [0m[0mx is less than y:[0m
+[33m[your_program] [0m[0m1[0m
+[33m[your_program] [0m[0m2[0m
 [33m[tester::#BZ4] [test-4] [0m[92m✓ 19 line(s) match on stdout[0m
 [33m[tester::#BZ4] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#BZ4] [0m[92mTest passed.[0m
@@ -619,171 +619,171 @@ Debug = true
 [33m[tester::#GG6] [0m[94mRunning tests for Stage #GG6 (gg6)[0m
 [33m[tester::#GG6] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#GG6] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#GG6] [test-1.lox] [0m[33m// This program demonstrates the use of closures[0m
-[33m[tester::#GG6] [test-1.lox] [0m[33m// to create a counter function.[0m
-[33m[tester::#GG6] [test-1.lox] [0m[33m// The inner function count() needs access to the[0m
-[33m[tester::#GG6] [test-1.lox] [0m[33m// outer function's local variable i.[0m
-[33m[tester::#GG6] [test-1.lox] [0m[33m// This can be achieved using closures.[0m
-[33m[tester::#GG6] [test-1.lox] [0mfun makeCounter() {
-[33m[tester::#GG6] [test-1.lox] [0m  var i = 0;
-[33m[tester::#GG6] [test-1.lox] [0m  fun count() {
-[33m[tester::#GG6] [test-1.lox] [0m    i = i + 4;
-[33m[tester::#GG6] [test-1.lox] [0m    print i;
-[33m[tester::#GG6] [test-1.lox] [0m  }
-[33m[tester::#GG6] [test-1.lox] [0m
-[33m[tester::#GG6] [test-1.lox] [0m  return count;
-[33m[tester::#GG6] [test-1.lox] [0m}
-[33m[tester::#GG6] [test-1.lox] [0m
-[33m[tester::#GG6] [test-1.lox] [0mvar counter = makeCounter();
-[33m[tester::#GG6] [test-1.lox] [0mcounter();
-[33m[tester::#GG6] [test-1.lox] [0mcounter();
+[33m[tester::#GG6] [test-1.lox] [0m[0m[33m// This program demonstrates the use of closures[0m[0m
+[33m[tester::#GG6] [test-1.lox] [0m[0m[33m// to create a counter function.[0m[0m
+[33m[tester::#GG6] [test-1.lox] [0m[0m[33m// The inner function count() needs access to the[0m[0m
+[33m[tester::#GG6] [test-1.lox] [0m[0m[33m// outer function's local variable i.[0m[0m
+[33m[tester::#GG6] [test-1.lox] [0m[0m[33m// This can be achieved using closures.[0m[0m
+[33m[tester::#GG6] [test-1.lox] [0m[0mfun makeCounter() {[0m
+[33m[tester::#GG6] [test-1.lox] [0m[0m  var i = 0;[0m
+[33m[tester::#GG6] [test-1.lox] [0m[0m  fun count() {[0m
+[33m[tester::#GG6] [test-1.lox] [0m[0m    i = i + 4;[0m
+[33m[tester::#GG6] [test-1.lox] [0m[0m    print i;[0m
+[33m[tester::#GG6] [test-1.lox] [0m[0m  }[0m
+[33m[tester::#GG6] [test-1.lox] [0m[0m[0m
+[33m[tester::#GG6] [test-1.lox] [0m[0m  return count;[0m
+[33m[tester::#GG6] [test-1.lox] [0m[0m}[0m
+[33m[tester::#GG6] [test-1.lox] [0m[0m[0m
+[33m[tester::#GG6] [test-1.lox] [0m[0mvar counter = makeCounter();[0m
+[33m[tester::#GG6] [test-1.lox] [0m[0mcounter();[0m
+[33m[tester::#GG6] [test-1.lox] [0m[0mcounter();[0m
 [33m[tester::#GG6] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m4
-[33m[your_program] [0m8
+[33m[your_program] [0m[0m4[0m
+[33m[your_program] [0m[0m8[0m
 [33m[tester::#GG6] [test-1] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#GG6] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#GG6] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#GG6] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#GG6] [test-2.lox] [0m[33m// This program uses mutual recursion to determine[0m
-[33m[tester::#GG6] [test-2.lox] [0m[33m// if a number is even or odd.[0m
-[33m[tester::#GG6] [test-2.lox] [0m[33m// It also uses a shared threshold variable that[0m
-[33m[tester::#GG6] [test-2.lox] [0m[33m// is used to determine if a number is too large[0m
-[33m[tester::#GG6] [test-2.lox] [0m[33m//to be processed.[0m
-[33m[tester::#GG6] [test-2.lox] [0m{
-[33m[tester::#GG6] [test-2.lox] [0m  var threshold = 50;
-[33m[tester::#GG6] [test-2.lox] [0m
-[33m[tester::#GG6] [test-2.lox] [0m  fun isEven(n) {
-[33m[tester::#GG6] [test-2.lox] [0m    if (n == 0) return true;
-[33m[tester::#GG6] [test-2.lox] [0m    if (n > threshold) return false;
-[33m[tester::#GG6] [test-2.lox] [0m    return isOdd(n - 1);
-[33m[tester::#GG6] [test-2.lox] [0m  }
-[33m[tester::#GG6] [test-2.lox] [0m
-[33m[tester::#GG6] [test-2.lox] [0m  fun isOdd(n) {
-[33m[tester::#GG6] [test-2.lox] [0m    if (n == 0) return false;
-[33m[tester::#GG6] [test-2.lox] [0m    if (n > threshold) return false;
-[33m[tester::#GG6] [test-2.lox] [0m    return isEven(n - 1);
-[33m[tester::#GG6] [test-2.lox] [0m  }
-[33m[tester::#GG6] [test-2.lox] [0m
-[33m[tester::#GG6] [test-2.lox] [0m  print isEven(75);
-[33m[tester::#GG6] [test-2.lox] [0m}
+[33m[tester::#GG6] [test-2.lox] [0m[0m[33m// This program uses mutual recursion to determine[0m[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m[33m// if a number is even or odd.[0m[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m[33m// It also uses a shared threshold variable that[0m[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m[33m// is used to determine if a number is too large[0m[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m[33m//to be processed.[0m[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m{[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m  var threshold = 50;[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m  fun isEven(n) {[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m    if (n == 0) return true;[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m    if (n > threshold) return false;[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m    return isOdd(n - 1);[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m  }[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m  fun isOdd(n) {[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m    if (n == 0) return false;[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m    if (n > threshold) return false;[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m    return isEven(n - 1);[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m  }[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m  print isEven(75);[0m
+[33m[tester::#GG6] [test-2.lox] [0m[0m}[0m
 [33m[tester::#GG6] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mfalse
+[33m[your_program] [0m[0mfalse[0m
 [33m[tester::#GG6] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#GG6] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#GG6] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#GG6] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#GG6] [test-3.lox] [0m[33m// This program demonstrates the use of closures[0m
-[33m[tester::#GG6] [test-3.lox] [0m[33m// to create a logger function.[0m
-[33m[tester::#GG6] [test-3.lox] [0m[33m// The inner function log() has access to the[0m
-[33m[tester::#GG6] [test-3.lox] [0m[33m// outer function's local variable logCount.[0m
-[33m[tester::#GG6] [test-3.lox] [0m[33m// This is an example of how closures can be used[0m
-[33m[tester::#GG6] [test-3.lox] [0m[33m// to create private variables and methods.[0m
-[33m[tester::#GG6] [test-3.lox] [0mfun makeLogger(prefix) {
-[33m[tester::#GG6] [test-3.lox] [0m  var logCount = 0;
-[33m[tester::#GG6] [test-3.lox] [0m
-[33m[tester::#GG6] [test-3.lox] [0m  fun log(message) {
-[33m[tester::#GG6] [test-3.lox] [0m    logCount = logCount + 1;
-[33m[tester::#GG6] [test-3.lox] [0m    print prefix + ": " + message;
-[33m[tester::#GG6] [test-3.lox] [0m
-[33m[tester::#GG6] [test-3.lox] [0m    if (logCount > 3) {
-[33m[tester::#GG6] [test-3.lox] [0m      print prefix + ": Too many log lines!";
-[33m[tester::#GG6] [test-3.lox] [0m      logCount = 0;
-[33m[tester::#GG6] [test-3.lox] [0m    }
-[33m[tester::#GG6] [test-3.lox] [0m  }
-[33m[tester::#GG6] [test-3.lox] [0m
-[33m[tester::#GG6] [test-3.lox] [0m  return log;
-[33m[tester::#GG6] [test-3.lox] [0m}
-[33m[tester::#GG6] [test-3.lox] [0m
-[33m[tester::#GG6] [test-3.lox] [0mvar debugLog = makeLogger("baz");
-[33m[tester::#GG6] [test-3.lox] [0mvar errorLog = makeLogger("hello");
-[33m[tester::#GG6] [test-3.lox] [0m
-[33m[tester::#GG6] [test-3.lox] [0mdebugLog("Starting");
-[33m[tester::#GG6] [test-3.lox] [0mdebugLog("Processing");
-[33m[tester::#GG6] [test-3.lox] [0mdebugLog("Finishing");
-[33m[tester::#GG6] [test-3.lox] [0mdebugLog("Extra line");
-[33m[tester::#GG6] [test-3.lox] [0m
-[33m[tester::#GG6] [test-3.lox] [0merrorLog("Failed!");
-[33m[tester::#GG6] [test-3.lox] [0merrorLog("Retrying...");
+[33m[tester::#GG6] [test-3.lox] [0m[0m[33m// This program demonstrates the use of closures[0m[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m[33m// to create a logger function.[0m[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m[33m// The inner function log() has access to the[0m[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m[33m// outer function's local variable logCount.[0m[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m[33m// This is an example of how closures can be used[0m[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m[33m// to create private variables and methods.[0m[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0mfun makeLogger(prefix) {[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m  var logCount = 0;[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m  fun log(message) {[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m    logCount = logCount + 1;[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m    print prefix + ": " + message;[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m    if (logCount > 3) {[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m      print prefix + ": Too many log lines!";[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m      logCount = 0;[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m    }[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m  }[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m  return log;[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m}[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0mvar debugLog = makeLogger("baz");[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0mvar errorLog = makeLogger("hello");[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0mdebugLog("Starting");[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0mdebugLog("Processing");[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0mdebugLog("Finishing");[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0mdebugLog("Extra line");[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0m[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0merrorLog("Failed!");[0m
+[33m[tester::#GG6] [test-3.lox] [0m[0merrorLog("Retrying...");[0m
 [33m[tester::#GG6] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mbaz: Starting
-[33m[your_program] [0mbaz: Processing
-[33m[your_program] [0mbaz: Finishing
-[33m[your_program] [0mbaz: Extra line
-[33m[your_program] [0mbaz: Too many log lines!
-[33m[your_program] [0mhello: Failed!
-[33m[your_program] [0mhello: Retrying...
+[33m[your_program] [0m[0mbaz: Starting[0m
+[33m[your_program] [0m[0mbaz: Processing[0m
+[33m[your_program] [0m[0mbaz: Finishing[0m
+[33m[your_program] [0m[0mbaz: Extra line[0m
+[33m[your_program] [0m[0mbaz: Too many log lines![0m
+[33m[your_program] [0m[0mhello: Failed![0m
+[33m[your_program] [0m[0mhello: Retrying...[0m
 [33m[tester::#GG6] [test-3] [0m[92m✓ 7 line(s) match on stdout[0m
 [33m[tester::#GG6] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#GG6] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#GG6] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#GG6] [test-4.lox] [0m[33m// This program demonstrates the use of closures[0m
-[33m[tester::#GG6] [test-4.lox] [0m[33m// to create an accumulator function.[0m
-[33m[tester::#GG6] [test-4.lox] [0m[33m// The inner function accumulate() has access to[0m
-[33m[tester::#GG6] [test-4.lox] [0m[33m// the outer function's local variables sum and[0m
-[33m[tester::#GG6] [test-4.lox] [0m[33m// count.[0m
-[33m[tester::#GG6] [test-4.lox] [0m[33m// This is an example of how closures can be used[0m
-[33m[tester::#GG6] [test-4.lox] [0m[33m// to create private variables and methods.[0m
-[33m[tester::#GG6] [test-4.lox] [0mfun makeAccumulator(label) {
-[33m[tester::#GG6] [test-4.lox] [0m  var sum = 0;
-[33m[tester::#GG6] [test-4.lox] [0m  var count = 0;
-[33m[tester::#GG6] [test-4.lox] [0m
-[33m[tester::#GG6] [test-4.lox] [0m  fun accumulate(value) {
-[33m[tester::#GG6] [test-4.lox] [0m    sum = sum + value;
-[33m[tester::#GG6] [test-4.lox] [0m    count = count + 1;
-[33m[tester::#GG6] [test-4.lox] [0m
-[33m[tester::#GG6] [test-4.lox] [0m    print label;
-[33m[tester::#GG6] [test-4.lox] [0m    print count;
-[33m[tester::#GG6] [test-4.lox] [0m    print sum;
-[33m[tester::#GG6] [test-4.lox] [0m    print sum;
-[33m[tester::#GG6] [test-4.lox] [0m
-[33m[tester::#GG6] [test-4.lox] [0m    if (count > 3) {
-[33m[tester::#GG6] [test-4.lox] [0m      print "reset";
-[33m[tester::#GG6] [test-4.lox] [0m      sum = 0;
-[33m[tester::#GG6] [test-4.lox] [0m      count = 0;
-[33m[tester::#GG6] [test-4.lox] [0m    }
-[33m[tester::#GG6] [test-4.lox] [0m
-[33m[tester::#GG6] [test-4.lox] [0m    return sum;
-[33m[tester::#GG6] [test-4.lox] [0m  }
-[33m[tester::#GG6] [test-4.lox] [0m
-[33m[tester::#GG6] [test-4.lox] [0m  return accumulate;
-[33m[tester::#GG6] [test-4.lox] [0m}
-[33m[tester::#GG6] [test-4.lox] [0m
-[33m[tester::#GG6] [test-4.lox] [0mvar acc1 = makeAccumulator("First:");
-[33m[tester::#GG6] [test-4.lox] [0mvar acc2 = makeAccumulator("Second:");
-[33m[tester::#GG6] [test-4.lox] [0m
-[33m[tester::#GG6] [test-4.lox] [0macc1(6);
-[33m[tester::#GG6] [test-4.lox] [0macc1(4);
-[33m[tester::#GG6] [test-4.lox] [0macc1(3);
-[33m[tester::#GG6] [test-4.lox] [0macc1(5);
-[33m[tester::#GG6] [test-4.lox] [0m
-[33m[tester::#GG6] [test-4.lox] [0macc2(4);
-[33m[tester::#GG6] [test-4.lox] [0macc2(5);
+[33m[tester::#GG6] [test-4.lox] [0m[0m[33m// This program demonstrates the use of closures[0m[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m[33m// to create an accumulator function.[0m[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m[33m// The inner function accumulate() has access to[0m[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m[33m// the outer function's local variables sum and[0m[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m[33m// count.[0m[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m[33m// This is an example of how closures can be used[0m[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m[33m// to create private variables and methods.[0m[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0mfun makeAccumulator(label) {[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m  var sum = 0;[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m  var count = 0;[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m  fun accumulate(value) {[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m    sum = sum + value;[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m    count = count + 1;[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m    print label;[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m    print count;[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m    print sum;[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m    print sum;[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m    if (count > 3) {[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m      print "reset";[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m      sum = 0;[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m      count = 0;[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m    }[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m    return sum;[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m  return accumulate;[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m}[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0mvar acc1 = makeAccumulator("First:");[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0mvar acc2 = makeAccumulator("Second:");[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0macc1(6);[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0macc1(4);[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0macc1(3);[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0macc1(5);[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0m[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0macc2(4);[0m
+[33m[tester::#GG6] [test-4.lox] [0m[0macc2(5);[0m
 [33m[tester::#GG6] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mFirst:
-[33m[your_program] [0m1
-[33m[your_program] [0m6
-[33m[your_program] [0m6
-[33m[your_program] [0mFirst:
-[33m[your_program] [0m2
-[33m[your_program] [0m10
-[33m[your_program] [0m10
-[33m[your_program] [0mFirst:
-[33m[your_program] [0m3
-[33m[your_program] [0m13
-[33m[your_program] [0m13
-[33m[your_program] [0mFirst:
-[33m[your_program] [0m4
-[33m[your_program] [0m18
-[33m[your_program] [0m18
-[33m[your_program] [0mreset
-[33m[your_program] [0mSecond:
-[33m[your_program] [0m1
-[33m[your_program] [0m4
-[33m[your_program] [0m4
-[33m[your_program] [0mSecond:
-[33m[your_program] [0m2
-[33m[your_program] [0m9
-[33m[your_program] [0m9
+[33m[your_program] [0m[0mFirst:[0m
+[33m[your_program] [0m[0m1[0m
+[33m[your_program] [0m[0m6[0m
+[33m[your_program] [0m[0m6[0m
+[33m[your_program] [0m[0mFirst:[0m
+[33m[your_program] [0m[0m2[0m
+[33m[your_program] [0m[0m10[0m
+[33m[your_program] [0m[0m10[0m
+[33m[your_program] [0m[0mFirst:[0m
+[33m[your_program] [0m[0m3[0m
+[33m[your_program] [0m[0m13[0m
+[33m[your_program] [0m[0m13[0m
+[33m[your_program] [0m[0mFirst:[0m
+[33m[your_program] [0m[0m4[0m
+[33m[your_program] [0m[0m18[0m
+[33m[your_program] [0m[0m18[0m
+[33m[your_program] [0m[0mreset[0m
+[33m[your_program] [0m[0mSecond:[0m
+[33m[your_program] [0m[0m1[0m
+[33m[your_program] [0m[0m4[0m
+[33m[your_program] [0m[0m4[0m
+[33m[your_program] [0m[0mSecond:[0m
+[33m[your_program] [0m[0m2[0m
+[33m[your_program] [0m[0m9[0m
+[33m[your_program] [0m[0m9[0m
 [33m[tester::#GG6] [test-4] [0m[92m✓ 25 line(s) match on stdout[0m
 [33m[tester::#GG6] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#GG6] [0m[92mTest passed.[0m

--- a/internal/test_helpers/fixtures/pass_inheritance
+++ b/internal/test_helpers/fixtures/pass_inheritance
@@ -3,78 +3,78 @@ Debug = true
 [33m[tester::#MF6] [0m[94mRunning tests for Stage #MF6 (mf6)[0m
 [33m[tester::#MF6] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#MF6] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#MF6] [test-1.lox] [0mclass Doughnut {}
-[33m[tester::#MF6] [test-1.lox] [0m
-[33m[tester::#MF6] [test-1.lox] [0m[33m// BostonCream is a subclass of Doughnut[0m
-[33m[tester::#MF6] [test-1.lox] [0mclass BostonCream < Doughnut {}
-[33m[tester::#MF6] [test-1.lox] [0m
-[33m[tester::#MF6] [test-1.lox] [0mprint Doughnut();
-[33m[tester::#MF6] [test-1.lox] [0mprint BostonCream();
+[33m[tester::#MF6] [test-1.lox] [0m[0mclass Doughnut {}[0m
+[33m[tester::#MF6] [test-1.lox] [0m[0m[0m
+[33m[tester::#MF6] [test-1.lox] [0m[0m[33m// BostonCream is a subclass of Doughnut[0m[0m
+[33m[tester::#MF6] [test-1.lox] [0m[0mclass BostonCream < Doughnut {}[0m
+[33m[tester::#MF6] [test-1.lox] [0m[0m[0m
+[33m[tester::#MF6] [test-1.lox] [0m[0mprint Doughnut();[0m
+[33m[tester::#MF6] [test-1.lox] [0m[0mprint BostonCream();[0m
 [33m[tester::#MF6] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mDoughnut instance
-[33m[your_program] [0mBostonCream instance
+[33m[your_program] [0m[0mDoughnut instance[0m
+[33m[your_program] [0m[0mBostonCream instance[0m
 [33m[tester::#MF6] [test-1] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#MF6] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#MF6] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#MF6] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#MF6] [test-2.lox] [0m{
-[33m[tester::#MF6] [test-2.lox] [0m  class A {}
-[33m[tester::#MF6] [test-2.lox] [0m
-[33m[tester::#MF6] [test-2.lox] [0m  [33m// B is a subclass of A[0m
-[33m[tester::#MF6] [test-2.lox] [0m  class B < A {}
-[33m[tester::#MF6] [test-2.lox] [0m
-[33m[tester::#MF6] [test-2.lox] [0m  [33m// C is also a subclass of A[0m
-[33m[tester::#MF6] [test-2.lox] [0m  class C < A {}
-[33m[tester::#MF6] [test-2.lox] [0m
-[33m[tester::#MF6] [test-2.lox] [0m  print A();
-[33m[tester::#MF6] [test-2.lox] [0m  print B();
-[33m[tester::#MF6] [test-2.lox] [0m  print C();
-[33m[tester::#MF6] [test-2.lox] [0m}
+[33m[tester::#MF6] [test-2.lox] [0m[0m{[0m
+[33m[tester::#MF6] [test-2.lox] [0m[0m  class A {}[0m
+[33m[tester::#MF6] [test-2.lox] [0m[0m[0m
+[33m[tester::#MF6] [test-2.lox] [0m[0m  [33m// B is a subclass of A[0m[0m
+[33m[tester::#MF6] [test-2.lox] [0m[0m  class B < A {}[0m
+[33m[tester::#MF6] [test-2.lox] [0m[0m[0m
+[33m[tester::#MF6] [test-2.lox] [0m[0m  [33m// C is also a subclass of A[0m[0m
+[33m[tester::#MF6] [test-2.lox] [0m[0m  class C < A {}[0m
+[33m[tester::#MF6] [test-2.lox] [0m[0m[0m
+[33m[tester::#MF6] [test-2.lox] [0m[0m  print A();[0m
+[33m[tester::#MF6] [test-2.lox] [0m[0m  print B();[0m
+[33m[tester::#MF6] [test-2.lox] [0m[0m  print C();[0m
+[33m[tester::#MF6] [test-2.lox] [0m[0m}[0m
 [33m[tester::#MF6] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mA instance
-[33m[your_program] [0mB instance
-[33m[your_program] [0mC instance
+[33m[your_program] [0m[0mA instance[0m
+[33m[your_program] [0m[0mB instance[0m
+[33m[your_program] [0m[0mC instance[0m
 [33m[tester::#MF6] [test-2] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#MF6] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#MF6] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#MF6] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#MF6] [test-3.lox] [0mclass A {}
-[33m[tester::#MF6] [test-3.lox] [0m
-[33m[tester::#MF6] [test-3.lox] [0mfun f() {
-[33m[tester::#MF6] [test-3.lox] [0m  [33m// B is a subclass of A[0m
-[33m[tester::#MF6] [test-3.lox] [0m  class B < A {}
-[33m[tester::#MF6] [test-3.lox] [0m  return B;
-[33m[tester::#MF6] [test-3.lox] [0m}
-[33m[tester::#MF6] [test-3.lox] [0m
-[33m[tester::#MF6] [test-3.lox] [0mprint f();
+[33m[tester::#MF6] [test-3.lox] [0m[0mclass A {}[0m
+[33m[tester::#MF6] [test-3.lox] [0m[0m[0m
+[33m[tester::#MF6] [test-3.lox] [0m[0mfun f() {[0m
+[33m[tester::#MF6] [test-3.lox] [0m[0m  [33m// B is a subclass of A[0m[0m
+[33m[tester::#MF6] [test-3.lox] [0m[0m  class B < A {}[0m
+[33m[tester::#MF6] [test-3.lox] [0m[0m  return B;[0m
+[33m[tester::#MF6] [test-3.lox] [0m[0m}[0m
+[33m[tester::#MF6] [test-3.lox] [0m[0m[0m
+[33m[tester::#MF6] [test-3.lox] [0m[0mprint f();[0m
 [33m[tester::#MF6] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mB
+[33m[your_program] [0m[0mB[0m
 [33m[tester::#MF6] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#MF6] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#MF6] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#MF6] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#MF6] [test-4.lox] [0mclass Vehicle {}
-[33m[tester::#MF6] [test-4.lox] [0m
-[33m[tester::#MF6] [test-4.lox] [0m[33m// Car is a subclass of Vehicle[0m
-[33m[tester::#MF6] [test-4.lox] [0mclass Car < Vehicle {}
-[33m[tester::#MF6] [test-4.lox] [0m
-[33m[tester::#MF6] [test-4.lox] [0m[33m// Sedan is a subclass of Car[0m
-[33m[tester::#MF6] [test-4.lox] [0mclass Sedan < Car {}
-[33m[tester::#MF6] [test-4.lox] [0m
-[33m[tester::#MF6] [test-4.lox] [0mprint Vehicle();
-[33m[tester::#MF6] [test-4.lox] [0mprint Car();
-[33m[tester::#MF6] [test-4.lox] [0mprint Sedan();
-[33m[tester::#MF6] [test-4.lox] [0m
-[33m[tester::#MF6] [test-4.lox] [0m{
-[33m[tester::#MF6] [test-4.lox] [0m  [33m// Truck is a subclass of Vehicle[0m
-[33m[tester::#MF6] [test-4.lox] [0m  class Truck < Vehicle {}
-[33m[tester::#MF6] [test-4.lox] [0m  print Truck();
-[33m[tester::#MF6] [test-4.lox] [0m}
+[33m[tester::#MF6] [test-4.lox] [0m[0mclass Vehicle {}[0m
+[33m[tester::#MF6] [test-4.lox] [0m[0m[0m
+[33m[tester::#MF6] [test-4.lox] [0m[0m[33m// Car is a subclass of Vehicle[0m[0m
+[33m[tester::#MF6] [test-4.lox] [0m[0mclass Car < Vehicle {}[0m
+[33m[tester::#MF6] [test-4.lox] [0m[0m[0m
+[33m[tester::#MF6] [test-4.lox] [0m[0m[33m// Sedan is a subclass of Car[0m[0m
+[33m[tester::#MF6] [test-4.lox] [0m[0mclass Sedan < Car {}[0m
+[33m[tester::#MF6] [test-4.lox] [0m[0m[0m
+[33m[tester::#MF6] [test-4.lox] [0m[0mprint Vehicle();[0m
+[33m[tester::#MF6] [test-4.lox] [0m[0mprint Car();[0m
+[33m[tester::#MF6] [test-4.lox] [0m[0mprint Sedan();[0m
+[33m[tester::#MF6] [test-4.lox] [0m[0m[0m
+[33m[tester::#MF6] [test-4.lox] [0m[0m{[0m
+[33m[tester::#MF6] [test-4.lox] [0m[0m  [33m// Truck is a subclass of Vehicle[0m[0m
+[33m[tester::#MF6] [test-4.lox] [0m[0m  class Truck < Vehicle {}[0m
+[33m[tester::#MF6] [test-4.lox] [0m[0m  print Truck();[0m
+[33m[tester::#MF6] [test-4.lox] [0m[0m}[0m
 [33m[tester::#MF6] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mVehicle instance
-[33m[your_program] [0mCar instance
-[33m[your_program] [0mSedan instance
-[33m[your_program] [0mTruck instance
+[33m[your_program] [0m[0mVehicle instance[0m
+[33m[your_program] [0m[0mCar instance[0m
+[33m[your_program] [0m[0mSedan instance[0m
+[33m[your_program] [0m[0mTruck instance[0m
 [33m[tester::#MF6] [test-4] [0m[92m✓ 4 line(s) match on stdout[0m
 [33m[tester::#MF6] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#MF6] [0m[92mTest passed.[0m
@@ -82,119 +82,119 @@ Debug = true
 [33m[tester::#KY1] [0m[94mRunning tests for Stage #KY1 (ky1)[0m
 [33m[tester::#KY1] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#KY1] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#KY1] [test-1.lox] [0mclass Doughnut {
-[33m[tester::#KY1] [test-1.lox] [0m  cook() {
-[33m[tester::#KY1] [test-1.lox] [0m    print "Fry until golden brown.";
-[33m[tester::#KY1] [test-1.lox] [0m    }
-[33m[tester::#KY1] [test-1.lox] [0m  }
-[33m[tester::#KY1] [test-1.lox] [0m
-[33m[tester::#KY1] [test-1.lox] [0m[33m// BostonCream is a subclass of Doughnut[0m
-[33m[tester::#KY1] [test-1.lox] [0mclass BostonCream < Doughnut {}
-[33m[tester::#KY1] [test-1.lox] [0m
-[33m[tester::#KY1] [test-1.lox] [0m[33m// BostonCream class should inherit the cook[0m
-[33m[tester::#KY1] [test-1.lox] [0m[33m// method from Doughnut class[0m
-[33m[tester::#KY1] [test-1.lox] [0mBostonCream().cook();
+[33m[tester::#KY1] [test-1.lox] [0m[0mclass Doughnut {[0m
+[33m[tester::#KY1] [test-1.lox] [0m[0m  cook() {[0m
+[33m[tester::#KY1] [test-1.lox] [0m[0m    print "Fry until golden brown.";[0m
+[33m[tester::#KY1] [test-1.lox] [0m[0m    }[0m
+[33m[tester::#KY1] [test-1.lox] [0m[0m  }[0m
+[33m[tester::#KY1] [test-1.lox] [0m[0m[0m
+[33m[tester::#KY1] [test-1.lox] [0m[0m[33m// BostonCream is a subclass of Doughnut[0m[0m
+[33m[tester::#KY1] [test-1.lox] [0m[0mclass BostonCream < Doughnut {}[0m
+[33m[tester::#KY1] [test-1.lox] [0m[0m[0m
+[33m[tester::#KY1] [test-1.lox] [0m[0m[33m// BostonCream class should inherit the cook[0m[0m
+[33m[tester::#KY1] [test-1.lox] [0m[0m[33m// method from Doughnut class[0m[0m
+[33m[tester::#KY1] [test-1.lox] [0m[0mBostonCream().cook();[0m
 [33m[tester::#KY1] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mFry until golden brown.
+[33m[your_program] [0m[0mFry until golden brown.[0m
 [33m[tester::#KY1] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#KY1] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#KY1] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#KY1] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#KY1] [test-2.lox] [0mclass Root {
-[33m[tester::#KY1] [test-2.lox] [0m  getName() {
-[33m[tester::#KY1] [test-2.lox] [0m    print "Root class";
-[33m[tester::#KY1] [test-2.lox] [0m  }
-[33m[tester::#KY1] [test-2.lox] [0m}
-[33m[tester::#KY1] [test-2.lox] [0m
-[33m[tester::#KY1] [test-2.lox] [0mclass Parent < Root {
-[33m[tester::#KY1] [test-2.lox] [0m  parentMethod() {
-[33m[tester::#KY1] [test-2.lox] [0m    print "Method defined in Parent";
-[33m[tester::#KY1] [test-2.lox] [0m  }
-[33m[tester::#KY1] [test-2.lox] [0m}
-[33m[tester::#KY1] [test-2.lox] [0m
-[33m[tester::#KY1] [test-2.lox] [0mclass Child < Parent {
-[33m[tester::#KY1] [test-2.lox] [0m  childMethod() {
-[33m[tester::#KY1] [test-2.lox] [0m    print "Method defined in Child";
-[33m[tester::#KY1] [test-2.lox] [0m  }
-[33m[tester::#KY1] [test-2.lox] [0m}
-[33m[tester::#KY1] [test-2.lox] [0m
-[33m[tester::#KY1] [test-2.lox] [0mvar root = Root();
-[33m[tester::#KY1] [test-2.lox] [0mvar parent = Parent();
-[33m[tester::#KY1] [test-2.lox] [0mvar child = Child();
-[33m[tester::#KY1] [test-2.lox] [0m
-[33m[tester::#KY1] [test-2.lox] [0m[33m// Root methods are available to all[0m
-[33m[tester::#KY1] [test-2.lox] [0mroot.getName();
-[33m[tester::#KY1] [test-2.lox] [0mparent.getName();
-[33m[tester::#KY1] [test-2.lox] [0mchild.getName();
-[33m[tester::#KY1] [test-2.lox] [0m
-[33m[tester::#KY1] [test-2.lox] [0m[33m// Parent methods are available to Parent and Child[0m
-[33m[tester::#KY1] [test-2.lox] [0mparent.parentMethod();
-[33m[tester::#KY1] [test-2.lox] [0mchild.parentMethod();
-[33m[tester::#KY1] [test-2.lox] [0m
-[33m[tester::#KY1] [test-2.lox] [0m[33m// Child methods are only available to Child[0m
-[33m[tester::#KY1] [test-2.lox] [0mchild.childMethod();
+[33m[tester::#KY1] [test-2.lox] [0m[0mclass Root {[0m
+[33m[tester::#KY1] [test-2.lox] [0m[0m  getName() {[0m
+[33m[tester::#KY1] [test-2.lox] [0m[0m    print "Root class";[0m
+[33m[tester::#KY1] [test-2.lox] [0m[0m  }[0m
+[33m[tester::#KY1] [test-2.lox] [0m[0m}[0m
+[33m[tester::#KY1] [test-2.lox] [0m[0m[0m
+[33m[tester::#KY1] [test-2.lox] [0m[0mclass Parent < Root {[0m
+[33m[tester::#KY1] [test-2.lox] [0m[0m  parentMethod() {[0m
+[33m[tester::#KY1] [test-2.lox] [0m[0m    print "Method defined in Parent";[0m
+[33m[tester::#KY1] [test-2.lox] [0m[0m  }[0m
+[33m[tester::#KY1] [test-2.lox] [0m[0m}[0m
+[33m[tester::#KY1] [test-2.lox] [0m[0m[0m
+[33m[tester::#KY1] [test-2.lox] [0m[0mclass Child < Parent {[0m
+[33m[tester::#KY1] [test-2.lox] [0m[0m  childMethod() {[0m
+[33m[tester::#KY1] [test-2.lox] [0m[0m    print "Method defined in Child";[0m
+[33m[tester::#KY1] [test-2.lox] [0m[0m  }[0m
+[33m[tester::#KY1] [test-2.lox] [0m[0m}[0m
+[33m[tester::#KY1] [test-2.lox] [0m[0m[0m
+[33m[tester::#KY1] [test-2.lox] [0m[0mvar root = Root();[0m
+[33m[tester::#KY1] [test-2.lox] [0m[0mvar parent = Parent();[0m
+[33m[tester::#KY1] [test-2.lox] [0m[0mvar child = Child();[0m
+[33m[tester::#KY1] [test-2.lox] [0m[0m[0m
+[33m[tester::#KY1] [test-2.lox] [0m[0m[33m// Root methods are available to all[0m[0m
+[33m[tester::#KY1] [test-2.lox] [0m[0mroot.getName();[0m
+[33m[tester::#KY1] [test-2.lox] [0m[0mparent.getName();[0m
+[33m[tester::#KY1] [test-2.lox] [0m[0mchild.getName();[0m
+[33m[tester::#KY1] [test-2.lox] [0m[0m[0m
+[33m[tester::#KY1] [test-2.lox] [0m[0m[33m// Parent methods are available to Parent and Child[0m[0m
+[33m[tester::#KY1] [test-2.lox] [0m[0mparent.parentMethod();[0m
+[33m[tester::#KY1] [test-2.lox] [0m[0mchild.parentMethod();[0m
+[33m[tester::#KY1] [test-2.lox] [0m[0m[0m
+[33m[tester::#KY1] [test-2.lox] [0m[0m[33m// Child methods are only available to Child[0m[0m
+[33m[tester::#KY1] [test-2.lox] [0m[0mchild.childMethod();[0m
 [33m[tester::#KY1] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mRoot class
-[33m[your_program] [0mRoot class
-[33m[your_program] [0mRoot class
-[33m[your_program] [0mMethod defined in Parent
-[33m[your_program] [0mMethod defined in Parent
-[33m[your_program] [0mMethod defined in Child
+[33m[your_program] [0m[0mRoot class[0m
+[33m[your_program] [0m[0mRoot class[0m
+[33m[your_program] [0m[0mRoot class[0m
+[33m[your_program] [0m[0mMethod defined in Parent[0m
+[33m[your_program] [0m[0mMethod defined in Parent[0m
+[33m[your_program] [0m[0mMethod defined in Child[0m
 [33m[tester::#KY1] [test-2] [0m[92m✓ 6 line(s) match on stdout[0m
 [33m[tester::#KY1] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#KY1] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#KY1] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#KY1] [test-3.lox] [0mclass Foo {
-[33m[tester::#KY1] [test-3.lox] [0m  init() {
-[33m[tester::#KY1] [test-3.lox] [0m    this.secret = 42;
-[33m[tester::#KY1] [test-3.lox] [0m  }
-[33m[tester::#KY1] [test-3.lox] [0m}
-[33m[tester::#KY1] [test-3.lox] [0m
-[33m[tester::#KY1] [test-3.lox] [0m[33m// Bar is a subclass of Foo[0m
-[33m[tester::#KY1] [test-3.lox] [0mclass Bar < Foo {}
-[33m[tester::#KY1] [test-3.lox] [0m
-[33m[tester::#KY1] [test-3.lox] [0m[33m// Baz is a subclass of Bar[0m
-[33m[tester::#KY1] [test-3.lox] [0mclass Baz < Bar {}
-[33m[tester::#KY1] [test-3.lox] [0m
-[33m[tester::#KY1] [test-3.lox] [0mvar baz = Baz();
-[33m[tester::#KY1] [test-3.lox] [0m
-[33m[tester::#KY1] [test-3.lox] [0m[33m// Baz should inherit the constructor from Foo[0m
-[33m[tester::#KY1] [test-3.lox] [0m[33m// which should set the secret value to 42[0m
-[33m[tester::#KY1] [test-3.lox] [0mprint baz.secret;
+[33m[tester::#KY1] [test-3.lox] [0m[0mclass Foo {[0m
+[33m[tester::#KY1] [test-3.lox] [0m[0m  init() {[0m
+[33m[tester::#KY1] [test-3.lox] [0m[0m    this.secret = 42;[0m
+[33m[tester::#KY1] [test-3.lox] [0m[0m  }[0m
+[33m[tester::#KY1] [test-3.lox] [0m[0m}[0m
+[33m[tester::#KY1] [test-3.lox] [0m[0m[0m
+[33m[tester::#KY1] [test-3.lox] [0m[0m[33m// Bar is a subclass of Foo[0m[0m
+[33m[tester::#KY1] [test-3.lox] [0m[0mclass Bar < Foo {}[0m
+[33m[tester::#KY1] [test-3.lox] [0m[0m[0m
+[33m[tester::#KY1] [test-3.lox] [0m[0m[33m// Baz is a subclass of Bar[0m[0m
+[33m[tester::#KY1] [test-3.lox] [0m[0mclass Baz < Bar {}[0m
+[33m[tester::#KY1] [test-3.lox] [0m[0m[0m
+[33m[tester::#KY1] [test-3.lox] [0m[0mvar baz = Baz();[0m
+[33m[tester::#KY1] [test-3.lox] [0m[0m[0m
+[33m[tester::#KY1] [test-3.lox] [0m[0m[33m// Baz should inherit the constructor from Foo[0m[0m
+[33m[tester::#KY1] [test-3.lox] [0m[0m[33m// which should set the secret value to 42[0m[0m
+[33m[tester::#KY1] [test-3.lox] [0m[0mprint baz.secret;[0m
 [33m[tester::#KY1] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m42
+[33m[your_program] [0m[0m42[0m
 [33m[tester::#KY1] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#KY1] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#KY1] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#KY1] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#KY1] [test-4.lox] [0mclass baz {
-[33m[tester::#KY1] [test-4.lox] [0m  inbaz() {
-[33m[tester::#KY1] [test-4.lox] [0m    print "from baz";
-[33m[tester::#KY1] [test-4.lox] [0m  }
-[33m[tester::#KY1] [test-4.lox] [0m}
-[33m[tester::#KY1] [test-4.lox] [0m
-[33m[tester::#KY1] [test-4.lox] [0mclass bar < baz {
-[33m[tester::#KY1] [test-4.lox] [0m  inbar() {
-[33m[tester::#KY1] [test-4.lox] [0m    print "from bar";
-[33m[tester::#KY1] [test-4.lox] [0m  }
-[33m[tester::#KY1] [test-4.lox] [0m}
-[33m[tester::#KY1] [test-4.lox] [0m
-[33m[tester::#KY1] [test-4.lox] [0mclass quz < bar {
-[33m[tester::#KY1] [test-4.lox] [0m  inquz() {
-[33m[tester::#KY1] [test-4.lox] [0m    print "from quz";
-[33m[tester::#KY1] [test-4.lox] [0m  }
-[33m[tester::#KY1] [test-4.lox] [0m}
-[33m[tester::#KY1] [test-4.lox] [0m
-[33m[tester::#KY1] [test-4.lox] [0m[33m// quz should inherit the methods[0m
-[33m[tester::#KY1] [test-4.lox] [0m[33m// from both baz and bar[0m
-[33m[tester::#KY1] [test-4.lox] [0mvar quz = quz();
-[33m[tester::#KY1] [test-4.lox] [0mquz.inbaz();
-[33m[tester::#KY1] [test-4.lox] [0mquz.inbar();
-[33m[tester::#KY1] [test-4.lox] [0mquz.inquz();
+[33m[tester::#KY1] [test-4.lox] [0m[0mclass baz {[0m
+[33m[tester::#KY1] [test-4.lox] [0m[0m  inbaz() {[0m
+[33m[tester::#KY1] [test-4.lox] [0m[0m    print "from baz";[0m
+[33m[tester::#KY1] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#KY1] [test-4.lox] [0m[0m}[0m
+[33m[tester::#KY1] [test-4.lox] [0m[0m[0m
+[33m[tester::#KY1] [test-4.lox] [0m[0mclass bar < baz {[0m
+[33m[tester::#KY1] [test-4.lox] [0m[0m  inbar() {[0m
+[33m[tester::#KY1] [test-4.lox] [0m[0m    print "from bar";[0m
+[33m[tester::#KY1] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#KY1] [test-4.lox] [0m[0m}[0m
+[33m[tester::#KY1] [test-4.lox] [0m[0m[0m
+[33m[tester::#KY1] [test-4.lox] [0m[0mclass quz < bar {[0m
+[33m[tester::#KY1] [test-4.lox] [0m[0m  inquz() {[0m
+[33m[tester::#KY1] [test-4.lox] [0m[0m    print "from quz";[0m
+[33m[tester::#KY1] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#KY1] [test-4.lox] [0m[0m}[0m
+[33m[tester::#KY1] [test-4.lox] [0m[0m[0m
+[33m[tester::#KY1] [test-4.lox] [0m[0m[33m// quz should inherit the methods[0m[0m
+[33m[tester::#KY1] [test-4.lox] [0m[0m[33m// from both baz and bar[0m[0m
+[33m[tester::#KY1] [test-4.lox] [0m[0mvar quz = quz();[0m
+[33m[tester::#KY1] [test-4.lox] [0m[0mquz.inbaz();[0m
+[33m[tester::#KY1] [test-4.lox] [0m[0mquz.inbar();[0m
+[33m[tester::#KY1] [test-4.lox] [0m[0mquz.inquz();[0m
 [33m[tester::#KY1] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mfrom baz
-[33m[your_program] [0mfrom bar
-[33m[your_program] [0mfrom quz
+[33m[your_program] [0m[0mfrom baz[0m
+[33m[your_program] [0m[0mfrom bar[0m
+[33m[your_program] [0m[0mfrom quz[0m
 [33m[tester::#KY1] [test-4] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#KY1] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#KY1] [0m[92mTest passed.[0m
@@ -202,143 +202,143 @@ Debug = true
 [33m[tester::#KA5] [0m[94mRunning tests for Stage #KA5 (ka5)[0m
 [33m[tester::#KA5] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#KA5] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#KA5] [test-1.lox] [0mclass A {
-[33m[tester::#KA5] [test-1.lox] [0m  method() {
-[33m[tester::#KA5] [test-1.lox] [0m    print "A method";
-[33m[tester::#KA5] [test-1.lox] [0m  }
-[33m[tester::#KA5] [test-1.lox] [0m}
-[33m[tester::#KA5] [test-1.lox] [0m
-[33m[tester::#KA5] [test-1.lox] [0m
-[33m[tester::#KA5] [test-1.lox] [0m[33m// B inherits method `method` from A[0m
-[33m[tester::#KA5] [test-1.lox] [0m[33m// and overrides it with a new implementation[0m
-[33m[tester::#KA5] [test-1.lox] [0mclass B < A {
-[33m[tester::#KA5] [test-1.lox] [0m  method() {
-[33m[tester::#KA5] [test-1.lox] [0m    print "B method";
-[33m[tester::#KA5] [test-1.lox] [0m  }
-[33m[tester::#KA5] [test-1.lox] [0m}
-[33m[tester::#KA5] [test-1.lox] [0m
-[33m[tester::#KA5] [test-1.lox] [0mvar b = B();
-[33m[tester::#KA5] [test-1.lox] [0mb.method();  [33m// expect: B method[0m
+[33m[tester::#KA5] [test-1.lox] [0m[0mclass A {[0m
+[33m[tester::#KA5] [test-1.lox] [0m[0m  method() {[0m
+[33m[tester::#KA5] [test-1.lox] [0m[0m    print "A method";[0m
+[33m[tester::#KA5] [test-1.lox] [0m[0m  }[0m
+[33m[tester::#KA5] [test-1.lox] [0m[0m}[0m
+[33m[tester::#KA5] [test-1.lox] [0m[0m[0m
+[33m[tester::#KA5] [test-1.lox] [0m[0m[0m
+[33m[tester::#KA5] [test-1.lox] [0m[0m[33m// B inherits method `method` from A[0m[0m
+[33m[tester::#KA5] [test-1.lox] [0m[0m[33m// and overrides it with a new implementation[0m[0m
+[33m[tester::#KA5] [test-1.lox] [0m[0mclass B < A {[0m
+[33m[tester::#KA5] [test-1.lox] [0m[0m  method() {[0m
+[33m[tester::#KA5] [test-1.lox] [0m[0m    print "B method";[0m
+[33m[tester::#KA5] [test-1.lox] [0m[0m  }[0m
+[33m[tester::#KA5] [test-1.lox] [0m[0m}[0m
+[33m[tester::#KA5] [test-1.lox] [0m[0m[0m
+[33m[tester::#KA5] [test-1.lox] [0m[0mvar b = B();[0m
+[33m[tester::#KA5] [test-1.lox] [0m[0mb.method();  [33m// expect: B method[0m[0m
 [33m[tester::#KA5] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mB method
+[33m[your_program] [0m[0mB method[0m
 [33m[tester::#KA5] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#KA5] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#KA5] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#KA5] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#KA5] [test-2.lox] [0mclass Base {
-[33m[tester::#KA5] [test-2.lox] [0m  init(a) {
-[33m[tester::#KA5] [test-2.lox] [0m    this.a = a;
-[33m[tester::#KA5] [test-2.lox] [0m  }
-[33m[tester::#KA5] [test-2.lox] [0m}
-[33m[tester::#KA5] [test-2.lox] [0m
-[33m[tester::#KA5] [test-2.lox] [0m
-[33m[tester::#KA5] [test-2.lox] [0m[33m// Constructors can also be overridden[0m
-[33m[tester::#KA5] [test-2.lox] [0mclass Derived < Base {
-[33m[tester::#KA5] [test-2.lox] [0m  init(a, b) {
-[33m[tester::#KA5] [test-2.lox] [0m    this.a = a;
-[33m[tester::#KA5] [test-2.lox] [0m    this.b = b;
-[33m[tester::#KA5] [test-2.lox] [0m  }
-[33m[tester::#KA5] [test-2.lox] [0m}
-[33m[tester::#KA5] [test-2.lox] [0m
-[33m[tester::#KA5] [test-2.lox] [0mvar derived = Derived(53, 31);
-[33m[tester::#KA5] [test-2.lox] [0mprint derived.a;
-[33m[tester::#KA5] [test-2.lox] [0mprint derived.b;
+[33m[tester::#KA5] [test-2.lox] [0m[0mclass Base {[0m
+[33m[tester::#KA5] [test-2.lox] [0m[0m  init(a) {[0m
+[33m[tester::#KA5] [test-2.lox] [0m[0m    this.a = a;[0m
+[33m[tester::#KA5] [test-2.lox] [0m[0m  }[0m
+[33m[tester::#KA5] [test-2.lox] [0m[0m}[0m
+[33m[tester::#KA5] [test-2.lox] [0m[0m[0m
+[33m[tester::#KA5] [test-2.lox] [0m[0m[0m
+[33m[tester::#KA5] [test-2.lox] [0m[0m[33m// Constructors can also be overridden[0m[0m
+[33m[tester::#KA5] [test-2.lox] [0m[0mclass Derived < Base {[0m
+[33m[tester::#KA5] [test-2.lox] [0m[0m  init(a, b) {[0m
+[33m[tester::#KA5] [test-2.lox] [0m[0m    this.a = a;[0m
+[33m[tester::#KA5] [test-2.lox] [0m[0m    this.b = b;[0m
+[33m[tester::#KA5] [test-2.lox] [0m[0m  }[0m
+[33m[tester::#KA5] [test-2.lox] [0m[0m}[0m
+[33m[tester::#KA5] [test-2.lox] [0m[0m[0m
+[33m[tester::#KA5] [test-2.lox] [0m[0mvar derived = Derived(53, 31);[0m
+[33m[tester::#KA5] [test-2.lox] [0m[0mprint derived.a;[0m
+[33m[tester::#KA5] [test-2.lox] [0m[0mprint derived.b;[0m
 [33m[tester::#KA5] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m53
-[33m[your_program] [0m31
+[33m[your_program] [0m[0m53[0m
+[33m[your_program] [0m[0m31[0m
 [33m[tester::#KA5] [test-2] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#KA5] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#KA5] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#KA5] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#KA5] [test-3.lox] [0mclass Base {
-[33m[tester::#KA5] [test-3.lox] [0m  init(a) {
-[33m[tester::#KA5] [test-3.lox] [0m    this.a = a;
-[33m[tester::#KA5] [test-3.lox] [0m  }
-[33m[tester::#KA5] [test-3.lox] [0m
-[33m[tester::#KA5] [test-3.lox] [0m  cook() {
-[33m[tester::#KA5] [test-3.lox] [0m    return "Base cooking " + this.a;
-[33m[tester::#KA5] [test-3.lox] [0m  }
-[33m[tester::#KA5] [test-3.lox] [0m}
-[33m[tester::#KA5] [test-3.lox] [0m
-[33m[tester::#KA5] [test-3.lox] [0mclass Derived < Base {
-[33m[tester::#KA5] [test-3.lox] [0m  init(a, b) {
-[33m[tester::#KA5] [test-3.lox] [0m    this.a = a;
-[33m[tester::#KA5] [test-3.lox] [0m    this.b = b;
-[33m[tester::#KA5] [test-3.lox] [0m  }
-[33m[tester::#KA5] [test-3.lox] [0m
-[33m[tester::#KA5] [test-3.lox] [0m  [33m// Derived overrides the cook method of Base[0m
-[33m[tester::#KA5] [test-3.lox] [0m  cook() {
-[33m[tester::#KA5] [test-3.lox] [0m    return "Derived cooking " + this.b + " with "
-[33m[tester::#KA5] [test-3.lox] [0m    + this.a + " and " + this.b;
-[33m[tester::#KA5] [test-3.lox] [0m  }
-[33m[tester::#KA5] [test-3.lox] [0m
-[33m[tester::#KA5] [test-3.lox] [0m  makeFood() {
-[33m[tester::#KA5] [test-3.lox] [0m    return this.cook();
-[33m[tester::#KA5] [test-3.lox] [0m  }
-[33m[tester::#KA5] [test-3.lox] [0m}
-[33m[tester::#KA5] [test-3.lox] [0m
-[33m[tester::#KA5] [test-3.lox] [0mvar derived = Derived("onions", "shallots");
-[33m[tester::#KA5] [test-3.lox] [0mprint derived.a;
-[33m[tester::#KA5] [test-3.lox] [0mprint derived.b;
-[33m[tester::#KA5] [test-3.lox] [0m
-[33m[tester::#KA5] [test-3.lox] [0mprint Base("ingredient").cook();
-[33m[tester::#KA5] [test-3.lox] [0mprint derived.cook();
+[33m[tester::#KA5] [test-3.lox] [0m[0mclass Base {[0m
+[33m[tester::#KA5] [test-3.lox] [0m[0m  init(a) {[0m
+[33m[tester::#KA5] [test-3.lox] [0m[0m    this.a = a;[0m
+[33m[tester::#KA5] [test-3.lox] [0m[0m  }[0m
+[33m[tester::#KA5] [test-3.lox] [0m[0m[0m
+[33m[tester::#KA5] [test-3.lox] [0m[0m  cook() {[0m
+[33m[tester::#KA5] [test-3.lox] [0m[0m    return "Base cooking " + this.a;[0m
+[33m[tester::#KA5] [test-3.lox] [0m[0m  }[0m
+[33m[tester::#KA5] [test-3.lox] [0m[0m}[0m
+[33m[tester::#KA5] [test-3.lox] [0m[0m[0m
+[33m[tester::#KA5] [test-3.lox] [0m[0mclass Derived < Base {[0m
+[33m[tester::#KA5] [test-3.lox] [0m[0m  init(a, b) {[0m
+[33m[tester::#KA5] [test-3.lox] [0m[0m    this.a = a;[0m
+[33m[tester::#KA5] [test-3.lox] [0m[0m    this.b = b;[0m
+[33m[tester::#KA5] [test-3.lox] [0m[0m  }[0m
+[33m[tester::#KA5] [test-3.lox] [0m[0m[0m
+[33m[tester::#KA5] [test-3.lox] [0m[0m  [33m// Derived overrides the cook method of Base[0m[0m
+[33m[tester::#KA5] [test-3.lox] [0m[0m  cook() {[0m
+[33m[tester::#KA5] [test-3.lox] [0m[0m    return "Derived cooking " + this.b + " with "[0m
+[33m[tester::#KA5] [test-3.lox] [0m[0m    + this.a + " and " + this.b;[0m
+[33m[tester::#KA5] [test-3.lox] [0m[0m  }[0m
+[33m[tester::#KA5] [test-3.lox] [0m[0m[0m
+[33m[tester::#KA5] [test-3.lox] [0m[0m  makeFood() {[0m
+[33m[tester::#KA5] [test-3.lox] [0m[0m    return this.cook();[0m
+[33m[tester::#KA5] [test-3.lox] [0m[0m  }[0m
+[33m[tester::#KA5] [test-3.lox] [0m[0m}[0m
+[33m[tester::#KA5] [test-3.lox] [0m[0m[0m
+[33m[tester::#KA5] [test-3.lox] [0m[0mvar derived = Derived("onions", "shallots");[0m
+[33m[tester::#KA5] [test-3.lox] [0m[0mprint derived.a;[0m
+[33m[tester::#KA5] [test-3.lox] [0m[0mprint derived.b;[0m
+[33m[tester::#KA5] [test-3.lox] [0m[0m[0m
+[33m[tester::#KA5] [test-3.lox] [0m[0mprint Base("ingredient").cook();[0m
+[33m[tester::#KA5] [test-3.lox] [0m[0mprint derived.cook();[0m
 [33m[tester::#KA5] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0monions
-[33m[your_program] [0mshallots
-[33m[your_program] [0mBase cooking ingredient
-[33m[your_program] [0mDerived cooking shallots with onions and shallots
+[33m[your_program] [0m[0monions[0m
+[33m[your_program] [0m[0mshallots[0m
+[33m[your_program] [0m[0mBase cooking ingredient[0m
+[33m[your_program] [0m[0mDerived cooking shallots with onions and shallots[0m
 [33m[tester::#KA5] [test-3] [0m[92m✓ 4 line(s) match on stdout[0m
 [33m[tester::#KA5] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#KA5] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#KA5] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#KA5] [test-4.lox] [0mclass Animal {
-[33m[tester::#KA5] [test-4.lox] [0m  speak() {
-[33m[tester::#KA5] [test-4.lox] [0m    return "Animal speaks";
-[33m[tester::#KA5] [test-4.lox] [0m  }
-[33m[tester::#KA5] [test-4.lox] [0m
-[33m[tester::#KA5] [test-4.lox] [0m  makeSound() {
-[33m[tester::#KA5] [test-4.lox] [0m    return "Generic sound";
-[33m[tester::#KA5] [test-4.lox] [0m  }
-[33m[tester::#KA5] [test-4.lox] [0m
-[33m[tester::#KA5] [test-4.lox] [0m  communicate() {
-[33m[tester::#KA5] [test-4.lox] [0m    return this.speak() + " : " + this.makeSound();
-[33m[tester::#KA5] [test-4.lox] [0m  }
-[33m[tester::#KA5] [test-4.lox] [0m}
-[33m[tester::#KA5] [test-4.lox] [0m
-[33m[tester::#KA5] [test-4.lox] [0m[33m// Dog inherits the speak and makeSound methods[0m
-[33m[tester::#KA5] [test-4.lox] [0m[33m// from Animal and overrides them with new[0m
-[33m[tester::#KA5] [test-4.lox] [0m[33m// implementations specific to dogs[0m
-[33m[tester::#KA5] [test-4.lox] [0mclass Dog < Animal {
-[33m[tester::#KA5] [test-4.lox] [0m  speak() {
-[33m[tester::#KA5] [test-4.lox] [0m    return "Dog speaks";
-[33m[tester::#KA5] [test-4.lox] [0m  }
-[33m[tester::#KA5] [test-4.lox] [0m
-[33m[tester::#KA5] [test-4.lox] [0m  makeSound() {
-[33m[tester::#KA5] [test-4.lox] [0m    return "Woof";
-[33m[tester::#KA5] [test-4.lox] [0m  }
-[33m[tester::#KA5] [test-4.lox] [0m}
-[33m[tester::#KA5] [test-4.lox] [0m
-[33m[tester::#KA5] [test-4.lox] [0m[33m// Puppy inherits the speak and makeSound methods[0m
-[33m[tester::#KA5] [test-4.lox] [0m[33m// from Dog and overrides them with new[0m
-[33m[tester::#KA5] [test-4.lox] [0m[33m// implementations specific to puppies[0m
-[33m[tester::#KA5] [test-4.lox] [0mclass Puppy < Dog {
-[33m[tester::#KA5] [test-4.lox] [0m  speak() {
-[33m[tester::#KA5] [test-4.lox] [0m    return "Puppy speaks";
-[33m[tester::#KA5] [test-4.lox] [0m  }
-[33m[tester::#KA5] [test-4.lox] [0m}
-[33m[tester::#KA5] [test-4.lox] [0m
-[33m[tester::#KA5] [test-4.lox] [0mvar animal = Animal();
-[33m[tester::#KA5] [test-4.lox] [0mvar dog = Dog();
-[33m[tester::#KA5] [test-4.lox] [0mvar puppy = Puppy();
-[33m[tester::#KA5] [test-4.lox] [0m
-[33m[tester::#KA5] [test-4.lox] [0mprint animal.communicate();
-[33m[tester::#KA5] [test-4.lox] [0mprint dog.communicate();
-[33m[tester::#KA5] [test-4.lox] [0mprint puppy.communicate();
+[33m[tester::#KA5] [test-4.lox] [0m[0mclass Animal {[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0m  speak() {[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0m    return "Animal speaks";[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0m[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0m  makeSound() {[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0m    return "Generic sound";[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0m[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0m  communicate() {[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0m    return this.speak() + " : " + this.makeSound();[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0m}[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0m[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0m[33m// Dog inherits the speak and makeSound methods[0m[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0m[33m// from Animal and overrides them with new[0m[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0m[33m// implementations specific to dogs[0m[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0mclass Dog < Animal {[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0m  speak() {[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0m    return "Dog speaks";[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0m[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0m  makeSound() {[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0m    return "Woof";[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0m}[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0m[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0m[33m// Puppy inherits the speak and makeSound methods[0m[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0m[33m// from Dog and overrides them with new[0m[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0m[33m// implementations specific to puppies[0m[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0mclass Puppy < Dog {[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0m  speak() {[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0m    return "Puppy speaks";[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0m}[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0m[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0mvar animal = Animal();[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0mvar dog = Dog();[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0mvar puppy = Puppy();[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0m[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0mprint animal.communicate();[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0mprint dog.communicate();[0m
+[33m[tester::#KA5] [test-4.lox] [0m[0mprint puppy.communicate();[0m
 [33m[tester::#KA5] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mAnimal speaks : Generic sound
-[33m[your_program] [0mDog speaks : Woof
-[33m[your_program] [0mPuppy speaks : Woof
+[33m[your_program] [0m[0mAnimal speaks : Generic sound[0m
+[33m[your_program] [0m[0mDog speaks : Woof[0m
+[33m[your_program] [0m[0mPuppy speaks : Woof[0m
 [33m[tester::#KA5] [test-4] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#KA5] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#KA5] [0m[92mTest passed.[0m
@@ -346,58 +346,58 @@ Debug = true
 [33m[tester::#AB0] [0m[94mRunning tests for Stage #AB0 (ab0)[0m
 [33m[tester::#AB0] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#AB0] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#AB0] [test-1.lox] [0m[33m// A class can't inherit from itself.[0m
-[33m[tester::#AB0] [test-1.lox] [0mclass Foo < Foo {} [33m// expect compile error[0m
+[33m[tester::#AB0] [test-1.lox] [0m[0m[33m// A class can't inherit from itself.[0m[0m
+[33m[tester::#AB0] [test-1.lox] [0m[0mclass Foo < Foo {} [33m// expect compile error[0m[0m
 [33m[tester::#AB0] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 2] Error at 'Foo': A class can't inherit from itself.
+[33m[your_program] [0m[0m[line 2] Error at 'Foo': A class can't inherit from itself.[0m
 [33m[tester::#AB0] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#AB0] [test-1] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#AB0] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#AB0] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#AB0] [test-2.lox] [0mfun A() {}
-[33m[tester::#AB0] [test-2.lox] [0m
-[33m[tester::#AB0] [test-2.lox] [0m[33m// A class can only inherit from a class.[0m
-[33m[tester::#AB0] [test-2.lox] [0mclass B < A {} [33m// expect runtime error[0m
-[33m[tester::#AB0] [test-2.lox] [0m
-[33m[tester::#AB0] [test-2.lox] [0mprint A();
-[33m[tester::#AB0] [test-2.lox] [0mprint B();
+[33m[tester::#AB0] [test-2.lox] [0m[0mfun A() {}[0m
+[33m[tester::#AB0] [test-2.lox] [0m[0m[0m
+[33m[tester::#AB0] [test-2.lox] [0m[0m[33m// A class can only inherit from a class.[0m[0m
+[33m[tester::#AB0] [test-2.lox] [0m[0mclass B < A {} [33m// expect runtime error[0m[0m
+[33m[tester::#AB0] [test-2.lox] [0m[0m[0m
+[33m[tester::#AB0] [test-2.lox] [0m[0mprint A();[0m
+[33m[tester::#AB0] [test-2.lox] [0m[0mprint B();[0m
 [33m[tester::#AB0] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mSuperclass must be a class.
-[33m[your_program] [0m[line 4]
+[33m[your_program] [0m[0mSuperclass must be a class.[0m
+[33m[your_program] [0m[0m[line 4][0m
 [33m[tester::#AB0] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#AB0] [test-2] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#AB0] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#AB0] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#AB0] [test-3.lox] [0mvar A = "class";
-[33m[tester::#AB0] [test-3.lox] [0m
-[33m[tester::#AB0] [test-3.lox] [0m[33m// A class can only inherit from a class[0m
-[33m[tester::#AB0] [test-3.lox] [0mclass B < A {} [33m// expect runtime error[0m
-[33m[tester::#AB0] [test-3.lox] [0m
-[33m[tester::#AB0] [test-3.lox] [0mprint B();
+[33m[tester::#AB0] [test-3.lox] [0m[0mvar A = "class";[0m
+[33m[tester::#AB0] [test-3.lox] [0m[0m[0m
+[33m[tester::#AB0] [test-3.lox] [0m[0m[33m// A class can only inherit from a class[0m[0m
+[33m[tester::#AB0] [test-3.lox] [0m[0mclass B < A {} [33m// expect runtime error[0m[0m
+[33m[tester::#AB0] [test-3.lox] [0m[0m[0m
+[33m[tester::#AB0] [test-3.lox] [0m[0mprint B();[0m
 [33m[tester::#AB0] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mSuperclass must be a class.
-[33m[your_program] [0m[line 4]
+[33m[your_program] [0m[0mSuperclass must be a class.[0m
+[33m[your_program] [0m[0m[line 4][0m
 [33m[tester::#AB0] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#AB0] [test-3] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#AB0] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#AB0] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#AB0] [test-4.lox] [0mclass A {
-[33m[tester::#AB0] [test-4.lox] [0m  method() {
-[33m[tester::#AB0] [test-4.lox] [0m    print "A";
-[33m[tester::#AB0] [test-4.lox] [0m  }
-[33m[tester::#AB0] [test-4.lox] [0m}
-[33m[tester::#AB0] [test-4.lox] [0m
-[33m[tester::#AB0] [test-4.lox] [0mclass B < A {}
-[33m[tester::#AB0] [test-4.lox] [0mclass C < B {}
-[33m[tester::#AB0] [test-4.lox] [0mclass D < A {}
-[33m[tester::#AB0] [test-4.lox] [0m
-[33m[tester::#AB0] [test-4.lox] [0m[33m// B is updated to a non-class value[0m
-[33m[tester::#AB0] [test-4.lox] [0mB = "not a class";
-[33m[tester::#AB0] [test-4.lox] [0m[33m// E inherits from B, which is not a class[0m
-[33m[tester::#AB0] [test-4.lox] [0mclass E < B {}  [33m// expect runtime error[0m
+[33m[tester::#AB0] [test-4.lox] [0m[0mclass A {[0m
+[33m[tester::#AB0] [test-4.lox] [0m[0m  method() {[0m
+[33m[tester::#AB0] [test-4.lox] [0m[0m    print "A";[0m
+[33m[tester::#AB0] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#AB0] [test-4.lox] [0m[0m}[0m
+[33m[tester::#AB0] [test-4.lox] [0m[0m[0m
+[33m[tester::#AB0] [test-4.lox] [0m[0mclass B < A {}[0m
+[33m[tester::#AB0] [test-4.lox] [0m[0mclass C < B {}[0m
+[33m[tester::#AB0] [test-4.lox] [0m[0mclass D < A {}[0m
+[33m[tester::#AB0] [test-4.lox] [0m[0m[0m
+[33m[tester::#AB0] [test-4.lox] [0m[0m[33m// B is updated to a non-class value[0m[0m
+[33m[tester::#AB0] [test-4.lox] [0m[0mB = "not a class";[0m
+[33m[tester::#AB0] [test-4.lox] [0m[0m[33m// E inherits from B, which is not a class[0m[0m
+[33m[tester::#AB0] [test-4.lox] [0m[0mclass E < B {}  [33m// expect runtime error[0m[0m
 [33m[tester::#AB0] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mSuperclass must be a class.
-[33m[your_program] [0m[line 14]
+[33m[your_program] [0m[0mSuperclass must be a class.[0m
+[33m[your_program] [0m[0m[line 14][0m
 [33m[tester::#AB0] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#AB0] [test-4] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#AB0] [0m[92mTest passed.[0m
@@ -405,124 +405,124 @@ Debug = true
 [33m[tester::#QI0] [0m[94mRunning tests for Stage #QI0 (qi0)[0m
 [33m[tester::#QI0] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#QI0] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#QI0] [test-1.lox] [0mclass Doughnut {
-[33m[tester::#QI0] [test-1.lox] [0m  cook() {
-[33m[tester::#QI0] [test-1.lox] [0m    print "Fry until golden brown.";
-[33m[tester::#QI0] [test-1.lox] [0m  }
-[33m[tester::#QI0] [test-1.lox] [0m}
-[33m[tester::#QI0] [test-1.lox] [0m
-[33m[tester::#QI0] [test-1.lox] [0m[33m// Super can be used to call the overridden method[0m
-[33m[tester::#QI0] [test-1.lox] [0m[33m// of the parent class[0m
-[33m[tester::#QI0] [test-1.lox] [0mclass BostonCream < Doughnut {
-[33m[tester::#QI0] [test-1.lox] [0m  cook() {
-[33m[tester::#QI0] [test-1.lox] [0m    super.cook();
-[33m[tester::#QI0] [test-1.lox] [0m  }
-[33m[tester::#QI0] [test-1.lox] [0m}
-[33m[tester::#QI0] [test-1.lox] [0m
-[33m[tester::#QI0] [test-1.lox] [0mBostonCream().cook();
+[33m[tester::#QI0] [test-1.lox] [0m[0mclass Doughnut {[0m
+[33m[tester::#QI0] [test-1.lox] [0m[0m  cook() {[0m
+[33m[tester::#QI0] [test-1.lox] [0m[0m    print "Fry until golden brown.";[0m
+[33m[tester::#QI0] [test-1.lox] [0m[0m  }[0m
+[33m[tester::#QI0] [test-1.lox] [0m[0m}[0m
+[33m[tester::#QI0] [test-1.lox] [0m[0m[0m
+[33m[tester::#QI0] [test-1.lox] [0m[0m[33m// Super can be used to call the overridden method[0m[0m
+[33m[tester::#QI0] [test-1.lox] [0m[0m[33m// of the parent class[0m[0m
+[33m[tester::#QI0] [test-1.lox] [0m[0mclass BostonCream < Doughnut {[0m
+[33m[tester::#QI0] [test-1.lox] [0m[0m  cook() {[0m
+[33m[tester::#QI0] [test-1.lox] [0m[0m    super.cook();[0m
+[33m[tester::#QI0] [test-1.lox] [0m[0m  }[0m
+[33m[tester::#QI0] [test-1.lox] [0m[0m}[0m
+[33m[tester::#QI0] [test-1.lox] [0m[0m[0m
+[33m[tester::#QI0] [test-1.lox] [0m[0mBostonCream().cook();[0m
 [33m[tester::#QI0] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mFry until golden brown.
+[33m[your_program] [0m[0mFry until golden brown.[0m
 [33m[tester::#QI0] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#QI0] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#QI0] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#QI0] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#QI0] [test-2.lox] [0mclass A {
-[33m[tester::#QI0] [test-2.lox] [0m  say() {
-[33m[tester::#QI0] [test-2.lox] [0m    print "A";
-[33m[tester::#QI0] [test-2.lox] [0m  }
-[33m[tester::#QI0] [test-2.lox] [0m}
-[33m[tester::#QI0] [test-2.lox] [0m
-[33m[tester::#QI0] [test-2.lox] [0mclass B < A {
-[33m[tester::#QI0] [test-2.lox] [0m  [33m// test calls say() from A[0m
-[33m[tester::#QI0] [test-2.lox] [0m  test() {
-[33m[tester::#QI0] [test-2.lox] [0m    super.say();
-[33m[tester::#QI0] [test-2.lox] [0m  }
-[33m[tester::#QI0] [test-2.lox] [0m
-[33m[tester::#QI0] [test-2.lox] [0m  say() {
-[33m[tester::#QI0] [test-2.lox] [0m    print "B";
-[33m[tester::#QI0] [test-2.lox] [0m  }
-[33m[tester::#QI0] [test-2.lox] [0m}
-[33m[tester::#QI0] [test-2.lox] [0m
-[33m[tester::#QI0] [test-2.lox] [0m[33m// C inherits test() from B[0m
-[33m[tester::#QI0] [test-2.lox] [0m[33m// But the super keyword used in test()[0m
-[33m[tester::#QI0] [test-2.lox] [0m[33m// should still have a binding to B[0m
-[33m[tester::#QI0] [test-2.lox] [0mclass C < B {
-[33m[tester::#QI0] [test-2.lox] [0m  say() {
-[33m[tester::#QI0] [test-2.lox] [0m    print "C";
-[33m[tester::#QI0] [test-2.lox] [0m  }
-[33m[tester::#QI0] [test-2.lox] [0m}
-[33m[tester::#QI0] [test-2.lox] [0m
-[33m[tester::#QI0] [test-2.lox] [0mC().say();
-[33m[tester::#QI0] [test-2.lox] [0mC().test(); [33m// expect: A[0m
+[33m[tester::#QI0] [test-2.lox] [0m[0mclass A {[0m
+[33m[tester::#QI0] [test-2.lox] [0m[0m  say() {[0m
+[33m[tester::#QI0] [test-2.lox] [0m[0m    print "A";[0m
+[33m[tester::#QI0] [test-2.lox] [0m[0m  }[0m
+[33m[tester::#QI0] [test-2.lox] [0m[0m}[0m
+[33m[tester::#QI0] [test-2.lox] [0m[0m[0m
+[33m[tester::#QI0] [test-2.lox] [0m[0mclass B < A {[0m
+[33m[tester::#QI0] [test-2.lox] [0m[0m  [33m// test calls say() from A[0m[0m
+[33m[tester::#QI0] [test-2.lox] [0m[0m  test() {[0m
+[33m[tester::#QI0] [test-2.lox] [0m[0m    super.say();[0m
+[33m[tester::#QI0] [test-2.lox] [0m[0m  }[0m
+[33m[tester::#QI0] [test-2.lox] [0m[0m[0m
+[33m[tester::#QI0] [test-2.lox] [0m[0m  say() {[0m
+[33m[tester::#QI0] [test-2.lox] [0m[0m    print "B";[0m
+[33m[tester::#QI0] [test-2.lox] [0m[0m  }[0m
+[33m[tester::#QI0] [test-2.lox] [0m[0m}[0m
+[33m[tester::#QI0] [test-2.lox] [0m[0m[0m
+[33m[tester::#QI0] [test-2.lox] [0m[0m[33m// C inherits test() from B[0m[0m
+[33m[tester::#QI0] [test-2.lox] [0m[0m[33m// But the super keyword used in test()[0m[0m
+[33m[tester::#QI0] [test-2.lox] [0m[0m[33m// should still have a binding to B[0m[0m
+[33m[tester::#QI0] [test-2.lox] [0m[0mclass C < B {[0m
+[33m[tester::#QI0] [test-2.lox] [0m[0m  say() {[0m
+[33m[tester::#QI0] [test-2.lox] [0m[0m    print "C";[0m
+[33m[tester::#QI0] [test-2.lox] [0m[0m  }[0m
+[33m[tester::#QI0] [test-2.lox] [0m[0m}[0m
+[33m[tester::#QI0] [test-2.lox] [0m[0m[0m
+[33m[tester::#QI0] [test-2.lox] [0m[0mC().say();[0m
+[33m[tester::#QI0] [test-2.lox] [0m[0mC().test(); [33m// expect: A[0m[0m
 [33m[tester::#QI0] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mC
-[33m[your_program] [0mA
+[33m[your_program] [0m[0mC[0m
+[33m[your_program] [0m[0mA[0m
 [33m[tester::#QI0] [test-2] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#QI0] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#QI0] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#QI0] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#QI0] [test-3.lox] [0mclass A {
-[33m[tester::#QI0] [test-3.lox] [0m  say() {
-[33m[tester::#QI0] [test-3.lox] [0m    print "A";
-[33m[tester::#QI0] [test-3.lox] [0m  }
-[33m[tester::#QI0] [test-3.lox] [0m}
-[33m[tester::#QI0] [test-3.lox] [0m
-[33m[tester::#QI0] [test-3.lox] [0mclass B < A {
-[33m[tester::#QI0] [test-3.lox] [0m  getClosure() {
-[33m[tester::#QI0] [test-3.lox] [0m    fun closure() {
-[33m[tester::#QI0] [test-3.lox] [0m      super.say();
-[33m[tester::#QI0] [test-3.lox] [0m    }
-[33m[tester::#QI0] [test-3.lox] [0m    return closure;
-[33m[tester::#QI0] [test-3.lox] [0m  }
-[33m[tester::#QI0] [test-3.lox] [0m
-[33m[tester::#QI0] [test-3.lox] [0m  say() {
-[33m[tester::#QI0] [test-3.lox] [0m    print "B";
-[33m[tester::#QI0] [test-3.lox] [0m  }
-[33m[tester::#QI0] [test-3.lox] [0m}
-[33m[tester::#QI0] [test-3.lox] [0m
-[33m[tester::#QI0] [test-3.lox] [0mclass C < B {
-[33m[tester::#QI0] [test-3.lox] [0m  say() {
-[33m[tester::#QI0] [test-3.lox] [0m    print "C";
-[33m[tester::#QI0] [test-3.lox] [0m  }
-[33m[tester::#QI0] [test-3.lox] [0m}
-[33m[tester::#QI0] [test-3.lox] [0m
-[33m[tester::#QI0] [test-3.lox] [0m[33m// C inherits getClosure() from B[0m
-[33m[tester::#QI0] [test-3.lox] [0m[33m// But the super keyword used in getClosure()[0m
-[33m[tester::#QI0] [test-3.lox] [0m[33m// should still have a binding to B[0m
-[33m[tester::#QI0] [test-3.lox] [0mC().getClosure()(); [33m// expect: A[0m
+[33m[tester::#QI0] [test-3.lox] [0m[0mclass A {[0m
+[33m[tester::#QI0] [test-3.lox] [0m[0m  say() {[0m
+[33m[tester::#QI0] [test-3.lox] [0m[0m    print "A";[0m
+[33m[tester::#QI0] [test-3.lox] [0m[0m  }[0m
+[33m[tester::#QI0] [test-3.lox] [0m[0m}[0m
+[33m[tester::#QI0] [test-3.lox] [0m[0m[0m
+[33m[tester::#QI0] [test-3.lox] [0m[0mclass B < A {[0m
+[33m[tester::#QI0] [test-3.lox] [0m[0m  getClosure() {[0m
+[33m[tester::#QI0] [test-3.lox] [0m[0m    fun closure() {[0m
+[33m[tester::#QI0] [test-3.lox] [0m[0m      super.say();[0m
+[33m[tester::#QI0] [test-3.lox] [0m[0m    }[0m
+[33m[tester::#QI0] [test-3.lox] [0m[0m    return closure;[0m
+[33m[tester::#QI0] [test-3.lox] [0m[0m  }[0m
+[33m[tester::#QI0] [test-3.lox] [0m[0m[0m
+[33m[tester::#QI0] [test-3.lox] [0m[0m  say() {[0m
+[33m[tester::#QI0] [test-3.lox] [0m[0m    print "B";[0m
+[33m[tester::#QI0] [test-3.lox] [0m[0m  }[0m
+[33m[tester::#QI0] [test-3.lox] [0m[0m}[0m
+[33m[tester::#QI0] [test-3.lox] [0m[0m[0m
+[33m[tester::#QI0] [test-3.lox] [0m[0mclass C < B {[0m
+[33m[tester::#QI0] [test-3.lox] [0m[0m  say() {[0m
+[33m[tester::#QI0] [test-3.lox] [0m[0m    print "C";[0m
+[33m[tester::#QI0] [test-3.lox] [0m[0m  }[0m
+[33m[tester::#QI0] [test-3.lox] [0m[0m}[0m
+[33m[tester::#QI0] [test-3.lox] [0m[0m[0m
+[33m[tester::#QI0] [test-3.lox] [0m[0m[33m// C inherits getClosure() from B[0m[0m
+[33m[tester::#QI0] [test-3.lox] [0m[0m[33m// But the super keyword used in getClosure()[0m[0m
+[33m[tester::#QI0] [test-3.lox] [0m[0m[33m// should still have a binding to B[0m[0m
+[33m[tester::#QI0] [test-3.lox] [0m[0mC().getClosure()(); [33m// expect: A[0m[0m
 [33m[tester::#QI0] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mA
+[33m[your_program] [0m[0mA[0m
 [33m[tester::#QI0] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#QI0] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#QI0] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#QI0] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#QI0] [test-4.lox] [0mclass Base {
-[33m[tester::#QI0] [test-4.lox] [0m  method() {
-[33m[tester::#QI0] [test-4.lox] [0m    print "Base.method()";
-[33m[tester::#QI0] [test-4.lox] [0m  }
-[33m[tester::#QI0] [test-4.lox] [0m}
-[33m[tester::#QI0] [test-4.lox] [0m
-[33m[tester::#QI0] [test-4.lox] [0m[33m// Parent inherits method from Base[0m
-[33m[tester::#QI0] [test-4.lox] [0mclass Parent < Base {
-[33m[tester::#QI0] [test-4.lox] [0m  method() {
-[33m[tester::#QI0] [test-4.lox] [0m    super.method();
-[33m[tester::#QI0] [test-4.lox] [0m  }
-[33m[tester::#QI0] [test-4.lox] [0m}
-[33m[tester::#QI0] [test-4.lox] [0m
-[33m[tester::#QI0] [test-4.lox] [0m[33m// Child inherits method from Parent[0m
-[33m[tester::#QI0] [test-4.lox] [0mclass Child < Parent {
-[33m[tester::#QI0] [test-4.lox] [0m  method() {
-[33m[tester::#QI0] [test-4.lox] [0m    super.method();
-[33m[tester::#QI0] [test-4.lox] [0m  }
-[33m[tester::#QI0] [test-4.lox] [0m}
-[33m[tester::#QI0] [test-4.lox] [0m
-[33m[tester::#QI0] [test-4.lox] [0mvar parent = Parent();
-[33m[tester::#QI0] [test-4.lox] [0mparent.method(); [33m// expect: Base.method()[0m
-[33m[tester::#QI0] [test-4.lox] [0mvar child = Child();
-[33m[tester::#QI0] [test-4.lox] [0mchild.method(); [33m// expect: Base.method()[0m
+[33m[tester::#QI0] [test-4.lox] [0m[0mclass Base {[0m
+[33m[tester::#QI0] [test-4.lox] [0m[0m  method() {[0m
+[33m[tester::#QI0] [test-4.lox] [0m[0m    print "Base.method()";[0m
+[33m[tester::#QI0] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#QI0] [test-4.lox] [0m[0m}[0m
+[33m[tester::#QI0] [test-4.lox] [0m[0m[0m
+[33m[tester::#QI0] [test-4.lox] [0m[0m[33m// Parent inherits method from Base[0m[0m
+[33m[tester::#QI0] [test-4.lox] [0m[0mclass Parent < Base {[0m
+[33m[tester::#QI0] [test-4.lox] [0m[0m  method() {[0m
+[33m[tester::#QI0] [test-4.lox] [0m[0m    super.method();[0m
+[33m[tester::#QI0] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#QI0] [test-4.lox] [0m[0m}[0m
+[33m[tester::#QI0] [test-4.lox] [0m[0m[0m
+[33m[tester::#QI0] [test-4.lox] [0m[0m[33m// Child inherits method from Parent[0m[0m
+[33m[tester::#QI0] [test-4.lox] [0m[0mclass Child < Parent {[0m
+[33m[tester::#QI0] [test-4.lox] [0m[0m  method() {[0m
+[33m[tester::#QI0] [test-4.lox] [0m[0m    super.method();[0m
+[33m[tester::#QI0] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#QI0] [test-4.lox] [0m[0m}[0m
+[33m[tester::#QI0] [test-4.lox] [0m[0m[0m
+[33m[tester::#QI0] [test-4.lox] [0m[0mvar parent = Parent();[0m
+[33m[tester::#QI0] [test-4.lox] [0m[0mparent.method(); [33m// expect: Base.method()[0m[0m
+[33m[tester::#QI0] [test-4.lox] [0m[0mvar child = Child();[0m
+[33m[tester::#QI0] [test-4.lox] [0m[0mchild.method(); [33m// expect: Base.method()[0m[0m
 [33m[tester::#QI0] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mBase.method()
-[33m[your_program] [0mBase.method()
+[33m[your_program] [0m[0mBase.method()[0m
+[33m[your_program] [0m[0mBase.method()[0m
 [33m[tester::#QI0] [test-4] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#QI0] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#QI0] [0m[92mTest passed.[0m
@@ -530,54 +530,54 @@ Debug = true
 [33m[tester::#IB9] [0m[94mRunning tests for Stage #IB9 (ib9)[0m
 [33m[tester::#IB9] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#IB9] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#IB9] [test-1.lox] [0mclass Foo {
-[33m[tester::#IB9] [test-1.lox] [0m  cook() {
-[33m[tester::#IB9] [test-1.lox] [0m    [33m// Foo is not a subclass[0m
-[33m[tester::#IB9] [test-1.lox] [0m    super.cook(); [33m// expect compile error[0m
-[33m[tester::#IB9] [test-1.lox] [0m  }
-[33m[tester::#IB9] [test-1.lox] [0m}
+[33m[tester::#IB9] [test-1.lox] [0m[0mclass Foo {[0m
+[33m[tester::#IB9] [test-1.lox] [0m[0m  cook() {[0m
+[33m[tester::#IB9] [test-1.lox] [0m[0m    [33m// Foo is not a subclass[0m[0m
+[33m[tester::#IB9] [test-1.lox] [0m[0m    super.cook(); [33m// expect compile error[0m[0m
+[33m[tester::#IB9] [test-1.lox] [0m[0m  }[0m
+[33m[tester::#IB9] [test-1.lox] [0m[0m}[0m
 [33m[tester::#IB9] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 4] Error at 'super': Can't use 'super' in a class with no superclass.
+[33m[your_program] [0m[0m[line 4] Error at 'super': Can't use 'super' in a class with no superclass.[0m
 [33m[tester::#IB9] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#IB9] [test-1] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#IB9] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#IB9] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#IB9] [test-2.lox] [0m[33m// super can't be used outside of a class[0m
-[33m[tester::#IB9] [test-2.lox] [0msuper.notEvenInAClass(); [33m// expect compile error[0m
+[33m[tester::#IB9] [test-2.lox] [0m[0m[33m// super can't be used outside of a class[0m[0m
+[33m[tester::#IB9] [test-2.lox] [0m[0msuper.notEvenInAClass(); [33m// expect compile error[0m[0m
 [33m[tester::#IB9] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 2] Error at 'super': Can't use 'super' outside of a class.
+[33m[your_program] [0m[0m[line 2] Error at 'super': Can't use 'super' outside of a class.[0m
 [33m[tester::#IB9] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#IB9] [test-2] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#IB9] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#IB9] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#IB9] [test-3.lox] [0mclass A {
-[33m[tester::#IB9] [test-3.lox] [0m  method() {}
-[33m[tester::#IB9] [test-3.lox] [0m}
-[33m[tester::#IB9] [test-3.lox] [0m
-[33m[tester::#IB9] [test-3.lox] [0mclass B < A {
-[33m[tester::#IB9] [test-3.lox] [0m  method() {
-[33m[tester::#IB9] [test-3.lox] [0m    [33m// super must be followed by `.`[0m
-[33m[tester::#IB9] [test-3.lox] [0m    [33m// and an expression[0m
-[33m[tester::#IB9] [test-3.lox] [0m    (super).method(); [33m// expect compile error[0m
-[33m[tester::#IB9] [test-3.lox] [0m  }
-[33m[tester::#IB9] [test-3.lox] [0m}
+[33m[tester::#IB9] [test-3.lox] [0m[0mclass A {[0m
+[33m[tester::#IB9] [test-3.lox] [0m[0m  method() {}[0m
+[33m[tester::#IB9] [test-3.lox] [0m[0m}[0m
+[33m[tester::#IB9] [test-3.lox] [0m[0m[0m
+[33m[tester::#IB9] [test-3.lox] [0m[0mclass B < A {[0m
+[33m[tester::#IB9] [test-3.lox] [0m[0m  method() {[0m
+[33m[tester::#IB9] [test-3.lox] [0m[0m    [33m// super must be followed by `.`[0m[0m
+[33m[tester::#IB9] [test-3.lox] [0m[0m    [33m// and an expression[0m[0m
+[33m[tester::#IB9] [test-3.lox] [0m[0m    (super).method(); [33m// expect compile error[0m[0m
+[33m[tester::#IB9] [test-3.lox] [0m[0m  }[0m
+[33m[tester::#IB9] [test-3.lox] [0m[0m}[0m
 [33m[tester::#IB9] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 9] Error at ')': Expect '.' after 'super'.
+[33m[your_program] [0m[0m[line 9] Error at ')': Expect '.' after 'super'.[0m
 [33m[tester::#IB9] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#IB9] [test-3] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#IB9] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#IB9] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#IB9] [test-4.lox] [0mclass A {}
-[33m[tester::#IB9] [test-4.lox] [0m
-[33m[tester::#IB9] [test-4.lox] [0mclass B < A {
-[33m[tester::#IB9] [test-4.lox] [0m  method() {
-[33m[tester::#IB9] [test-4.lox] [0m    [33m// super must be followed by `.`[0m
-[33m[tester::#IB9] [test-4.lox] [0m    [33m// and an expression[0m
-[33m[tester::#IB9] [test-4.lox] [0m    super; [33m// expect compile error[0m
-[33m[tester::#IB9] [test-4.lox] [0m  }
-[33m[tester::#IB9] [test-4.lox] [0m}
+[33m[tester::#IB9] [test-4.lox] [0m[0mclass A {}[0m
+[33m[tester::#IB9] [test-4.lox] [0m[0m[0m
+[33m[tester::#IB9] [test-4.lox] [0m[0mclass B < A {[0m
+[33m[tester::#IB9] [test-4.lox] [0m[0m  method() {[0m
+[33m[tester::#IB9] [test-4.lox] [0m[0m    [33m// super must be followed by `.`[0m[0m
+[33m[tester::#IB9] [test-4.lox] [0m[0m    [33m// and an expression[0m[0m
+[33m[tester::#IB9] [test-4.lox] [0m[0m    super; [33m// expect compile error[0m[0m
+[33m[tester::#IB9] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#IB9] [test-4.lox] [0m[0m}[0m
 [33m[tester::#IB9] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 7] Error at ';': Expect '.' after 'super'.
+[33m[your_program] [0m[0m[line 7] Error at ';': Expect '.' after 'super'.[0m
 [33m[tester::#IB9] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#IB9] [test-4] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#IB9] [0m[92mTest passed.[0m

--- a/internal/test_helpers/fixtures/pass_parsing
+++ b/internal/test_helpers/fixtures/pass_parsing
@@ -3,31 +3,31 @@ Debug = true
 [33m[tester::#WZ8] [0m[94mRunning tests for Stage #WZ8 (wz8)[0m
 [33m[tester::#WZ8] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#WZ8] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#WZ8] [test-1.lox] [0m"foo
+[33m[tester::#WZ8] [test-1.lox] [0m[0m"foo[0m
 [33m[tester::#WZ8] [test-1] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m[line 1] Error: Unterminated string.
-[33m[your_program] [0m[line 1] Error at end: Expect expression.
+[33m[your_program] [0m[0m[line 1] Error: Unterminated string.[0m
+[33m[your_program] [0m[0m[line 1] Error at end: Expect expression.[0m
 [33m[tester::#WZ8] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#WZ8] [test-1] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#WZ8] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#WZ8] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#WZ8] [test-2.lox] [0m(foo
+[33m[tester::#WZ8] [test-2.lox] [0m[0m(foo[0m
 [33m[tester::#WZ8] [test-2] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m[line 1] Error at 'foo': Expect expression.
+[33m[your_program] [0m[0m[line 1] Error at 'foo': Expect expression.[0m
 [33m[tester::#WZ8] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#WZ8] [test-2] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#WZ8] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#WZ8] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#WZ8] [test-3.lox] [0m(49 +)
+[33m[tester::#WZ8] [test-3.lox] [0m[0m(49 +)[0m
 [33m[tester::#WZ8] [test-3] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m[line 1] Error at ')': Expect expression.
+[33m[your_program] [0m[0m[line 1] Error at ')': Expect expression.[0m
 [33m[tester::#WZ8] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#WZ8] [test-3] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#WZ8] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#WZ8] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#WZ8] [test-4.lox] [0m+
+[33m[tester::#WZ8] [test-4.lox] [0m[0m+[0m
 [33m[tester::#WZ8] [test-4] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m[line 1] Error at '+': Expect expression.
+[33m[your_program] [0m[0m[line 1] Error at '+': Expect expression.[0m
 [33m[tester::#WZ8] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#WZ8] [test-4] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#WZ8] [0m[92mTest passed.[0m
@@ -35,30 +35,30 @@ Debug = true
 [33m[tester::#HT8] [0m[94mRunning tests for Stage #HT8 (ht8)[0m
 [33m[tester::#HT8] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#HT8] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#HT8] [test-1.lox] [0m"foo"!="hello"
+[33m[tester::#HT8] [test-1.lox] [0m[0m"foo"!="hello"[0m
 [33m[tester::#HT8] [test-1] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(!= foo hello)
+[33m[your_program] [0m[0m(!= foo hello)[0m
 [33m[tester::#HT8] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#HT8] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#HT8] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#HT8] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#HT8] [test-2.lox] [0m"bar" == "bar"
+[33m[tester::#HT8] [test-2.lox] [0m[0m"bar" == "bar"[0m
 [33m[tester::#HT8] [test-2] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(== bar bar)
+[33m[your_program] [0m[0m(== bar bar)[0m
 [33m[tester::#HT8] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#HT8] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#HT8] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#HT8] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#HT8] [test-3.lox] [0m32 == 56
+[33m[tester::#HT8] [test-3.lox] [0m[0m32 == 56[0m
 [33m[tester::#HT8] [test-3] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(== 32.0 56.0)
+[33m[your_program] [0m[0m(== 32.0 56.0)[0m
 [33m[tester::#HT8] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#HT8] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#HT8] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#HT8] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#HT8] [test-4.lox] [0m(70 != 33) == ((-92 + 75) >= (78 * 90))
+[33m[tester::#HT8] [test-4.lox] [0m[0m(70 != 33) == ((-92 + 75) >= (78 * 90))[0m
 [33m[tester::#HT8] [test-4] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(== (group (!= 70.0 33.0)) (group (>= (group (+ (- 92.0) 75.0)) (group (* 78.0 90.0)))))
+[33m[your_program] [0m[0m(== (group (!= 70.0 33.0)) (group (>= (group (+ (- 92.0) 75.0)) (group (* 78.0 90.0)))))[0m
 [33m[tester::#HT8] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#HT8] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#HT8] [0m[92mTest passed.[0m
@@ -66,30 +66,30 @@ Debug = true
 [33m[tester::#UH4] [0m[94mRunning tests for Stage #UH4 (uh4)[0m
 [33m[tester::#UH4] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#UH4] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#UH4] [test-1.lox] [0m20 > 4
+[33m[tester::#UH4] [test-1.lox] [0m[0m20 > 4[0m
 [33m[tester::#UH4] [test-1] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(> 20.0 4.0)
+[33m[your_program] [0m[0m(> 20.0 4.0)[0m
 [33m[tester::#UH4] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#UH4] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#UH4] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#UH4] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#UH4] [test-2.lox] [0m16 <= 36
+[33m[tester::#UH4] [test-2.lox] [0m[0m16 <= 36[0m
 [33m[tester::#UH4] [test-2] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(<= 16.0 36.0)
+[33m[your_program] [0m[0m(<= 16.0 36.0)[0m
 [33m[tester::#UH4] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#UH4] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#UH4] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#UH4] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#UH4] [test-3.lox] [0m20 < 36 < 52
+[33m[tester::#UH4] [test-3.lox] [0m[0m20 < 36 < 52[0m
 [33m[tester::#UH4] [test-3] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(< (< 20.0 36.0) 52.0)
+[33m[your_program] [0m[0m(< (< 20.0 36.0) 52.0)[0m
 [33m[tester::#UH4] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#UH4] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#UH4] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#UH4] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#UH4] [test-4.lox] [0m(12 - 53) >= -(30 / 19 + 96)
+[33m[tester::#UH4] [test-4.lox] [0m[0m(12 - 53) >= -(30 / 19 + 96)[0m
 [33m[tester::#UH4] [test-4] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(>= (group (- 12.0 53.0)) (- (group (+ (/ 30.0 19.0) 96.0))))
+[33m[your_program] [0m[0m(>= (group (- 12.0 53.0)) (- (group (+ (/ 30.0 19.0) 96.0))))[0m
 [33m[tester::#UH4] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#UH4] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#UH4] [0m[92mTest passed.[0m
@@ -97,30 +97,30 @@ Debug = true
 [33m[tester::#YF2] [0m[94mRunning tests for Stage #YF2 (yf2)[0m
 [33m[tester::#YF2] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#YF2] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YF2] [test-1.lox] [0m"hello" + "world"
+[33m[tester::#YF2] [test-1.lox] [0m[0m"hello" + "world"[0m
 [33m[tester::#YF2] [test-1] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(+ hello world)
+[33m[your_program] [0m[0m(+ hello world)[0m
 [33m[tester::#YF2] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#YF2] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#YF2] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#YF2] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YF2] [test-2.lox] [0m42 - 53 * 67 - 43
+[33m[tester::#YF2] [test-2.lox] [0m[0m42 - 53 * 67 - 43[0m
 [33m[tester::#YF2] [test-2] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(- (- 42.0 (* 53.0 67.0)) 43.0)
+[33m[your_program] [0m[0m(- (- 42.0 (* 53.0 67.0)) 43.0)[0m
 [33m[tester::#YF2] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#YF2] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#YF2] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#YF2] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YF2] [test-3.lox] [0m15 + 70 - 99 / 91
+[33m[tester::#YF2] [test-3.lox] [0m[0m15 + 70 - 99 / 91[0m
 [33m[tester::#YF2] [test-3] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(- (+ 15.0 70.0) (/ 99.0 91.0))
+[33m[your_program] [0m[0m(- (+ 15.0 70.0) (/ 99.0 91.0))[0m
 [33m[tester::#YF2] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#YF2] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#YF2] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#YF2] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YF2] [test-4.lox] [0m(-10 + 69) * (52 * 20) / (95 + 89)
+[33m[tester::#YF2] [test-4.lox] [0m[0m(-10 + 69) * (52 * 20) / (95 + 89)[0m
 [33m[tester::#YF2] [test-4] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(/ (* (group (+ (- 10.0) 69.0)) (group (* 52.0 20.0))) (group (+ 95.0 89.0)))
+[33m[your_program] [0m[0m(/ (* (group (+ (- 10.0) 69.0)) (group (* 52.0 20.0))) (group (+ 95.0 89.0)))[0m
 [33m[tester::#YF2] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#YF2] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#YF2] [0m[92mTest passed.[0m
@@ -128,30 +128,30 @@ Debug = true
 [33m[tester::#WA9] [0m[94mRunning tests for Stage #WA9 (wa9)[0m
 [33m[tester::#WA9] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#WA9] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#WA9] [test-1.lox] [0m64 * 28 / 32
+[33m[tester::#WA9] [test-1.lox] [0m[0m64 * 28 / 32[0m
 [33m[tester::#WA9] [test-1] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(/ (* 64.0 28.0) 32.0)
+[33m[your_program] [0m[0m(/ (* 64.0 28.0) 32.0)[0m
 [33m[tester::#WA9] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#WA9] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#WA9] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#WA9] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#WA9] [test-2.lox] [0m19 / 80 / 32
+[33m[tester::#WA9] [test-2.lox] [0m[0m19 / 80 / 32[0m
 [33m[tester::#WA9] [test-2] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(/ (/ 19.0 80.0) 32.0)
+[33m[your_program] [0m[0m(/ (/ 19.0 80.0) 32.0)[0m
 [33m[tester::#WA9] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#WA9] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#WA9] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#WA9] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#WA9] [test-3.lox] [0m54 * 34 * 77 / 67
+[33m[tester::#WA9] [test-3.lox] [0m[0m54 * 34 * 77 / 67[0m
 [33m[tester::#WA9] [test-3] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(/ (* (* 54.0 34.0) 77.0) 67.0)
+[33m[your_program] [0m[0m(/ (* (* 54.0 34.0) 77.0) 67.0)[0m
 [33m[tester::#WA9] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#WA9] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#WA9] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#WA9] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#WA9] [test-4.lox] [0m(82 * -83 / (80 * 80))
+[33m[tester::#WA9] [test-4.lox] [0m[0m(82 * -83 / (80 * 80))[0m
 [33m[tester::#WA9] [test-4] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(group (/ (* 82.0 (- 83.0)) (group (* 80.0 80.0))))
+[33m[your_program] [0m[0m(group (/ (* 82.0 (- 83.0)) (group (* 80.0 80.0))))[0m
 [33m[tester::#WA9] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#WA9] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#WA9] [0m[92mTest passed.[0m
@@ -159,30 +159,30 @@ Debug = true
 [33m[tester::#MQ1] [0m[94mRunning tests for Stage #MQ1 (mq1)[0m
 [33m[tester::#MQ1] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#MQ1] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#MQ1] [test-1.lox] [0m!true
+[33m[tester::#MQ1] [test-1.lox] [0m[0m!true[0m
 [33m[tester::#MQ1] [test-1] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(! true)
+[33m[your_program] [0m[0m(! true)[0m
 [33m[tester::#MQ1] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#MQ1] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#MQ1] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#MQ1] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#MQ1] [test-2.lox] [0m-82
+[33m[tester::#MQ1] [test-2.lox] [0m[0m-82[0m
 [33m[tester::#MQ1] [test-2] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(- 82.0)
+[33m[your_program] [0m[0m(- 82.0)[0m
 [33m[tester::#MQ1] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#MQ1] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#MQ1] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#MQ1] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#MQ1] [test-3.lox] [0m!!true
+[33m[tester::#MQ1] [test-3.lox] [0m[0m!!true[0m
 [33m[tester::#MQ1] [test-3] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(! (! true))
+[33m[your_program] [0m[0m(! (! true))[0m
 [33m[tester::#MQ1] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#MQ1] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#MQ1] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#MQ1] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#MQ1] [test-4.lox] [0m(!!(true))
+[33m[tester::#MQ1] [test-4.lox] [0m[0m(!!(true))[0m
 [33m[tester::#MQ1] [test-4] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(group (! (! (group true))))
+[33m[your_program] [0m[0m(group (! (! (group true))))[0m
 [33m[tester::#MQ1] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#MQ1] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#MQ1] [0m[92mTest passed.[0m
@@ -190,30 +190,30 @@ Debug = true
 [33m[tester::#XE6] [0m[94mRunning tests for Stage #XE6 (xe6)[0m
 [33m[tester::#XE6] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#XE6] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#XE6] [test-1.lox] [0m("foo")
+[33m[tester::#XE6] [test-1.lox] [0m[0m("foo")[0m
 [33m[tester::#XE6] [test-1] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(group foo)
+[33m[your_program] [0m[0m(group foo)[0m
 [33m[tester::#XE6] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#XE6] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#XE6] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#XE6] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#XE6] [test-2.lox] [0m((true))
+[33m[tester::#XE6] [test-2.lox] [0m[0m((true))[0m
 [33m[tester::#XE6] [test-2] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(group (group true))
+[33m[your_program] [0m[0m(group (group true))[0m
 [33m[tester::#XE6] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#XE6] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#XE6] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#XE6] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#XE6] [test-3.lox] [0m(nil)
+[33m[tester::#XE6] [test-3.lox] [0m[0m(nil)[0m
 [33m[tester::#XE6] [test-3] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(group nil)
+[33m[your_program] [0m[0m(group nil)[0m
 [33m[tester::#XE6] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#XE6] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#XE6] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#XE6] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#XE6] [test-4.lox] [0m(91.72)
+[33m[tester::#XE6] [test-4.lox] [0m[0m(91.72)[0m
 [33m[tester::#XE6] [test-4] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m(group 91.72)
+[33m[your_program] [0m[0m(group 91.72)[0m
 [33m[tester::#XE6] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#XE6] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#XE6] [0m[92mTest passed.[0m
@@ -221,30 +221,30 @@ Debug = true
 [33m[tester::#TH5] [0m[94mRunning tests for Stage #TH5 (th5)[0m
 [33m[tester::#TH5] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#TH5] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#TH5] [test-1.lox] [0m"quz world"
+[33m[tester::#TH5] [test-1.lox] [0m[0m"quz world"[0m
 [33m[tester::#TH5] [test-1] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0mquz world
+[33m[your_program] [0m[0mquz world[0m
 [33m[tester::#TH5] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#TH5] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#TH5] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#TH5] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#TH5] [test-2.lox] [0m"'bar'"
+[33m[tester::#TH5] [test-2.lox] [0m[0m"'bar'"[0m
 [33m[tester::#TH5] [test-2] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m'bar'
+[33m[your_program] [0m[0m'bar'[0m
 [33m[tester::#TH5] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#TH5] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#TH5] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#TH5] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#TH5] [test-3.lox] [0m"[33m// hello"[0m
+[33m[tester::#TH5] [test-3.lox] [0m[0m"[33m// hello"[0m[0m
 [33m[tester::#TH5] [test-3] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m// hello
+[33m[your_program] [0m[0m// hello[0m
 [33m[tester::#TH5] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#TH5] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#TH5] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#TH5] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#TH5] [test-4.lox] [0m"12"
+[33m[tester::#TH5] [test-4.lox] [0m[0m"12"[0m
 [33m[tester::#TH5] [test-4] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m12
+[33m[your_program] [0m[0m12[0m
 [33m[tester::#TH5] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#TH5] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#TH5] [0m[92mTest passed.[0m
@@ -252,23 +252,23 @@ Debug = true
 [33m[tester::#RA8] [0m[94mRunning tests for Stage #RA8 (ra8)[0m
 [33m[tester::#RA8] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#RA8] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#RA8] [test-1.lox] [0m52
+[33m[tester::#RA8] [test-1.lox] [0m[0m52[0m
 [33m[tester::#RA8] [test-1] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m52.0
+[33m[your_program] [0m[0m52.0[0m
 [33m[tester::#RA8] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#RA8] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#RA8] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#RA8] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#RA8] [test-2.lox] [0m0.0
+[33m[tester::#RA8] [test-2.lox] [0m[0m0.0[0m
 [33m[tester::#RA8] [test-2] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m0.0
+[33m[your_program] [0m[0m0.0[0m
 [33m[tester::#RA8] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#RA8] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#RA8] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#RA8] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#RA8] [test-3.lox] [0m89.51
+[33m[tester::#RA8] [test-3.lox] [0m[0m89.51[0m
 [33m[tester::#RA8] [test-3] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0m89.51
+[33m[your_program] [0m[0m89.51[0m
 [33m[tester::#RA8] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#RA8] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#RA8] [0m[92mTest passed.[0m
@@ -276,23 +276,23 @@ Debug = true
 [33m[tester::#SC2] [0m[94mRunning tests for Stage #SC2 (sc2)[0m
 [33m[tester::#SC2] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#SC2] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#SC2] [test-1.lox] [0mtrue
+[33m[tester::#SC2] [test-1.lox] [0m[0mtrue[0m
 [33m[tester::#SC2] [test-1] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0mtrue
+[33m[your_program] [0m[0mtrue[0m
 [33m[tester::#SC2] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#SC2] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#SC2] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#SC2] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#SC2] [test-2.lox] [0mfalse
+[33m[tester::#SC2] [test-2.lox] [0m[0mfalse[0m
 [33m[tester::#SC2] [test-2] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0mfalse
+[33m[your_program] [0m[0mfalse[0m
 [33m[tester::#SC2] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#SC2] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#SC2] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#SC2] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#SC2] [test-3.lox] [0mnil
+[33m[tester::#SC2] [test-3.lox] [0m[0mnil[0m
 [33m[tester::#SC2] [test-3] [0m[94m$ ./your_program.sh parse test.lox[0m
-[33m[your_program] [0mnil
+[33m[your_program] [0m[0mnil[0m
 [33m[tester::#SC2] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#SC2] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#SC2] [0m[92mTest passed.[0m

--- a/internal/test_helpers/fixtures/pass_resolving
+++ b/internal/test_helpers/fixtures/pass_resolving
@@ -3,120 +3,120 @@ Debug = true
 [33m[tester::#DE8] [0m[94mRunning tests for Stage #DE8 (de8)[0m
 [33m[tester::#DE8] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#DE8] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#DE8] [test-1.lox] [0m[33m// This variable is used in the function `f` below.[0m
-[33m[tester::#DE8] [test-1.lox] [0mvar variable = "global";
-[33m[tester::#DE8] [test-1.lox] [0m
-[33m[tester::#DE8] [test-1.lox] [0m{
-[33m[tester::#DE8] [test-1.lox] [0m  fun f() {
-[33m[tester::#DE8] [test-1.lox] [0m    print variable;
-[33m[tester::#DE8] [test-1.lox] [0m  }
-[33m[tester::#DE8] [test-1.lox] [0m
-[33m[tester::#DE8] [test-1.lox] [0m  f(); [33m// this should print "global"[0m
-[33m[tester::#DE8] [test-1.lox] [0m
-[33m[tester::#DE8] [test-1.lox] [0m  [33m// This variable declaration shouldn't affect[0m
-[33m[tester::#DE8] [test-1.lox] [0m  [33m// the usage in `f` above.[0m
-[33m[tester::#DE8] [test-1.lox] [0m  var variable = "local";
-[33m[tester::#DE8] [test-1.lox] [0m
-[33m[tester::#DE8] [test-1.lox] [0m  f(); [33m// this should still print "global"[0m
-[33m[tester::#DE8] [test-1.lox] [0m}
+[33m[tester::#DE8] [test-1.lox] [0m[0m[33m// This variable is used in the function `f` below.[0m[0m
+[33m[tester::#DE8] [test-1.lox] [0m[0mvar variable = "global";[0m
+[33m[tester::#DE8] [test-1.lox] [0m[0m[0m
+[33m[tester::#DE8] [test-1.lox] [0m[0m{[0m
+[33m[tester::#DE8] [test-1.lox] [0m[0m  fun f() {[0m
+[33m[tester::#DE8] [test-1.lox] [0m[0m    print variable;[0m
+[33m[tester::#DE8] [test-1.lox] [0m[0m  }[0m
+[33m[tester::#DE8] [test-1.lox] [0m[0m[0m
+[33m[tester::#DE8] [test-1.lox] [0m[0m  f(); [33m// this should print "global"[0m[0m
+[33m[tester::#DE8] [test-1.lox] [0m[0m[0m
+[33m[tester::#DE8] [test-1.lox] [0m[0m  [33m// This variable declaration shouldn't affect[0m[0m
+[33m[tester::#DE8] [test-1.lox] [0m[0m  [33m// the usage in `f` above.[0m[0m
+[33m[tester::#DE8] [test-1.lox] [0m[0m  var variable = "local";[0m
+[33m[tester::#DE8] [test-1.lox] [0m[0m[0m
+[33m[tester::#DE8] [test-1.lox] [0m[0m  f(); [33m// this should still print "global"[0m[0m
+[33m[tester::#DE8] [test-1.lox] [0m[0m}[0m
 [33m[tester::#DE8] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mglobal
-[33m[your_program] [0mglobal
+[33m[your_program] [0m[0mglobal[0m
+[33m[your_program] [0m[0mglobal[0m
 [33m[tester::#DE8] [test-1] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#DE8] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#DE8] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#DE8] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#DE8] [test-2.lox] [0m[33m// This function is used in the function `f` below.[0m
-[33m[tester::#DE8] [test-2.lox] [0mfun global() {
-[33m[tester::#DE8] [test-2.lox] [0m  print "global";
-[33m[tester::#DE8] [test-2.lox] [0m}
-[33m[tester::#DE8] [test-2.lox] [0m
-[33m[tester::#DE8] [test-2.lox] [0m{
-[33m[tester::#DE8] [test-2.lox] [0m  fun f() {
-[33m[tester::#DE8] [test-2.lox] [0m    global();
-[33m[tester::#DE8] [test-2.lox] [0m  }
-[33m[tester::#DE8] [test-2.lox] [0m
-[33m[tester::#DE8] [test-2.lox] [0m  f(); [33m// this should print "global"[0m
-[33m[tester::#DE8] [test-2.lox] [0m
-[33m[tester::#DE8] [test-2.lox] [0m  [33m// This function declaration shouldn't affect[0m
-[33m[tester::#DE8] [test-2.lox] [0m  [33m// the usage in `f` above.[0m
-[33m[tester::#DE8] [test-2.lox] [0m  fun global() {
-[33m[tester::#DE8] [test-2.lox] [0m    print "local";
-[33m[tester::#DE8] [test-2.lox] [0m  }
-[33m[tester::#DE8] [test-2.lox] [0m
-[33m[tester::#DE8] [test-2.lox] [0m  f(); [33m// this should also print "global"[0m
-[33m[tester::#DE8] [test-2.lox] [0m}
+[33m[tester::#DE8] [test-2.lox] [0m[0m[33m// This function is used in the function `f` below.[0m[0m
+[33m[tester::#DE8] [test-2.lox] [0m[0mfun global() {[0m
+[33m[tester::#DE8] [test-2.lox] [0m[0m  print "global";[0m
+[33m[tester::#DE8] [test-2.lox] [0m[0m}[0m
+[33m[tester::#DE8] [test-2.lox] [0m[0m[0m
+[33m[tester::#DE8] [test-2.lox] [0m[0m{[0m
+[33m[tester::#DE8] [test-2.lox] [0m[0m  fun f() {[0m
+[33m[tester::#DE8] [test-2.lox] [0m[0m    global();[0m
+[33m[tester::#DE8] [test-2.lox] [0m[0m  }[0m
+[33m[tester::#DE8] [test-2.lox] [0m[0m[0m
+[33m[tester::#DE8] [test-2.lox] [0m[0m  f(); [33m// this should print "global"[0m[0m
+[33m[tester::#DE8] [test-2.lox] [0m[0m[0m
+[33m[tester::#DE8] [test-2.lox] [0m[0m  [33m// This function declaration shouldn't affect[0m[0m
+[33m[tester::#DE8] [test-2.lox] [0m[0m  [33m// the usage in `f` above.[0m[0m
+[33m[tester::#DE8] [test-2.lox] [0m[0m  fun global() {[0m
+[33m[tester::#DE8] [test-2.lox] [0m[0m    print "local";[0m
+[33m[tester::#DE8] [test-2.lox] [0m[0m  }[0m
+[33m[tester::#DE8] [test-2.lox] [0m[0m[0m
+[33m[tester::#DE8] [test-2.lox] [0m[0m  f(); [33m// this should also print "global"[0m[0m
+[33m[tester::#DE8] [test-2.lox] [0m[0m}[0m
 [33m[tester::#DE8] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mglobal
-[33m[your_program] [0mglobal
+[33m[your_program] [0m[0mglobal[0m
+[33m[your_program] [0m[0mglobal[0m
 [33m[tester::#DE8] [test-2] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#DE8] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#DE8] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#DE8] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#DE8] [test-3.lox] [0mvar x = "global";
-[33m[tester::#DE8] [test-3.lox] [0m
-[33m[tester::#DE8] [test-3.lox] [0mfun outer() {
-[33m[tester::#DE8] [test-3.lox] [0m  var x = "outer";
-[33m[tester::#DE8] [test-3.lox] [0m
-[33m[tester::#DE8] [test-3.lox] [0m  fun middle() {
-[33m[tester::#DE8] [test-3.lox] [0m    [33m// The `inner` function should capture the[0m
-[33m[tester::#DE8] [test-3.lox] [0m    [33m// variable from the closest outer[0m
-[33m[tester::#DE8] [test-3.lox] [0m    [33m// scope, which is the `outer` function's[0m
-[33m[tester::#DE8] [test-3.lox] [0m    [33m// scope.[0m
-[33m[tester::#DE8] [test-3.lox] [0m    fun inner() {
-[33m[tester::#DE8] [test-3.lox] [0m      print x; [33m// Should capture "outer"[0m
-[33m[tester::#DE8] [test-3.lox] [0m    }
-[33m[tester::#DE8] [test-3.lox] [0m
-[33m[tester::#DE8] [test-3.lox] [0m    inner(); [33m// Should print "outer"[0m
-[33m[tester::#DE8] [test-3.lox] [0m
-[33m[tester::#DE8] [test-3.lox] [0m    [33m// This variable declaration shouldn't affect[0m
-[33m[tester::#DE8] [test-3.lox] [0m    [33m// the usage in `inner` above.[0m
-[33m[tester::#DE8] [test-3.lox] [0m    var x = "middle";
-[33m[tester::#DE8] [test-3.lox] [0m
-[33m[tester::#DE8] [test-3.lox] [0m    inner(); [33m// Should still print "outer"[0m
-[33m[tester::#DE8] [test-3.lox] [0m  }
-[33m[tester::#DE8] [test-3.lox] [0m
-[33m[tester::#DE8] [test-3.lox] [0m  middle();
-[33m[tester::#DE8] [test-3.lox] [0m}
-[33m[tester::#DE8] [test-3.lox] [0m
-[33m[tester::#DE8] [test-3.lox] [0mouter();
+[33m[tester::#DE8] [test-3.lox] [0m[0mvar x = "global";[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0mfun outer() {[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m  var x = "outer";[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m  fun middle() {[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m    [33m// The `inner` function should capture the[0m[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m    [33m// variable from the closest outer[0m[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m    [33m// scope, which is the `outer` function's[0m[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m    [33m// scope.[0m[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m    fun inner() {[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m      print x; [33m// Should capture "outer"[0m[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m    }[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m    inner(); [33m// Should print "outer"[0m[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m    [33m// This variable declaration shouldn't affect[0m[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m    [33m// the usage in `inner` above.[0m[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m    var x = "middle";[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m    inner(); [33m// Should still print "outer"[0m[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m  }[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m  middle();[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m}[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0mouter();[0m
 [33m[tester::#DE8] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mouter
-[33m[your_program] [0mouter
+[33m[your_program] [0m[0mouter[0m
+[33m[your_program] [0m[0mouter[0m
 [33m[tester::#DE8] [test-3] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#DE8] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#DE8] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#DE8] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#DE8] [test-4.lox] [0mvar count = 0;
-[33m[tester::#DE8] [test-4.lox] [0m
-[33m[tester::#DE8] [test-4.lox] [0m{
-[33m[tester::#DE8] [test-4.lox] [0m  [33m// The `counter` function should use the `count`[0m
-[33m[tester::#DE8] [test-4.lox] [0m  [33m// variable from the[0m
-[33m[tester::#DE8] [test-4.lox] [0m  [33m// global scope.[0m
-[33m[tester::#DE8] [test-4.lox] [0m  fun makeCounter() {
-[33m[tester::#DE8] [test-4.lox] [0m    fun counter() {
-[33m[tester::#DE8] [test-4.lox] [0m      [33m// This should increment the `count`[0m
-[33m[tester::#DE8] [test-4.lox] [0m      [33m// variable from the global scope.[0m
-[33m[tester::#DE8] [test-4.lox] [0m      count = count + 1;
-[33m[tester::#DE8] [test-4.lox] [0m      print count;
-[33m[tester::#DE8] [test-4.lox] [0m    }
-[33m[tester::#DE8] [test-4.lox] [0m    return counter;
-[33m[tester::#DE8] [test-4.lox] [0m  }
-[33m[tester::#DE8] [test-4.lox] [0m
-[33m[tester::#DE8] [test-4.lox] [0m  var counter1 = makeCounter();
-[33m[tester::#DE8] [test-4.lox] [0m  counter1(); [33m// Should print 1[0m
-[33m[tester::#DE8] [test-4.lox] [0m  counter1(); [33m// Should print 2[0m
-[33m[tester::#DE8] [test-4.lox] [0m
-[33m[tester::#DE8] [test-4.lox] [0m  [33m// This variable declaration shouldn't affect[0m
-[33m[tester::#DE8] [test-4.lox] [0m  [33m// our counter.[0m
-[33m[tester::#DE8] [test-4.lox] [0m  var count = 0;
-[33m[tester::#DE8] [test-4.lox] [0m
-[33m[tester::#DE8] [test-4.lox] [0m  counter1(); [33m// Should print 3[0m
-[33m[tester::#DE8] [test-4.lox] [0m}
+[33m[tester::#DE8] [test-4.lox] [0m[0mvar count = 0;[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m{[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m  [33m// The `counter` function should use the `count`[0m[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m  [33m// variable from the[0m[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m  [33m// global scope.[0m[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m  fun makeCounter() {[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m    fun counter() {[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m      [33m// This should increment the `count`[0m[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m      [33m// variable from the global scope.[0m[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m      count = count + 1;[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m      print count;[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m    }[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m    return counter;[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m  var counter1 = makeCounter();[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m  counter1(); [33m// Should print 1[0m[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m  counter1(); [33m// Should print 2[0m[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m  [33m// This variable declaration shouldn't affect[0m[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m  [33m// our counter.[0m[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m  var count = 0;[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m  counter1(); [33m// Should print 3[0m[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m}[0m
 [33m[tester::#DE8] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m1
-[33m[your_program] [0m2
-[33m[your_program] [0m3
+[33m[your_program] [0m[0m1[0m
+[33m[your_program] [0m[0m2[0m
+[33m[your_program] [0m[0m3[0m
 [33m[tester::#DE8] [test-4] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#DE8] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#DE8] [0m[92mTest passed.[0m
@@ -124,79 +124,79 @@ Debug = true
 [33m[tester::#PT7] [0m[94mRunning tests for Stage #PT7 (pt7)[0m
 [33m[tester::#PT7] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#PT7] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PT7] [test-1.lox] [0m[33m// First declaration of variable 'a' in global[0m
-[33m[tester::#PT7] [test-1.lox] [0m[33m// scope[0m
-[33m[tester::#PT7] [test-1.lox] [0mvar a = "value";
-[33m[tester::#PT7] [test-1.lox] [0m
-[33m[tester::#PT7] [test-1.lox] [0m[33m// Redeclaring 'a' with its own value should be[0m
-[33m[tester::#PT7] [test-1.lox] [0m[33m// allowed in global scope[0m
-[33m[tester::#PT7] [test-1.lox] [0mvar a = a;
-[33m[tester::#PT7] [test-1.lox] [0mprint a; [33m// this should print "value"[0m
+[33m[tester::#PT7] [test-1.lox] [0m[0m[33m// First declaration of variable 'a' in global[0m[0m
+[33m[tester::#PT7] [test-1.lox] [0m[0m[33m// scope[0m[0m
+[33m[tester::#PT7] [test-1.lox] [0m[0mvar a = "value";[0m
+[33m[tester::#PT7] [test-1.lox] [0m[0m[0m
+[33m[tester::#PT7] [test-1.lox] [0m[0m[33m// Redeclaring 'a' with its own value should be[0m[0m
+[33m[tester::#PT7] [test-1.lox] [0m[0m[33m// allowed in global scope[0m[0m
+[33m[tester::#PT7] [test-1.lox] [0m[0mvar a = a;[0m
+[33m[tester::#PT7] [test-1.lox] [0m[0mprint a; [33m// this should print "value"[0m[0m
 [33m[tester::#PT7] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mvalue
+[33m[your_program] [0m[0mvalue[0m
 [33m[tester::#PT7] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#PT7] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#PT7] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#PT7] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PT7] [test-2.lox] [0m[33m// Declare outer variable 'a' in global scope[0m
-[33m[tester::#PT7] [test-2.lox] [0mvar a = "outer";
-[33m[tester::#PT7] [test-2.lox] [0m
-[33m[tester::#PT7] [test-2.lox] [0m{
-[33m[tester::#PT7] [test-2.lox] [0m  [33m// Attempting to declare local variable'a'[0m
-[33m[tester::#PT7] [test-2.lox] [0m  [33m// initialized with itself[0m
-[33m[tester::#PT7] [test-2.lox] [0m  var a = a; [33m// expect compile error[0m
-[33m[tester::#PT7] [test-2.lox] [0m}
+[33m[tester::#PT7] [test-2.lox] [0m[0m[33m// Declare outer variable 'a' in global scope[0m[0m
+[33m[tester::#PT7] [test-2.lox] [0m[0mvar a = "outer";[0m
+[33m[tester::#PT7] [test-2.lox] [0m[0m[0m
+[33m[tester::#PT7] [test-2.lox] [0m[0m{[0m
+[33m[tester::#PT7] [test-2.lox] [0m[0m  [33m// Attempting to declare local variable'a'[0m[0m
+[33m[tester::#PT7] [test-2.lox] [0m[0m  [33m// initialized with itself[0m[0m
+[33m[tester::#PT7] [test-2.lox] [0m[0m  var a = a; [33m// expect compile error[0m[0m
+[33m[tester::#PT7] [test-2.lox] [0m[0m}[0m
 [33m[tester::#PT7] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 7] Error at 'a': Can't read local variable in its own initializer.
+[33m[your_program] [0m[0m[line 7] Error at 'a': Can't read local variable in its own initializer.[0m
 [33m[tester::#PT7] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#PT7] [test-2] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#PT7] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#PT7] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PT7] [test-3.lox] [0m[33m// Helper function that simply returns its argument[0m
-[33m[tester::#PT7] [test-3.lox] [0mfun returnArg(arg) {
-[33m[tester::#PT7] [test-3.lox] [0m  return arg;
-[33m[tester::#PT7] [test-3.lox] [0m}
-[33m[tester::#PT7] [test-3.lox] [0m
-[33m[tester::#PT7] [test-3.lox] [0m[33m// Declare global variable 'b'[0m
-[33m[tester::#PT7] [test-3.lox] [0mvar b = "global";
-[33m[tester::#PT7] [test-3.lox] [0m
-[33m[tester::#PT7] [test-3.lox] [0m{
-[33m[tester::#PT7] [test-3.lox] [0m  [33m// Local variable declaration[0m
-[33m[tester::#PT7] [test-3.lox] [0m  var a = "first";
-[33m[tester::#PT7] [test-3.lox] [0m
-[33m[tester::#PT7] [test-3.lox] [0m  [33m// Attempting to initialize local variable 'b'[0m
-[33m[tester::#PT7] [test-3.lox] [0m  [33m// using local variable 'b'[0m
-[33m[tester::#PT7] [test-3.lox] [0m  [33m// through a function call[0m
-[33m[tester::#PT7] [test-3.lox] [0m  var b = returnArg(b); [33m// expect compile error[0m
-[33m[tester::#PT7] [test-3.lox] [0m  print b;
-[33m[tester::#PT7] [test-3.lox] [0m}
-[33m[tester::#PT7] [test-3.lox] [0m
-[33m[tester::#PT7] [test-3.lox] [0mvar b = b + " updated";
-[33m[tester::#PT7] [test-3.lox] [0mprint b;
+[33m[tester::#PT7] [test-3.lox] [0m[0m[33m// Helper function that simply returns its argument[0m[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0mfun returnArg(arg) {[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0m  return arg;[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0m}[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0m[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0m[33m// Declare global variable 'b'[0m[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0mvar b = "global";[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0m[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0m{[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0m  [33m// Local variable declaration[0m[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0m  var a = "first";[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0m[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0m  [33m// Attempting to initialize local variable 'b'[0m[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0m  [33m// using local variable 'b'[0m[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0m  [33m// through a function call[0m[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0m  var b = returnArg(b); [33m// expect compile error[0m[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0m  print b;[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0m}[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0m[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0mvar b = b + " updated";[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0mprint b;[0m
 [33m[tester::#PT7] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 16] Error at 'b': Can't read local variable in its own initializer.
+[33m[your_program] [0m[0m[line 16] Error at 'b': Can't read local variable in its own initializer.[0m
 [33m[tester::#PT7] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#PT7] [test-3] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#PT7] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#PT7] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PT7] [test-4.lox] [0mfun outer() {
-[33m[tester::#PT7] [test-4.lox] [0m  [33m// Declare variable 'a' in outer function scope[0m
-[33m[tester::#PT7] [test-4.lox] [0m  var a = "outer";
-[33m[tester::#PT7] [test-4.lox] [0m
-[33m[tester::#PT7] [test-4.lox] [0m  [33m// Inner function with its own scope[0m
-[33m[tester::#PT7] [test-4.lox] [0m  fun inner() {
-[33m[tester::#PT7] [test-4.lox] [0m    [33m// Attempting to declare local 'a' initialized[0m
-[33m[tester::#PT7] [test-4.lox] [0m    [33m// with itself[0m
-[33m[tester::#PT7] [test-4.lox] [0m    var a = a; [33m// expect compile error[0m
-[33m[tester::#PT7] [test-4.lox] [0m    print a;
-[33m[tester::#PT7] [test-4.lox] [0m  }
-[33m[tester::#PT7] [test-4.lox] [0m
-[33m[tester::#PT7] [test-4.lox] [0m  inner();
-[33m[tester::#PT7] [test-4.lox] [0m}
-[33m[tester::#PT7] [test-4.lox] [0m
-[33m[tester::#PT7] [test-4.lox] [0mouter();
+[33m[tester::#PT7] [test-4.lox] [0m[0mfun outer() {[0m
+[33m[tester::#PT7] [test-4.lox] [0m[0m  [33m// Declare variable 'a' in outer function scope[0m[0m
+[33m[tester::#PT7] [test-4.lox] [0m[0m  var a = "outer";[0m
+[33m[tester::#PT7] [test-4.lox] [0m[0m[0m
+[33m[tester::#PT7] [test-4.lox] [0m[0m  [33m// Inner function with its own scope[0m[0m
+[33m[tester::#PT7] [test-4.lox] [0m[0m  fun inner() {[0m
+[33m[tester::#PT7] [test-4.lox] [0m[0m    [33m// Attempting to declare local 'a' initialized[0m[0m
+[33m[tester::#PT7] [test-4.lox] [0m[0m    [33m// with itself[0m[0m
+[33m[tester::#PT7] [test-4.lox] [0m[0m    var a = a; [33m// expect compile error[0m[0m
+[33m[tester::#PT7] [test-4.lox] [0m[0m    print a;[0m
+[33m[tester::#PT7] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#PT7] [test-4.lox] [0m[0m[0m
+[33m[tester::#PT7] [test-4.lox] [0m[0m  inner();[0m
+[33m[tester::#PT7] [test-4.lox] [0m[0m}[0m
+[33m[tester::#PT7] [test-4.lox] [0m[0m[0m
+[33m[tester::#PT7] [test-4.lox] [0m[0mouter();[0m
 [33m[tester::#PT7] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 9] Error at 'a': Can't read local variable in its own initializer.
+[33m[your_program] [0m[0m[line 9] Error at 'a': Can't read local variable in its own initializer.[0m
 [33m[tester::#PT7] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#PT7] [test-4] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#PT7] [0m[92mTest passed.[0m
@@ -204,64 +204,64 @@ Debug = true
 [33m[tester::#PZ7] [0m[94mRunning tests for Stage #PZ7 (pz7)[0m
 [33m[tester::#PZ7] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#PZ7] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PZ7] [test-1.lox] [0m{
-[33m[tester::#PZ7] [test-1.lox] [0m  var a = "value";
-[33m[tester::#PZ7] [test-1.lox] [0m
-[33m[tester::#PZ7] [test-1.lox] [0m  [33m// Attempting to redeclare 'a' in the same scope[0m
-[33m[tester::#PZ7] [test-1.lox] [0m  var a = "other"; [33m// expect compile error[0m
-[33m[tester::#PZ7] [test-1.lox] [0m}
+[33m[tester::#PZ7] [test-1.lox] [0m[0m{[0m
+[33m[tester::#PZ7] [test-1.lox] [0m[0m  var a = "value";[0m
+[33m[tester::#PZ7] [test-1.lox] [0m[0m[0m
+[33m[tester::#PZ7] [test-1.lox] [0m[0m  [33m// Attempting to redeclare 'a' in the same scope[0m[0m
+[33m[tester::#PZ7] [test-1.lox] [0m[0m  var a = "other"; [33m// expect compile error[0m[0m
+[33m[tester::#PZ7] [test-1.lox] [0m[0m}[0m
 [33m[tester::#PZ7] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 5] Error at 'a': Already a variable with this name in this scope.
+[33m[your_program] [0m[0m[line 5] Error at 'a': Already a variable with this name in this scope.[0m
 [33m[tester::#PZ7] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#PZ7] [test-1] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#PZ7] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#PZ7] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PZ7] [test-2.lox] [0m[33m// Function parameters are considered variables in[0m
-[33m[tester::#PZ7] [test-2.lox] [0m[33m// the function's scope[0m
-[33m[tester::#PZ7] [test-2.lox] [0mfun foo(a) {
-[33m[tester::#PZ7] [test-2.lox] [0m  [33m// Attempting to declare a variable with same[0m
-[33m[tester::#PZ7] [test-2.lox] [0m  [33m// name as parameter[0m
-[33m[tester::#PZ7] [test-2.lox] [0m  var a; [33m// expect compile error[0m
-[33m[tester::#PZ7] [test-2.lox] [0m}
+[33m[tester::#PZ7] [test-2.lox] [0m[0m[33m// Function parameters are considered variables in[0m[0m
+[33m[tester::#PZ7] [test-2.lox] [0m[0m[33m// the function's scope[0m[0m
+[33m[tester::#PZ7] [test-2.lox] [0m[0mfun foo(a) {[0m
+[33m[tester::#PZ7] [test-2.lox] [0m[0m  [33m// Attempting to declare a variable with same[0m[0m
+[33m[tester::#PZ7] [test-2.lox] [0m[0m  [33m// name as parameter[0m[0m
+[33m[tester::#PZ7] [test-2.lox] [0m[0m  var a; [33m// expect compile error[0m[0m
+[33m[tester::#PZ7] [test-2.lox] [0m[0m}[0m
 [33m[tester::#PZ7] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 6] Error at 'a': Already a variable with this name in this scope.
+[33m[your_program] [0m[0m[line 6] Error at 'a': Already a variable with this name in this scope.[0m
 [33m[tester::#PZ7] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#PZ7] [test-2] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#PZ7] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#PZ7] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PZ7] [test-3.lox] [0m[33m// Function parameters must have unique names[0m
-[33m[tester::#PZ7] [test-3.lox] [0mfun foo(arg, arg) { [33m// expect compile error[0m
-[33m[tester::#PZ7] [test-3.lox] [0m  [33m// Function body is irrelevant as the error[0m
-[33m[tester::#PZ7] [test-3.lox] [0m  [33m// occurs in parameter list[0m
-[33m[tester::#PZ7] [test-3.lox] [0m  "body";
-[33m[tester::#PZ7] [test-3.lox] [0m}
+[33m[tester::#PZ7] [test-3.lox] [0m[0m[33m// Function parameters must have unique names[0m[0m
+[33m[tester::#PZ7] [test-3.lox] [0m[0mfun foo(arg, arg) { [33m// expect compile error[0m[0m
+[33m[tester::#PZ7] [test-3.lox] [0m[0m  [33m// Function body is irrelevant as the error[0m[0m
+[33m[tester::#PZ7] [test-3.lox] [0m[0m  [33m// occurs in parameter list[0m[0m
+[33m[tester::#PZ7] [test-3.lox] [0m[0m  "body";[0m
+[33m[tester::#PZ7] [test-3.lox] [0m[0m}[0m
 [33m[tester::#PZ7] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 2] Error at 'arg': Already a variable with this name in this scope.
+[33m[your_program] [0m[0m[line 2] Error at 'arg': Already a variable with this name in this scope.[0m
 [33m[tester::#PZ7] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#PZ7] [test-3] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#PZ7] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#PZ7] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PZ7] [test-4.lox] [0m[33m// Due to the compile error on line 17[0m
-[33m[tester::#PZ7] [test-4.lox] [0m[33m// Nothing should be printed[0m
-[33m[tester::#PZ7] [test-4.lox] [0mvar a = "1";
-[33m[tester::#PZ7] [test-4.lox] [0mprint a;
-[33m[tester::#PZ7] [test-4.lox] [0m
-[33m[tester::#PZ7] [test-4.lox] [0mvar a;
-[33m[tester::#PZ7] [test-4.lox] [0mprint a;
-[33m[tester::#PZ7] [test-4.lox] [0m
-[33m[tester::#PZ7] [test-4.lox] [0mvar a = "2";
-[33m[tester::#PZ7] [test-4.lox] [0mprint a;
-[33m[tester::#PZ7] [test-4.lox] [0m
-[33m[tester::#PZ7] [test-4.lox] [0m{
-[33m[tester::#PZ7] [test-4.lox] [0m  [33m// First declaration in local scope[0m
-[33m[tester::#PZ7] [test-4.lox] [0m  var a = "1";
-[33m[tester::#PZ7] [test-4.lox] [0m
-[33m[tester::#PZ7] [test-4.lox] [0m  [33m// Attempting to redeclare in local scope[0m
-[33m[tester::#PZ7] [test-4.lox] [0m  var a = "2"; [33m// This should be a compile error[0m
-[33m[tester::#PZ7] [test-4.lox] [0m  print a;
-[33m[tester::#PZ7] [test-4.lox] [0m}
+[33m[tester::#PZ7] [test-4.lox] [0m[0m[33m// Due to the compile error on line 17[0m[0m
+[33m[tester::#PZ7] [test-4.lox] [0m[0m[33m// Nothing should be printed[0m[0m
+[33m[tester::#PZ7] [test-4.lox] [0m[0mvar a = "1";[0m
+[33m[tester::#PZ7] [test-4.lox] [0m[0mprint a;[0m
+[33m[tester::#PZ7] [test-4.lox] [0m[0m[0m
+[33m[tester::#PZ7] [test-4.lox] [0m[0mvar a;[0m
+[33m[tester::#PZ7] [test-4.lox] [0m[0mprint a;[0m
+[33m[tester::#PZ7] [test-4.lox] [0m[0m[0m
+[33m[tester::#PZ7] [test-4.lox] [0m[0mvar a = "2";[0m
+[33m[tester::#PZ7] [test-4.lox] [0m[0mprint a;[0m
+[33m[tester::#PZ7] [test-4.lox] [0m[0m[0m
+[33m[tester::#PZ7] [test-4.lox] [0m[0m{[0m
+[33m[tester::#PZ7] [test-4.lox] [0m[0m  [33m// First declaration in local scope[0m[0m
+[33m[tester::#PZ7] [test-4.lox] [0m[0m  var a = "1";[0m
+[33m[tester::#PZ7] [test-4.lox] [0m[0m[0m
+[33m[tester::#PZ7] [test-4.lox] [0m[0m  [33m// Attempting to redeclare in local scope[0m[0m
+[33m[tester::#PZ7] [test-4.lox] [0m[0m  var a = "2"; [33m// This should be a compile error[0m[0m
+[33m[tester::#PZ7] [test-4.lox] [0m[0m  print a;[0m
+[33m[tester::#PZ7] [test-4.lox] [0m[0m}[0m
 [33m[tester::#PZ7] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 17] Error at 'a': Already a variable with this name in this scope.
+[33m[your_program] [0m[0m[line 17] Error at 'a': Already a variable with this name in this scope.[0m
 [33m[tester::#PZ7] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#PZ7] [test-4] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#PZ7] [0m[92mTest passed.[0m
@@ -269,79 +269,79 @@ Debug = true
 [33m[tester::#EH3] [0m[94mRunning tests for Stage #EH3 (eh3)[0m
 [33m[tester::#EH3] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#EH3] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#EH3] [test-1.lox] [0mfun foo() {
-[33m[tester::#EH3] [test-1.lox] [0m  [33m// Return statements are allowed within function[0m
-[33m[tester::#EH3] [test-1.lox] [0m  [33m// scope[0m
-[33m[tester::#EH3] [test-1.lox] [0m  return "at function scope is ok";
-[33m[tester::#EH3] [test-1.lox] [0m}
-[33m[tester::#EH3] [test-1.lox] [0m
-[33m[tester::#EH3] [test-1.lox] [0m[33m// Return statements are not allowed at the[0m
-[33m[tester::#EH3] [test-1.lox] [0m[33m// top-level[0m
-[33m[tester::#EH3] [test-1.lox] [0mreturn; [33m// expect compile error[0m
+[33m[tester::#EH3] [test-1.lox] [0m[0mfun foo() {[0m
+[33m[tester::#EH3] [test-1.lox] [0m[0m  [33m// Return statements are allowed within function[0m[0m
+[33m[tester::#EH3] [test-1.lox] [0m[0m  [33m// scope[0m[0m
+[33m[tester::#EH3] [test-1.lox] [0m[0m  return "at function scope is ok";[0m
+[33m[tester::#EH3] [test-1.lox] [0m[0m}[0m
+[33m[tester::#EH3] [test-1.lox] [0m[0m[0m
+[33m[tester::#EH3] [test-1.lox] [0m[0m[33m// Return statements are not allowed at the[0m[0m
+[33m[tester::#EH3] [test-1.lox] [0m[0m[33m// top-level[0m[0m
+[33m[tester::#EH3] [test-1.lox] [0m[0mreturn; [33m// expect compile error[0m[0m
 [33m[tester::#EH3] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 9] Error at 'return': Can't return from top-level code.
+[33m[your_program] [0m[0m[line 9] Error at 'return': Can't return from top-level code.[0m
 [33m[tester::#EH3] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#EH3] [test-1] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#EH3] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#EH3] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#EH3] [test-2.lox] [0mfun foo() {
-[33m[tester::#EH3] [test-2.lox] [0m  if (true) {
-[33m[tester::#EH3] [test-2.lox] [0m    return "early return";
-[33m[tester::#EH3] [test-2.lox] [0m  }
-[33m[tester::#EH3] [test-2.lox] [0m
-[33m[tester::#EH3] [test-2.lox] [0m  for (var i = 0; i < 10; i = i + 1) {
-[33m[tester::#EH3] [test-2.lox] [0m    return "loop return";
-[33m[tester::#EH3] [test-2.lox] [0m  }
-[33m[tester::#EH3] [test-2.lox] [0m}
-[33m[tester::#EH3] [test-2.lox] [0m
-[33m[tester::#EH3] [test-2.lox] [0mif (true) {
-[33m[tester::#EH3] [test-2.lox] [0m  return "conditional return";
-[33m[tester::#EH3] [test-2.lox] [0m  [33m// expect compile error[0m
-[33m[tester::#EH3] [test-2.lox] [0m}
+[33m[tester::#EH3] [test-2.lox] [0m[0mfun foo() {[0m
+[33m[tester::#EH3] [test-2.lox] [0m[0m  if (true) {[0m
+[33m[tester::#EH3] [test-2.lox] [0m[0m    return "early return";[0m
+[33m[tester::#EH3] [test-2.lox] [0m[0m  }[0m
+[33m[tester::#EH3] [test-2.lox] [0m[0m[0m
+[33m[tester::#EH3] [test-2.lox] [0m[0m  for (var i = 0; i < 10; i = i + 1) {[0m
+[33m[tester::#EH3] [test-2.lox] [0m[0m    return "loop return";[0m
+[33m[tester::#EH3] [test-2.lox] [0m[0m  }[0m
+[33m[tester::#EH3] [test-2.lox] [0m[0m}[0m
+[33m[tester::#EH3] [test-2.lox] [0m[0m[0m
+[33m[tester::#EH3] [test-2.lox] [0m[0mif (true) {[0m
+[33m[tester::#EH3] [test-2.lox] [0m[0m  return "conditional return";[0m
+[33m[tester::#EH3] [test-2.lox] [0m[0m  [33m// expect compile error[0m[0m
+[33m[tester::#EH3] [test-2.lox] [0m[0m}[0m
 [33m[tester::#EH3] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 12] Error at 'return': Can't return from top-level code.
+[33m[your_program] [0m[0m[line 12] Error at 'return': Can't return from top-level code.[0m
 [33m[tester::#EH3] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#EH3] [test-2] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#EH3] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#EH3] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#EH3] [test-3.lox] [0m{
-[33m[tester::#EH3] [test-3.lox] [0m  [33m// Return statements are not allowed in[0m
-[33m[tester::#EH3] [test-3.lox] [0m  [33m// top-level blocks[0m
-[33m[tester::#EH3] [test-3.lox] [0m  return "not allowed in a block either";
-[33m[tester::#EH3] [test-3.lox] [0m  [33m// expect compile error[0m
-[33m[tester::#EH3] [test-3.lox] [0m}
-[33m[tester::#EH3] [test-3.lox] [0m
-[33m[tester::#EH3] [test-3.lox] [0mfun allowed() {
-[33m[tester::#EH3] [test-3.lox] [0m  if (true) {
-[33m[tester::#EH3] [test-3.lox] [0m    return "this is fine";
-[33m[tester::#EH3] [test-3.lox] [0m  }
-[33m[tester::#EH3] [test-3.lox] [0m  return;
-[33m[tester::#EH3] [test-3.lox] [0m}
+[33m[tester::#EH3] [test-3.lox] [0m[0m{[0m
+[33m[tester::#EH3] [test-3.lox] [0m[0m  [33m// Return statements are not allowed in[0m[0m
+[33m[tester::#EH3] [test-3.lox] [0m[0m  [33m// top-level blocks[0m[0m
+[33m[tester::#EH3] [test-3.lox] [0m[0m  return "not allowed in a block either";[0m
+[33m[tester::#EH3] [test-3.lox] [0m[0m  [33m// expect compile error[0m[0m
+[33m[tester::#EH3] [test-3.lox] [0m[0m}[0m
+[33m[tester::#EH3] [test-3.lox] [0m[0m[0m
+[33m[tester::#EH3] [test-3.lox] [0m[0mfun allowed() {[0m
+[33m[tester::#EH3] [test-3.lox] [0m[0m  if (true) {[0m
+[33m[tester::#EH3] [test-3.lox] [0m[0m    return "this is fine";[0m
+[33m[tester::#EH3] [test-3.lox] [0m[0m  }[0m
+[33m[tester::#EH3] [test-3.lox] [0m[0m  return;[0m
+[33m[tester::#EH3] [test-3.lox] [0m[0m}[0m
 [33m[tester::#EH3] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 4] Error at 'return': Can't return from top-level code.
+[33m[your_program] [0m[0m[line 4] Error at 'return': Can't return from top-level code.[0m
 [33m[tester::#EH3] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#EH3] [test-3] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#EH3] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#EH3] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#EH3] [test-4.lox] [0mfun outer() {
-[33m[tester::#EH3] [test-4.lox] [0m  fun inner() {
-[33m[tester::#EH3] [test-4.lox] [0m    return "ok";
-[33m[tester::#EH3] [test-4.lox] [0m  }
-[33m[tester::#EH3] [test-4.lox] [0m
-[33m[tester::#EH3] [test-4.lox] [0m  return "also ok";
-[33m[tester::#EH3] [test-4.lox] [0m}
-[33m[tester::#EH3] [test-4.lox] [0m
-[33m[tester::#EH3] [test-4.lox] [0mif (true) {
-[33m[tester::#EH3] [test-4.lox] [0m  fun nested() {
-[33m[tester::#EH3] [test-4.lox] [0m    return;
-[33m[tester::#EH3] [test-4.lox] [0m  }
-[33m[tester::#EH3] [test-4.lox] [0m
-[33m[tester::#EH3] [test-4.lox] [0m  [33m// Return statements are not allowed outside of[0m
-[33m[tester::#EH3] [test-4.lox] [0m  [33m// functions[0m
-[33m[tester::#EH3] [test-4.lox] [0m  return "not ok"; [33m// expect compile error[0m
-[33m[tester::#EH3] [test-4.lox] [0m}
+[33m[tester::#EH3] [test-4.lox] [0m[0mfun outer() {[0m
+[33m[tester::#EH3] [test-4.lox] [0m[0m  fun inner() {[0m
+[33m[tester::#EH3] [test-4.lox] [0m[0m    return "ok";[0m
+[33m[tester::#EH3] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#EH3] [test-4.lox] [0m[0m[0m
+[33m[tester::#EH3] [test-4.lox] [0m[0m  return "also ok";[0m
+[33m[tester::#EH3] [test-4.lox] [0m[0m}[0m
+[33m[tester::#EH3] [test-4.lox] [0m[0m[0m
+[33m[tester::#EH3] [test-4.lox] [0m[0mif (true) {[0m
+[33m[tester::#EH3] [test-4.lox] [0m[0m  fun nested() {[0m
+[33m[tester::#EH3] [test-4.lox] [0m[0m    return;[0m
+[33m[tester::#EH3] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#EH3] [test-4.lox] [0m[0m[0m
+[33m[tester::#EH3] [test-4.lox] [0m[0m  [33m// Return statements are not allowed outside of[0m[0m
+[33m[tester::#EH3] [test-4.lox] [0m[0m  [33m// functions[0m[0m
+[33m[tester::#EH3] [test-4.lox] [0m[0m  return "not ok"; [33m// expect compile error[0m[0m
+[33m[tester::#EH3] [test-4.lox] [0m[0m}[0m
 [33m[tester::#EH3] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 16] Error at 'return': Can't return from top-level code.
+[33m[your_program] [0m[0m[line 16] Error at 'return': Can't return from top-level code.[0m
 [33m[tester::#EH3] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#EH3] [test-4] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#EH3] [0m[92mTest passed.[0m

--- a/internal/test_helpers/fixtures/pass_resolving_final
+++ b/internal/test_helpers/fixtures/pass_resolving_final
@@ -3,120 +3,120 @@ Debug = true
 [33m[tester::#DE8] [0m[94mRunning tests for Stage #DE8 (de8)[0m
 [33m[tester::#DE8] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#DE8] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#DE8] [test-1.lox] [0m[33m// This variable is used in the function `f` below.[0m
-[33m[tester::#DE8] [test-1.lox] [0mvar variable = "global";
-[33m[tester::#DE8] [test-1.lox] [0m
-[33m[tester::#DE8] [test-1.lox] [0m{
-[33m[tester::#DE8] [test-1.lox] [0m  fun f() {
-[33m[tester::#DE8] [test-1.lox] [0m    print variable;
-[33m[tester::#DE8] [test-1.lox] [0m  }
-[33m[tester::#DE8] [test-1.lox] [0m
-[33m[tester::#DE8] [test-1.lox] [0m  f(); [33m// this should print "global"[0m
-[33m[tester::#DE8] [test-1.lox] [0m
-[33m[tester::#DE8] [test-1.lox] [0m  [33m// This variable declaration shouldn't affect[0m
-[33m[tester::#DE8] [test-1.lox] [0m  [33m// the usage in `f` above.[0m
-[33m[tester::#DE8] [test-1.lox] [0m  var variable = "local";
-[33m[tester::#DE8] [test-1.lox] [0m
-[33m[tester::#DE8] [test-1.lox] [0m  f(); [33m// this should still print "global"[0m
-[33m[tester::#DE8] [test-1.lox] [0m}
+[33m[tester::#DE8] [test-1.lox] [0m[0m[33m// This variable is used in the function `f` below.[0m[0m
+[33m[tester::#DE8] [test-1.lox] [0m[0mvar variable = "global";[0m
+[33m[tester::#DE8] [test-1.lox] [0m[0m[0m
+[33m[tester::#DE8] [test-1.lox] [0m[0m{[0m
+[33m[tester::#DE8] [test-1.lox] [0m[0m  fun f() {[0m
+[33m[tester::#DE8] [test-1.lox] [0m[0m    print variable;[0m
+[33m[tester::#DE8] [test-1.lox] [0m[0m  }[0m
+[33m[tester::#DE8] [test-1.lox] [0m[0m[0m
+[33m[tester::#DE8] [test-1.lox] [0m[0m  f(); [33m// this should print "global"[0m[0m
+[33m[tester::#DE8] [test-1.lox] [0m[0m[0m
+[33m[tester::#DE8] [test-1.lox] [0m[0m  [33m// This variable declaration shouldn't affect[0m[0m
+[33m[tester::#DE8] [test-1.lox] [0m[0m  [33m// the usage in `f` above.[0m[0m
+[33m[tester::#DE8] [test-1.lox] [0m[0m  var variable = "local";[0m
+[33m[tester::#DE8] [test-1.lox] [0m[0m[0m
+[33m[tester::#DE8] [test-1.lox] [0m[0m  f(); [33m// this should still print "global"[0m[0m
+[33m[tester::#DE8] [test-1.lox] [0m[0m}[0m
 [33m[tester::#DE8] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mglobal
-[33m[your_program] [0mglobal
+[33m[your_program] [0m[0mglobal[0m
+[33m[your_program] [0m[0mglobal[0m
 [33m[tester::#DE8] [test-1] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#DE8] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#DE8] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#DE8] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#DE8] [test-2.lox] [0m[33m// This function is used in the function `f` below.[0m
-[33m[tester::#DE8] [test-2.lox] [0mfun global() {
-[33m[tester::#DE8] [test-2.lox] [0m  print "global";
-[33m[tester::#DE8] [test-2.lox] [0m}
-[33m[tester::#DE8] [test-2.lox] [0m
-[33m[tester::#DE8] [test-2.lox] [0m{
-[33m[tester::#DE8] [test-2.lox] [0m  fun f() {
-[33m[tester::#DE8] [test-2.lox] [0m    global();
-[33m[tester::#DE8] [test-2.lox] [0m  }
-[33m[tester::#DE8] [test-2.lox] [0m
-[33m[tester::#DE8] [test-2.lox] [0m  f(); [33m// this should print "global"[0m
-[33m[tester::#DE8] [test-2.lox] [0m
-[33m[tester::#DE8] [test-2.lox] [0m  [33m// This function declaration shouldn't affect[0m
-[33m[tester::#DE8] [test-2.lox] [0m  [33m// the usage in `f` above.[0m
-[33m[tester::#DE8] [test-2.lox] [0m  fun global() {
-[33m[tester::#DE8] [test-2.lox] [0m    print "local";
-[33m[tester::#DE8] [test-2.lox] [0m  }
-[33m[tester::#DE8] [test-2.lox] [0m
-[33m[tester::#DE8] [test-2.lox] [0m  f(); [33m// this should also print "global"[0m
-[33m[tester::#DE8] [test-2.lox] [0m}
+[33m[tester::#DE8] [test-2.lox] [0m[0m[33m// This function is used in the function `f` below.[0m[0m
+[33m[tester::#DE8] [test-2.lox] [0m[0mfun global() {[0m
+[33m[tester::#DE8] [test-2.lox] [0m[0m  print "global";[0m
+[33m[tester::#DE8] [test-2.lox] [0m[0m}[0m
+[33m[tester::#DE8] [test-2.lox] [0m[0m[0m
+[33m[tester::#DE8] [test-2.lox] [0m[0m{[0m
+[33m[tester::#DE8] [test-2.lox] [0m[0m  fun f() {[0m
+[33m[tester::#DE8] [test-2.lox] [0m[0m    global();[0m
+[33m[tester::#DE8] [test-2.lox] [0m[0m  }[0m
+[33m[tester::#DE8] [test-2.lox] [0m[0m[0m
+[33m[tester::#DE8] [test-2.lox] [0m[0m  f(); [33m// this should print "global"[0m[0m
+[33m[tester::#DE8] [test-2.lox] [0m[0m[0m
+[33m[tester::#DE8] [test-2.lox] [0m[0m  [33m// This function declaration shouldn't affect[0m[0m
+[33m[tester::#DE8] [test-2.lox] [0m[0m  [33m// the usage in `f` above.[0m[0m
+[33m[tester::#DE8] [test-2.lox] [0m[0m  fun global() {[0m
+[33m[tester::#DE8] [test-2.lox] [0m[0m    print "local";[0m
+[33m[tester::#DE8] [test-2.lox] [0m[0m  }[0m
+[33m[tester::#DE8] [test-2.lox] [0m[0m[0m
+[33m[tester::#DE8] [test-2.lox] [0m[0m  f(); [33m// this should also print "global"[0m[0m
+[33m[tester::#DE8] [test-2.lox] [0m[0m}[0m
 [33m[tester::#DE8] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mglobal
-[33m[your_program] [0mglobal
+[33m[your_program] [0m[0mglobal[0m
+[33m[your_program] [0m[0mglobal[0m
 [33m[tester::#DE8] [test-2] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#DE8] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#DE8] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#DE8] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#DE8] [test-3.lox] [0mvar x = "global";
-[33m[tester::#DE8] [test-3.lox] [0m
-[33m[tester::#DE8] [test-3.lox] [0mfun outer() {
-[33m[tester::#DE8] [test-3.lox] [0m  var x = "outer";
-[33m[tester::#DE8] [test-3.lox] [0m
-[33m[tester::#DE8] [test-3.lox] [0m  fun middle() {
-[33m[tester::#DE8] [test-3.lox] [0m    [33m// The `inner` function should capture the[0m
-[33m[tester::#DE8] [test-3.lox] [0m    [33m// variable from the closest outer[0m
-[33m[tester::#DE8] [test-3.lox] [0m    [33m// scope, which is the `outer` function's[0m
-[33m[tester::#DE8] [test-3.lox] [0m    [33m// scope.[0m
-[33m[tester::#DE8] [test-3.lox] [0m    fun inner() {
-[33m[tester::#DE8] [test-3.lox] [0m      print x; [33m// Should capture "outer"[0m
-[33m[tester::#DE8] [test-3.lox] [0m    }
-[33m[tester::#DE8] [test-3.lox] [0m
-[33m[tester::#DE8] [test-3.lox] [0m    inner(); [33m// Should print "outer"[0m
-[33m[tester::#DE8] [test-3.lox] [0m
-[33m[tester::#DE8] [test-3.lox] [0m    [33m// This variable declaration shouldn't affect[0m
-[33m[tester::#DE8] [test-3.lox] [0m    [33m// the usage in `inner` above.[0m
-[33m[tester::#DE8] [test-3.lox] [0m    var x = "middle";
-[33m[tester::#DE8] [test-3.lox] [0m
-[33m[tester::#DE8] [test-3.lox] [0m    inner(); [33m// Should still print "outer"[0m
-[33m[tester::#DE8] [test-3.lox] [0m  }
-[33m[tester::#DE8] [test-3.lox] [0m
-[33m[tester::#DE8] [test-3.lox] [0m  middle();
-[33m[tester::#DE8] [test-3.lox] [0m}
-[33m[tester::#DE8] [test-3.lox] [0m
-[33m[tester::#DE8] [test-3.lox] [0mouter();
+[33m[tester::#DE8] [test-3.lox] [0m[0mvar x = "global";[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0mfun outer() {[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m  var x = "outer";[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m  fun middle() {[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m    [33m// The `inner` function should capture the[0m[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m    [33m// variable from the closest outer[0m[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m    [33m// scope, which is the `outer` function's[0m[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m    [33m// scope.[0m[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m    fun inner() {[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m      print x; [33m// Should capture "outer"[0m[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m    }[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m    inner(); [33m// Should print "outer"[0m[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m    [33m// This variable declaration shouldn't affect[0m[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m    [33m// the usage in `inner` above.[0m[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m    var x = "middle";[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m    inner(); [33m// Should still print "outer"[0m[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m  }[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m  middle();[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m}[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0m[0m
+[33m[tester::#DE8] [test-3.lox] [0m[0mouter();[0m
 [33m[tester::#DE8] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mouter
-[33m[your_program] [0mouter
+[33m[your_program] [0m[0mouter[0m
+[33m[your_program] [0m[0mouter[0m
 [33m[tester::#DE8] [test-3] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#DE8] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#DE8] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#DE8] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#DE8] [test-4.lox] [0mvar count = 0;
-[33m[tester::#DE8] [test-4.lox] [0m
-[33m[tester::#DE8] [test-4.lox] [0m{
-[33m[tester::#DE8] [test-4.lox] [0m  [33m// The `counter` function should use the `count`[0m
-[33m[tester::#DE8] [test-4.lox] [0m  [33m// variable from the[0m
-[33m[tester::#DE8] [test-4.lox] [0m  [33m// global scope.[0m
-[33m[tester::#DE8] [test-4.lox] [0m  fun makeCounter() {
-[33m[tester::#DE8] [test-4.lox] [0m    fun counter() {
-[33m[tester::#DE8] [test-4.lox] [0m      [33m// This should increment the `count`[0m
-[33m[tester::#DE8] [test-4.lox] [0m      [33m// variable from the global scope.[0m
-[33m[tester::#DE8] [test-4.lox] [0m      count = count + 1;
-[33m[tester::#DE8] [test-4.lox] [0m      print count;
-[33m[tester::#DE8] [test-4.lox] [0m    }
-[33m[tester::#DE8] [test-4.lox] [0m    return counter;
-[33m[tester::#DE8] [test-4.lox] [0m  }
-[33m[tester::#DE8] [test-4.lox] [0m
-[33m[tester::#DE8] [test-4.lox] [0m  var counter1 = makeCounter();
-[33m[tester::#DE8] [test-4.lox] [0m  counter1(); [33m// Should print 1[0m
-[33m[tester::#DE8] [test-4.lox] [0m  counter1(); [33m// Should print 2[0m
-[33m[tester::#DE8] [test-4.lox] [0m
-[33m[tester::#DE8] [test-4.lox] [0m  [33m// This variable declaration shouldn't affect[0m
-[33m[tester::#DE8] [test-4.lox] [0m  [33m// our counter.[0m
-[33m[tester::#DE8] [test-4.lox] [0m  var count = 0;
-[33m[tester::#DE8] [test-4.lox] [0m
-[33m[tester::#DE8] [test-4.lox] [0m  counter1(); [33m// Should print 3[0m
-[33m[tester::#DE8] [test-4.lox] [0m}
+[33m[tester::#DE8] [test-4.lox] [0m[0mvar count = 0;[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m{[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m  [33m// The `counter` function should use the `count`[0m[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m  [33m// variable from the[0m[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m  [33m// global scope.[0m[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m  fun makeCounter() {[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m    fun counter() {[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m      [33m// This should increment the `count`[0m[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m      [33m// variable from the global scope.[0m[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m      count = count + 1;[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m      print count;[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m    }[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m    return counter;[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m  var counter1 = makeCounter();[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m  counter1(); [33m// Should print 1[0m[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m  counter1(); [33m// Should print 2[0m[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m  [33m// This variable declaration shouldn't affect[0m[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m  [33m// our counter.[0m[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m  var count = 0;[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m  counter1(); [33m// Should print 3[0m[0m
+[33m[tester::#DE8] [test-4.lox] [0m[0m}[0m
 [33m[tester::#DE8] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m1
-[33m[your_program] [0m2
-[33m[your_program] [0m3
+[33m[your_program] [0m[0m1[0m
+[33m[your_program] [0m[0m2[0m
+[33m[your_program] [0m[0m3[0m
 [33m[tester::#DE8] [test-4] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#DE8] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#DE8] [0m[92mTest passed.[0m
@@ -124,79 +124,79 @@ Debug = true
 [33m[tester::#PT7] [0m[94mRunning tests for Stage #PT7 (pt7)[0m
 [33m[tester::#PT7] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#PT7] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PT7] [test-1.lox] [0m[33m// First declaration of variable 'a' in global[0m
-[33m[tester::#PT7] [test-1.lox] [0m[33m// scope[0m
-[33m[tester::#PT7] [test-1.lox] [0mvar a = "value";
-[33m[tester::#PT7] [test-1.lox] [0m
-[33m[tester::#PT7] [test-1.lox] [0m[33m// Redeclaring 'a' with its own value should be[0m
-[33m[tester::#PT7] [test-1.lox] [0m[33m// allowed in global scope[0m
-[33m[tester::#PT7] [test-1.lox] [0mvar a = a;
-[33m[tester::#PT7] [test-1.lox] [0mprint a; [33m// this should print "value"[0m
+[33m[tester::#PT7] [test-1.lox] [0m[0m[33m// First declaration of variable 'a' in global[0m[0m
+[33m[tester::#PT7] [test-1.lox] [0m[0m[33m// scope[0m[0m
+[33m[tester::#PT7] [test-1.lox] [0m[0mvar a = "value";[0m
+[33m[tester::#PT7] [test-1.lox] [0m[0m[0m
+[33m[tester::#PT7] [test-1.lox] [0m[0m[33m// Redeclaring 'a' with its own value should be[0m[0m
+[33m[tester::#PT7] [test-1.lox] [0m[0m[33m// allowed in global scope[0m[0m
+[33m[tester::#PT7] [test-1.lox] [0m[0mvar a = a;[0m
+[33m[tester::#PT7] [test-1.lox] [0m[0mprint a; [33m// this should print "value"[0m[0m
 [33m[tester::#PT7] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mvalue
+[33m[your_program] [0m[0mvalue[0m
 [33m[tester::#PT7] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#PT7] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#PT7] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#PT7] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PT7] [test-2.lox] [0m[33m// Declare outer variable 'a' in global scope[0m
-[33m[tester::#PT7] [test-2.lox] [0mvar a = "outer";
-[33m[tester::#PT7] [test-2.lox] [0m
-[33m[tester::#PT7] [test-2.lox] [0m{
-[33m[tester::#PT7] [test-2.lox] [0m  [33m// Attempting to declare local variable'a'[0m
-[33m[tester::#PT7] [test-2.lox] [0m  [33m// initialized with itself[0m
-[33m[tester::#PT7] [test-2.lox] [0m  var a = a; [33m// expect compile error[0m
-[33m[tester::#PT7] [test-2.lox] [0m}
+[33m[tester::#PT7] [test-2.lox] [0m[0m[33m// Declare outer variable 'a' in global scope[0m[0m
+[33m[tester::#PT7] [test-2.lox] [0m[0mvar a = "outer";[0m
+[33m[tester::#PT7] [test-2.lox] [0m[0m[0m
+[33m[tester::#PT7] [test-2.lox] [0m[0m{[0m
+[33m[tester::#PT7] [test-2.lox] [0m[0m  [33m// Attempting to declare local variable'a'[0m[0m
+[33m[tester::#PT7] [test-2.lox] [0m[0m  [33m// initialized with itself[0m[0m
+[33m[tester::#PT7] [test-2.lox] [0m[0m  var a = a; [33m// expect compile error[0m[0m
+[33m[tester::#PT7] [test-2.lox] [0m[0m}[0m
 [33m[tester::#PT7] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 7] Error at 'a': Can't read local variable in its own initializer.
+[33m[your_program] [0m[0m[line 7] Error at 'a': Can't read local variable in its own initializer.[0m
 [33m[tester::#PT7] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#PT7] [test-2] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#PT7] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#PT7] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PT7] [test-3.lox] [0m[33m// Helper function that simply returns its argument[0m
-[33m[tester::#PT7] [test-3.lox] [0mfun returnArg(arg) {
-[33m[tester::#PT7] [test-3.lox] [0m  return arg;
-[33m[tester::#PT7] [test-3.lox] [0m}
-[33m[tester::#PT7] [test-3.lox] [0m
-[33m[tester::#PT7] [test-3.lox] [0m[33m// Declare global variable 'b'[0m
-[33m[tester::#PT7] [test-3.lox] [0mvar b = "global";
-[33m[tester::#PT7] [test-3.lox] [0m
-[33m[tester::#PT7] [test-3.lox] [0m{
-[33m[tester::#PT7] [test-3.lox] [0m  [33m// Local variable declaration[0m
-[33m[tester::#PT7] [test-3.lox] [0m  var a = "first";
-[33m[tester::#PT7] [test-3.lox] [0m
-[33m[tester::#PT7] [test-3.lox] [0m  [33m// Attempting to initialize local variable 'b'[0m
-[33m[tester::#PT7] [test-3.lox] [0m  [33m// using local variable 'b'[0m
-[33m[tester::#PT7] [test-3.lox] [0m  [33m// through a function call[0m
-[33m[tester::#PT7] [test-3.lox] [0m  var b = returnArg(b); [33m// expect compile error[0m
-[33m[tester::#PT7] [test-3.lox] [0m  print b;
-[33m[tester::#PT7] [test-3.lox] [0m}
-[33m[tester::#PT7] [test-3.lox] [0m
-[33m[tester::#PT7] [test-3.lox] [0mvar b = b + " updated";
-[33m[tester::#PT7] [test-3.lox] [0mprint b;
+[33m[tester::#PT7] [test-3.lox] [0m[0m[33m// Helper function that simply returns its argument[0m[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0mfun returnArg(arg) {[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0m  return arg;[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0m}[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0m[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0m[33m// Declare global variable 'b'[0m[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0mvar b = "global";[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0m[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0m{[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0m  [33m// Local variable declaration[0m[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0m  var a = "first";[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0m[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0m  [33m// Attempting to initialize local variable 'b'[0m[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0m  [33m// using local variable 'b'[0m[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0m  [33m// through a function call[0m[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0m  var b = returnArg(b); [33m// expect compile error[0m[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0m  print b;[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0m}[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0m[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0mvar b = b + " updated";[0m
+[33m[tester::#PT7] [test-3.lox] [0m[0mprint b;[0m
 [33m[tester::#PT7] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 16] Error at 'b': Can't read local variable in its own initializer.
+[33m[your_program] [0m[0m[line 16] Error at 'b': Can't read local variable in its own initializer.[0m
 [33m[tester::#PT7] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#PT7] [test-3] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#PT7] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#PT7] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PT7] [test-4.lox] [0mfun outer() {
-[33m[tester::#PT7] [test-4.lox] [0m  [33m// Declare variable 'a' in outer function scope[0m
-[33m[tester::#PT7] [test-4.lox] [0m  var a = "outer";
-[33m[tester::#PT7] [test-4.lox] [0m
-[33m[tester::#PT7] [test-4.lox] [0m  [33m// Inner function with its own scope[0m
-[33m[tester::#PT7] [test-4.lox] [0m  fun inner() {
-[33m[tester::#PT7] [test-4.lox] [0m    [33m// Attempting to declare local 'a' initialized[0m
-[33m[tester::#PT7] [test-4.lox] [0m    [33m// with itself[0m
-[33m[tester::#PT7] [test-4.lox] [0m    var a = a; [33m// expect compile error[0m
-[33m[tester::#PT7] [test-4.lox] [0m    print a;
-[33m[tester::#PT7] [test-4.lox] [0m  }
-[33m[tester::#PT7] [test-4.lox] [0m
-[33m[tester::#PT7] [test-4.lox] [0m  inner();
-[33m[tester::#PT7] [test-4.lox] [0m}
-[33m[tester::#PT7] [test-4.lox] [0m
-[33m[tester::#PT7] [test-4.lox] [0mouter();
+[33m[tester::#PT7] [test-4.lox] [0m[0mfun outer() {[0m
+[33m[tester::#PT7] [test-4.lox] [0m[0m  [33m// Declare variable 'a' in outer function scope[0m[0m
+[33m[tester::#PT7] [test-4.lox] [0m[0m  var a = "outer";[0m
+[33m[tester::#PT7] [test-4.lox] [0m[0m[0m
+[33m[tester::#PT7] [test-4.lox] [0m[0m  [33m// Inner function with its own scope[0m[0m
+[33m[tester::#PT7] [test-4.lox] [0m[0m  fun inner() {[0m
+[33m[tester::#PT7] [test-4.lox] [0m[0m    [33m// Attempting to declare local 'a' initialized[0m[0m
+[33m[tester::#PT7] [test-4.lox] [0m[0m    [33m// with itself[0m[0m
+[33m[tester::#PT7] [test-4.lox] [0m[0m    var a = a; [33m// expect compile error[0m[0m
+[33m[tester::#PT7] [test-4.lox] [0m[0m    print a;[0m
+[33m[tester::#PT7] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#PT7] [test-4.lox] [0m[0m[0m
+[33m[tester::#PT7] [test-4.lox] [0m[0m  inner();[0m
+[33m[tester::#PT7] [test-4.lox] [0m[0m}[0m
+[33m[tester::#PT7] [test-4.lox] [0m[0m[0m
+[33m[tester::#PT7] [test-4.lox] [0m[0mouter();[0m
 [33m[tester::#PT7] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 9] Error at 'a': Can't read local variable in its own initializer.
+[33m[your_program] [0m[0m[line 9] Error at 'a': Can't read local variable in its own initializer.[0m
 [33m[tester::#PT7] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#PT7] [test-4] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#PT7] [0m[92mTest passed.[0m
@@ -204,64 +204,64 @@ Debug = true
 [33m[tester::#PZ7] [0m[94mRunning tests for Stage #PZ7 (pz7)[0m
 [33m[tester::#PZ7] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#PZ7] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PZ7] [test-1.lox] [0m{
-[33m[tester::#PZ7] [test-1.lox] [0m  var a = "value";
-[33m[tester::#PZ7] [test-1.lox] [0m
-[33m[tester::#PZ7] [test-1.lox] [0m  [33m// Attempting to redeclare 'a' in the same scope[0m
-[33m[tester::#PZ7] [test-1.lox] [0m  var a = "other"; [33m// expect compile error[0m
-[33m[tester::#PZ7] [test-1.lox] [0m}
+[33m[tester::#PZ7] [test-1.lox] [0m[0m{[0m
+[33m[tester::#PZ7] [test-1.lox] [0m[0m  var a = "value";[0m
+[33m[tester::#PZ7] [test-1.lox] [0m[0m[0m
+[33m[tester::#PZ7] [test-1.lox] [0m[0m  [33m// Attempting to redeclare 'a' in the same scope[0m[0m
+[33m[tester::#PZ7] [test-1.lox] [0m[0m  var a = "other"; [33m// expect compile error[0m[0m
+[33m[tester::#PZ7] [test-1.lox] [0m[0m}[0m
 [33m[tester::#PZ7] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 5] Error at 'a': Already a variable with this name in this scope.
+[33m[your_program] [0m[0m[line 5] Error at 'a': Already a variable with this name in this scope.[0m
 [33m[tester::#PZ7] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#PZ7] [test-1] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#PZ7] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#PZ7] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PZ7] [test-2.lox] [0m[33m// Function parameters are considered variables in[0m
-[33m[tester::#PZ7] [test-2.lox] [0m[33m// the function's scope[0m
-[33m[tester::#PZ7] [test-2.lox] [0mfun foo(a) {
-[33m[tester::#PZ7] [test-2.lox] [0m  [33m// Attempting to declare a variable with same[0m
-[33m[tester::#PZ7] [test-2.lox] [0m  [33m// name as parameter[0m
-[33m[tester::#PZ7] [test-2.lox] [0m  var a; [33m// expect compile error[0m
-[33m[tester::#PZ7] [test-2.lox] [0m}
+[33m[tester::#PZ7] [test-2.lox] [0m[0m[33m// Function parameters are considered variables in[0m[0m
+[33m[tester::#PZ7] [test-2.lox] [0m[0m[33m// the function's scope[0m[0m
+[33m[tester::#PZ7] [test-2.lox] [0m[0mfun foo(a) {[0m
+[33m[tester::#PZ7] [test-2.lox] [0m[0m  [33m// Attempting to declare a variable with same[0m[0m
+[33m[tester::#PZ7] [test-2.lox] [0m[0m  [33m// name as parameter[0m[0m
+[33m[tester::#PZ7] [test-2.lox] [0m[0m  var a; [33m// expect compile error[0m[0m
+[33m[tester::#PZ7] [test-2.lox] [0m[0m}[0m
 [33m[tester::#PZ7] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 6] Error at 'a': Already a variable with this name in this scope.
+[33m[your_program] [0m[0m[line 6] Error at 'a': Already a variable with this name in this scope.[0m
 [33m[tester::#PZ7] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#PZ7] [test-2] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#PZ7] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#PZ7] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PZ7] [test-3.lox] [0m[33m// Function parameters must have unique names[0m
-[33m[tester::#PZ7] [test-3.lox] [0mfun foo(arg, arg) { [33m// expect compile error[0m
-[33m[tester::#PZ7] [test-3.lox] [0m  [33m// Function body is irrelevant as the error[0m
-[33m[tester::#PZ7] [test-3.lox] [0m  [33m// occurs in parameter list[0m
-[33m[tester::#PZ7] [test-3.lox] [0m  "body";
-[33m[tester::#PZ7] [test-3.lox] [0m}
+[33m[tester::#PZ7] [test-3.lox] [0m[0m[33m// Function parameters must have unique names[0m[0m
+[33m[tester::#PZ7] [test-3.lox] [0m[0mfun foo(arg, arg) { [33m// expect compile error[0m[0m
+[33m[tester::#PZ7] [test-3.lox] [0m[0m  [33m// Function body is irrelevant as the error[0m[0m
+[33m[tester::#PZ7] [test-3.lox] [0m[0m  [33m// occurs in parameter list[0m[0m
+[33m[tester::#PZ7] [test-3.lox] [0m[0m  "body";[0m
+[33m[tester::#PZ7] [test-3.lox] [0m[0m}[0m
 [33m[tester::#PZ7] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 2] Error at 'arg': Already a variable with this name in this scope.
+[33m[your_program] [0m[0m[line 2] Error at 'arg': Already a variable with this name in this scope.[0m
 [33m[tester::#PZ7] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#PZ7] [test-3] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#PZ7] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#PZ7] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PZ7] [test-4.lox] [0m[33m// Due to the compile error on line 17[0m
-[33m[tester::#PZ7] [test-4.lox] [0m[33m// Nothing should be printed[0m
-[33m[tester::#PZ7] [test-4.lox] [0mvar a = "1";
-[33m[tester::#PZ7] [test-4.lox] [0mprint a;
-[33m[tester::#PZ7] [test-4.lox] [0m
-[33m[tester::#PZ7] [test-4.lox] [0mvar a;
-[33m[tester::#PZ7] [test-4.lox] [0mprint a;
-[33m[tester::#PZ7] [test-4.lox] [0m
-[33m[tester::#PZ7] [test-4.lox] [0mvar a = "2";
-[33m[tester::#PZ7] [test-4.lox] [0mprint a;
-[33m[tester::#PZ7] [test-4.lox] [0m
-[33m[tester::#PZ7] [test-4.lox] [0m{
-[33m[tester::#PZ7] [test-4.lox] [0m  [33m// First declaration in local scope[0m
-[33m[tester::#PZ7] [test-4.lox] [0m  var a = "1";
-[33m[tester::#PZ7] [test-4.lox] [0m
-[33m[tester::#PZ7] [test-4.lox] [0m  [33m// Attempting to redeclare in local scope[0m
-[33m[tester::#PZ7] [test-4.lox] [0m  var a = "2"; [33m// This should be a compile error[0m
-[33m[tester::#PZ7] [test-4.lox] [0m  print a;
-[33m[tester::#PZ7] [test-4.lox] [0m}
+[33m[tester::#PZ7] [test-4.lox] [0m[0m[33m// Due to the compile error on line 17[0m[0m
+[33m[tester::#PZ7] [test-4.lox] [0m[0m[33m// Nothing should be printed[0m[0m
+[33m[tester::#PZ7] [test-4.lox] [0m[0mvar a = "1";[0m
+[33m[tester::#PZ7] [test-4.lox] [0m[0mprint a;[0m
+[33m[tester::#PZ7] [test-4.lox] [0m[0m[0m
+[33m[tester::#PZ7] [test-4.lox] [0m[0mvar a;[0m
+[33m[tester::#PZ7] [test-4.lox] [0m[0mprint a;[0m
+[33m[tester::#PZ7] [test-4.lox] [0m[0m[0m
+[33m[tester::#PZ7] [test-4.lox] [0m[0mvar a = "2";[0m
+[33m[tester::#PZ7] [test-4.lox] [0m[0mprint a;[0m
+[33m[tester::#PZ7] [test-4.lox] [0m[0m[0m
+[33m[tester::#PZ7] [test-4.lox] [0m[0m{[0m
+[33m[tester::#PZ7] [test-4.lox] [0m[0m  [33m// First declaration in local scope[0m[0m
+[33m[tester::#PZ7] [test-4.lox] [0m[0m  var a = "1";[0m
+[33m[tester::#PZ7] [test-4.lox] [0m[0m[0m
+[33m[tester::#PZ7] [test-4.lox] [0m[0m  [33m// Attempting to redeclare in local scope[0m[0m
+[33m[tester::#PZ7] [test-4.lox] [0m[0m  var a = "2"; [33m// This should be a compile error[0m[0m
+[33m[tester::#PZ7] [test-4.lox] [0m[0m  print a;[0m
+[33m[tester::#PZ7] [test-4.lox] [0m[0m}[0m
 [33m[tester::#PZ7] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 17] Error at 'a': Already a variable with this name in this scope.
+[33m[your_program] [0m[0m[line 17] Error at 'a': Already a variable with this name in this scope.[0m
 [33m[tester::#PZ7] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#PZ7] [test-4] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#PZ7] [0m[92mTest passed.[0m
@@ -269,79 +269,79 @@ Debug = true
 [33m[tester::#EH3] [0m[94mRunning tests for Stage #EH3 (eh3)[0m
 [33m[tester::#EH3] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#EH3] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#EH3] [test-1.lox] [0mfun foo() {
-[33m[tester::#EH3] [test-1.lox] [0m  [33m// Return statements are allowed within function[0m
-[33m[tester::#EH3] [test-1.lox] [0m  [33m// scope[0m
-[33m[tester::#EH3] [test-1.lox] [0m  return "at function scope is ok";
-[33m[tester::#EH3] [test-1.lox] [0m}
-[33m[tester::#EH3] [test-1.lox] [0m
-[33m[tester::#EH3] [test-1.lox] [0m[33m// Return statements are not allowed at the[0m
-[33m[tester::#EH3] [test-1.lox] [0m[33m// top-level[0m
-[33m[tester::#EH3] [test-1.lox] [0mreturn; [33m// expect compile error[0m
+[33m[tester::#EH3] [test-1.lox] [0m[0mfun foo() {[0m
+[33m[tester::#EH3] [test-1.lox] [0m[0m  [33m// Return statements are allowed within function[0m[0m
+[33m[tester::#EH3] [test-1.lox] [0m[0m  [33m// scope[0m[0m
+[33m[tester::#EH3] [test-1.lox] [0m[0m  return "at function scope is ok";[0m
+[33m[tester::#EH3] [test-1.lox] [0m[0m}[0m
+[33m[tester::#EH3] [test-1.lox] [0m[0m[0m
+[33m[tester::#EH3] [test-1.lox] [0m[0m[33m// Return statements are not allowed at the[0m[0m
+[33m[tester::#EH3] [test-1.lox] [0m[0m[33m// top-level[0m[0m
+[33m[tester::#EH3] [test-1.lox] [0m[0mreturn; [33m// expect compile error[0m[0m
 [33m[tester::#EH3] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 9] Error at 'return': Can't return from top-level code.
+[33m[your_program] [0m[0m[line 9] Error at 'return': Can't return from top-level code.[0m
 [33m[tester::#EH3] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#EH3] [test-1] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#EH3] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#EH3] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#EH3] [test-2.lox] [0mfun foo() {
-[33m[tester::#EH3] [test-2.lox] [0m  if (true) {
-[33m[tester::#EH3] [test-2.lox] [0m    return "early return";
-[33m[tester::#EH3] [test-2.lox] [0m  }
-[33m[tester::#EH3] [test-2.lox] [0m
-[33m[tester::#EH3] [test-2.lox] [0m  for (var i = 0; i < 10; i = i + 1) {
-[33m[tester::#EH3] [test-2.lox] [0m    return "loop return";
-[33m[tester::#EH3] [test-2.lox] [0m  }
-[33m[tester::#EH3] [test-2.lox] [0m}
-[33m[tester::#EH3] [test-2.lox] [0m
-[33m[tester::#EH3] [test-2.lox] [0mif (true) {
-[33m[tester::#EH3] [test-2.lox] [0m  return "conditional return";
-[33m[tester::#EH3] [test-2.lox] [0m  [33m// expect compile error[0m
-[33m[tester::#EH3] [test-2.lox] [0m}
+[33m[tester::#EH3] [test-2.lox] [0m[0mfun foo() {[0m
+[33m[tester::#EH3] [test-2.lox] [0m[0m  if (true) {[0m
+[33m[tester::#EH3] [test-2.lox] [0m[0m    return "early return";[0m
+[33m[tester::#EH3] [test-2.lox] [0m[0m  }[0m
+[33m[tester::#EH3] [test-2.lox] [0m[0m[0m
+[33m[tester::#EH3] [test-2.lox] [0m[0m  for (var i = 0; i < 10; i = i + 1) {[0m
+[33m[tester::#EH3] [test-2.lox] [0m[0m    return "loop return";[0m
+[33m[tester::#EH3] [test-2.lox] [0m[0m  }[0m
+[33m[tester::#EH3] [test-2.lox] [0m[0m}[0m
+[33m[tester::#EH3] [test-2.lox] [0m[0m[0m
+[33m[tester::#EH3] [test-2.lox] [0m[0mif (true) {[0m
+[33m[tester::#EH3] [test-2.lox] [0m[0m  return "conditional return";[0m
+[33m[tester::#EH3] [test-2.lox] [0m[0m  [33m// expect compile error[0m[0m
+[33m[tester::#EH3] [test-2.lox] [0m[0m}[0m
 [33m[tester::#EH3] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 12] Error at 'return': Can't return from top-level code.
+[33m[your_program] [0m[0m[line 12] Error at 'return': Can't return from top-level code.[0m
 [33m[tester::#EH3] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#EH3] [test-2] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#EH3] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#EH3] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#EH3] [test-3.lox] [0m{
-[33m[tester::#EH3] [test-3.lox] [0m  [33m// Return statements are not allowed in[0m
-[33m[tester::#EH3] [test-3.lox] [0m  [33m// top-level blocks[0m
-[33m[tester::#EH3] [test-3.lox] [0m  return "not allowed in a block either";
-[33m[tester::#EH3] [test-3.lox] [0m  [33m// expect compile error[0m
-[33m[tester::#EH3] [test-3.lox] [0m}
-[33m[tester::#EH3] [test-3.lox] [0m
-[33m[tester::#EH3] [test-3.lox] [0mfun allowed() {
-[33m[tester::#EH3] [test-3.lox] [0m  if (true) {
-[33m[tester::#EH3] [test-3.lox] [0m    return "this is fine";
-[33m[tester::#EH3] [test-3.lox] [0m  }
-[33m[tester::#EH3] [test-3.lox] [0m  return;
-[33m[tester::#EH3] [test-3.lox] [0m}
+[33m[tester::#EH3] [test-3.lox] [0m[0m{[0m
+[33m[tester::#EH3] [test-3.lox] [0m[0m  [33m// Return statements are not allowed in[0m[0m
+[33m[tester::#EH3] [test-3.lox] [0m[0m  [33m// top-level blocks[0m[0m
+[33m[tester::#EH3] [test-3.lox] [0m[0m  return "not allowed in a block either";[0m
+[33m[tester::#EH3] [test-3.lox] [0m[0m  [33m// expect compile error[0m[0m
+[33m[tester::#EH3] [test-3.lox] [0m[0m}[0m
+[33m[tester::#EH3] [test-3.lox] [0m[0m[0m
+[33m[tester::#EH3] [test-3.lox] [0m[0mfun allowed() {[0m
+[33m[tester::#EH3] [test-3.lox] [0m[0m  if (true) {[0m
+[33m[tester::#EH3] [test-3.lox] [0m[0m    return "this is fine";[0m
+[33m[tester::#EH3] [test-3.lox] [0m[0m  }[0m
+[33m[tester::#EH3] [test-3.lox] [0m[0m  return;[0m
+[33m[tester::#EH3] [test-3.lox] [0m[0m}[0m
 [33m[tester::#EH3] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 4] Error at 'return': Can't return from top-level code.
+[33m[your_program] [0m[0m[line 4] Error at 'return': Can't return from top-level code.[0m
 [33m[tester::#EH3] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#EH3] [test-3] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#EH3] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#EH3] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#EH3] [test-4.lox] [0mfun outer() {
-[33m[tester::#EH3] [test-4.lox] [0m  fun inner() {
-[33m[tester::#EH3] [test-4.lox] [0m    return "ok";
-[33m[tester::#EH3] [test-4.lox] [0m  }
-[33m[tester::#EH3] [test-4.lox] [0m
-[33m[tester::#EH3] [test-4.lox] [0m  return "also ok";
-[33m[tester::#EH3] [test-4.lox] [0m}
-[33m[tester::#EH3] [test-4.lox] [0m
-[33m[tester::#EH3] [test-4.lox] [0mif (true) {
-[33m[tester::#EH3] [test-4.lox] [0m  fun nested() {
-[33m[tester::#EH3] [test-4.lox] [0m    return;
-[33m[tester::#EH3] [test-4.lox] [0m  }
-[33m[tester::#EH3] [test-4.lox] [0m
-[33m[tester::#EH3] [test-4.lox] [0m  [33m// Return statements are not allowed outside of[0m
-[33m[tester::#EH3] [test-4.lox] [0m  [33m// functions[0m
-[33m[tester::#EH3] [test-4.lox] [0m  return "not ok"; [33m// expect compile error[0m
-[33m[tester::#EH3] [test-4.lox] [0m}
+[33m[tester::#EH3] [test-4.lox] [0m[0mfun outer() {[0m
+[33m[tester::#EH3] [test-4.lox] [0m[0m  fun inner() {[0m
+[33m[tester::#EH3] [test-4.lox] [0m[0m    return "ok";[0m
+[33m[tester::#EH3] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#EH3] [test-4.lox] [0m[0m[0m
+[33m[tester::#EH3] [test-4.lox] [0m[0m  return "also ok";[0m
+[33m[tester::#EH3] [test-4.lox] [0m[0m}[0m
+[33m[tester::#EH3] [test-4.lox] [0m[0m[0m
+[33m[tester::#EH3] [test-4.lox] [0m[0mif (true) {[0m
+[33m[tester::#EH3] [test-4.lox] [0m[0m  fun nested() {[0m
+[33m[tester::#EH3] [test-4.lox] [0m[0m    return;[0m
+[33m[tester::#EH3] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#EH3] [test-4.lox] [0m[0m[0m
+[33m[tester::#EH3] [test-4.lox] [0m[0m  [33m// Return statements are not allowed outside of[0m[0m
+[33m[tester::#EH3] [test-4.lox] [0m[0m  [33m// functions[0m[0m
+[33m[tester::#EH3] [test-4.lox] [0m[0m  return "not ok"; [33m// expect compile error[0m[0m
+[33m[tester::#EH3] [test-4.lox] [0m[0m}[0m
 [33m[tester::#EH3] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 16] Error at 'return': Can't return from top-level code.
+[33m[your_program] [0m[0m[line 16] Error at 'return': Can't return from top-level code.[0m
 [33m[tester::#EH3] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#EH3] [test-4] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#EH3] [0m[92mTest passed.[0m

--- a/internal/test_helpers/fixtures/pass_scanning
+++ b/internal/test_helpers/fixtures/pass_scanning
@@ -3,137 +3,137 @@ Debug = true
 [33m[tester::#PQ5] [0m[94mRunning tests for Stage #PQ5 (pq5)[0m
 [33m[tester::#PQ5] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#PQ5] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PQ5] [test-1.lox] [0mand
+[33m[tester::#PQ5] [test-1.lox] [0m[0mand[0m
 [33m[tester::#PQ5] [test-1] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mAND and null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mAND and null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#PQ5] [test-1] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#PQ5] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#PQ5] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#PQ5] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PQ5] [test-2.lox] [0mprint else IF FALSE if FOR FUN CLASS or var false VAR AND fun SUPER RETURN while return and TRUE OR true super this THIS PRINT NIL nil WHILE for ELSE class
+[33m[tester::#PQ5] [test-2.lox] [0m[0mprint else IF FALSE if FOR FUN CLASS or var false VAR AND fun SUPER RETURN while return and TRUE OR true super this THIS PRINT NIL nil WHILE for ELSE class[0m
 [33m[tester::#PQ5] [test-2] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mPRINT print null
-[33m[your_program] [0mELSE else null
-[33m[your_program] [0mIDENTIFIER IF null
-[33m[your_program] [0mIDENTIFIER FALSE null
-[33m[your_program] [0mIF if null
-[33m[your_program] [0mIDENTIFIER FOR null
-[33m[your_program] [0mIDENTIFIER FUN null
-[33m[your_program] [0mIDENTIFIER CLASS null
-[33m[your_program] [0mOR or null
-[33m[your_program] [0mVAR var null
-[33m[your_program] [0mFALSE false null
-[33m[your_program] [0mIDENTIFIER VAR null
-[33m[your_program] [0mIDENTIFIER AND null
-[33m[your_program] [0mFUN fun null
-[33m[your_program] [0mIDENTIFIER SUPER null
-[33m[your_program] [0mIDENTIFIER RETURN null
-[33m[your_program] [0mWHILE while null
-[33m[your_program] [0mRETURN return null
-[33m[your_program] [0mAND and null
-[33m[your_program] [0mIDENTIFIER TRUE null
-[33m[your_program] [0mIDENTIFIER OR null
-[33m[your_program] [0mTRUE true null
-[33m[your_program] [0mSUPER super null
-[33m[your_program] [0mTHIS this null
-[33m[your_program] [0mIDENTIFIER THIS null
-[33m[your_program] [0mIDENTIFIER PRINT null
-[33m[your_program] [0mIDENTIFIER NIL null
-[33m[your_program] [0mNIL nil null
-[33m[your_program] [0mIDENTIFIER WHILE null
-[33m[your_program] [0mFOR for null
-[33m[your_program] [0mIDENTIFIER ELSE null
-[33m[your_program] [0mCLASS class null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mPRINT print null[0m
+[33m[your_program] [0m[0mELSE else null[0m
+[33m[your_program] [0m[0mIDENTIFIER IF null[0m
+[33m[your_program] [0m[0mIDENTIFIER FALSE null[0m
+[33m[your_program] [0m[0mIF if null[0m
+[33m[your_program] [0m[0mIDENTIFIER FOR null[0m
+[33m[your_program] [0m[0mIDENTIFIER FUN null[0m
+[33m[your_program] [0m[0mIDENTIFIER CLASS null[0m
+[33m[your_program] [0m[0mOR or null[0m
+[33m[your_program] [0m[0mVAR var null[0m
+[33m[your_program] [0m[0mFALSE false null[0m
+[33m[your_program] [0m[0mIDENTIFIER VAR null[0m
+[33m[your_program] [0m[0mIDENTIFIER AND null[0m
+[33m[your_program] [0m[0mFUN fun null[0m
+[33m[your_program] [0m[0mIDENTIFIER SUPER null[0m
+[33m[your_program] [0m[0mIDENTIFIER RETURN null[0m
+[33m[your_program] [0m[0mWHILE while null[0m
+[33m[your_program] [0m[0mRETURN return null[0m
+[33m[your_program] [0m[0mAND and null[0m
+[33m[your_program] [0m[0mIDENTIFIER TRUE null[0m
+[33m[your_program] [0m[0mIDENTIFIER OR null[0m
+[33m[your_program] [0m[0mTRUE true null[0m
+[33m[your_program] [0m[0mSUPER super null[0m
+[33m[your_program] [0m[0mTHIS this null[0m
+[33m[your_program] [0m[0mIDENTIFIER THIS null[0m
+[33m[your_program] [0m[0mIDENTIFIER PRINT null[0m
+[33m[your_program] [0m[0mIDENTIFIER NIL null[0m
+[33m[your_program] [0m[0mNIL nil null[0m
+[33m[your_program] [0m[0mIDENTIFIER WHILE null[0m
+[33m[your_program] [0m[0mFOR for null[0m
+[33m[your_program] [0m[0mIDENTIFIER ELSE null[0m
+[33m[your_program] [0m[0mCLASS class null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#PQ5] [test-2] [0m[92m✓ 33 line(s) match on stdout[0m
 [33m[tester::#PQ5] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#PQ5] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#PQ5] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PQ5] [test-3.lox] [0mvar greeting = "Hello"
-[33m[tester::#PQ5] [test-3.lox] [0mif (greeting == "Hello") {
-[33m[tester::#PQ5] [test-3.lox] [0m    return true
-[33m[tester::#PQ5] [test-3.lox] [0m} else {
-[33m[tester::#PQ5] [test-3.lox] [0m    return false
-[33m[tester::#PQ5] [test-3.lox] [0m}
+[33m[tester::#PQ5] [test-3.lox] [0m[0mvar greeting = "Hello"[0m
+[33m[tester::#PQ5] [test-3.lox] [0m[0mif (greeting == "Hello") {[0m
+[33m[tester::#PQ5] [test-3.lox] [0m[0m    return true[0m
+[33m[tester::#PQ5] [test-3.lox] [0m[0m} else {[0m
+[33m[tester::#PQ5] [test-3.lox] [0m[0m    return false[0m
+[33m[tester::#PQ5] [test-3.lox] [0m[0m}[0m
 [33m[tester::#PQ5] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mVAR var null
-[33m[your_program] [0mIDENTIFIER greeting null
-[33m[your_program] [0mEQUAL = null
-[33m[your_program] [0mSTRING "Hello" Hello
-[33m[your_program] [0mIF if null
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mIDENTIFIER greeting null
-[33m[your_program] [0mEQUAL_EQUAL == null
-[33m[your_program] [0mSTRING "Hello" Hello
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mLEFT_BRACE { null
-[33m[your_program] [0mRETURN return null
-[33m[your_program] [0mTRUE true null
-[33m[your_program] [0mRIGHT_BRACE } null
-[33m[your_program] [0mELSE else null
-[33m[your_program] [0mLEFT_BRACE { null
-[33m[your_program] [0mRETURN return null
-[33m[your_program] [0mFALSE false null
-[33m[your_program] [0mRIGHT_BRACE } null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mVAR var null[0m
+[33m[your_program] [0m[0mIDENTIFIER greeting null[0m
+[33m[your_program] [0m[0mEQUAL = null[0m
+[33m[your_program] [0m[0mSTRING "Hello" Hello[0m
+[33m[your_program] [0m[0mIF if null[0m
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mIDENTIFIER greeting null[0m
+[33m[your_program] [0m[0mEQUAL_EQUAL == null[0m
+[33m[your_program] [0m[0mSTRING "Hello" Hello[0m
+[33m[your_program] [0m[0mRIGHT_PAREN ) null[0m
+[33m[your_program] [0m[0mLEFT_BRACE { null[0m
+[33m[your_program] [0m[0mRETURN return null[0m
+[33m[your_program] [0m[0mTRUE true null[0m
+[33m[your_program] [0m[0mRIGHT_BRACE } null[0m
+[33m[your_program] [0m[0mELSE else null[0m
+[33m[your_program] [0m[0mLEFT_BRACE { null[0m
+[33m[your_program] [0m[0mRETURN return null[0m
+[33m[your_program] [0m[0mFALSE false null[0m
+[33m[your_program] [0m[0mRIGHT_BRACE } null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#PQ5] [test-3] [0m[92m✓ 20 line(s) match on stdout[0m
 [33m[tester::#PQ5] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#PQ5] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#PQ5] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PQ5] [test-4.lox] [0mvar result = (a + b) > 7 or "Success" != "Failure" or x >= 5
-[33m[tester::#PQ5] [test-4.lox] [0mwhile (result) {
-[33m[tester::#PQ5] [test-4.lox] [0m    var counter = 0
-[33m[tester::#PQ5] [test-4.lox] [0m    counter = counter + 1
-[33m[tester::#PQ5] [test-4.lox] [0m    if (counter == 10) {
-[33m[tester::#PQ5] [test-4.lox] [0m        return nil
-[33m[tester::#PQ5] [test-4.lox] [0m    }
-[33m[tester::#PQ5] [test-4.lox] [0m}
+[33m[tester::#PQ5] [test-4.lox] [0m[0mvar result = (a + b) > 7 or "Success" != "Failure" or x >= 5[0m
+[33m[tester::#PQ5] [test-4.lox] [0m[0mwhile (result) {[0m
+[33m[tester::#PQ5] [test-4.lox] [0m[0m    var counter = 0[0m
+[33m[tester::#PQ5] [test-4.lox] [0m[0m    counter = counter + 1[0m
+[33m[tester::#PQ5] [test-4.lox] [0m[0m    if (counter == 10) {[0m
+[33m[tester::#PQ5] [test-4.lox] [0m[0m        return nil[0m
+[33m[tester::#PQ5] [test-4.lox] [0m[0m    }[0m
+[33m[tester::#PQ5] [test-4.lox] [0m[0m}[0m
 [33m[tester::#PQ5] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mVAR var null
-[33m[your_program] [0mIDENTIFIER result null
-[33m[your_program] [0mEQUAL = null
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mIDENTIFIER a null
-[33m[your_program] [0mPLUS + null
-[33m[your_program] [0mIDENTIFIER b null
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mGREATER > null
-[33m[your_program] [0mNUMBER 7 7.0
-[33m[your_program] [0mOR or null
-[33m[your_program] [0mSTRING "Success" Success
-[33m[your_program] [0mBANG_EQUAL != null
-[33m[your_program] [0mSTRING "Failure" Failure
-[33m[your_program] [0mOR or null
-[33m[your_program] [0mIDENTIFIER x null
-[33m[your_program] [0mGREATER_EQUAL >= null
-[33m[your_program] [0mNUMBER 5 5.0
-[33m[your_program] [0mWHILE while null
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mIDENTIFIER result null
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mLEFT_BRACE { null
-[33m[your_program] [0mVAR var null
-[33m[your_program] [0mIDENTIFIER counter null
-[33m[your_program] [0mEQUAL = null
-[33m[your_program] [0mNUMBER 0 0.0
-[33m[your_program] [0mIDENTIFIER counter null
-[33m[your_program] [0mEQUAL = null
-[33m[your_program] [0mIDENTIFIER counter null
-[33m[your_program] [0mPLUS + null
-[33m[your_program] [0mNUMBER 1 1.0
-[33m[your_program] [0mIF if null
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mIDENTIFIER counter null
-[33m[your_program] [0mEQUAL_EQUAL == null
-[33m[your_program] [0mNUMBER 10 10.0
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mLEFT_BRACE { null
-[33m[your_program] [0mRETURN return null
-[33m[your_program] [0mNIL nil null
-[33m[your_program] [0mRIGHT_BRACE } null
-[33m[your_program] [0mRIGHT_BRACE } null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mVAR var null[0m
+[33m[your_program] [0m[0mIDENTIFIER result null[0m
+[33m[your_program] [0m[0mEQUAL = null[0m
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mIDENTIFIER a null[0m
+[33m[your_program] [0m[0mPLUS + null[0m
+[33m[your_program] [0m[0mIDENTIFIER b null[0m
+[33m[your_program] [0m[0mRIGHT_PAREN ) null[0m
+[33m[your_program] [0m[0mGREATER > null[0m
+[33m[your_program] [0m[0mNUMBER 7 7.0[0m
+[33m[your_program] [0m[0mOR or null[0m
+[33m[your_program] [0m[0mSTRING "Success" Success[0m
+[33m[your_program] [0m[0mBANG_EQUAL != null[0m
+[33m[your_program] [0m[0mSTRING "Failure" Failure[0m
+[33m[your_program] [0m[0mOR or null[0m
+[33m[your_program] [0m[0mIDENTIFIER x null[0m
+[33m[your_program] [0m[0mGREATER_EQUAL >= null[0m
+[33m[your_program] [0m[0mNUMBER 5 5.0[0m
+[33m[your_program] [0m[0mWHILE while null[0m
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mIDENTIFIER result null[0m
+[33m[your_program] [0m[0mRIGHT_PAREN ) null[0m
+[33m[your_program] [0m[0mLEFT_BRACE { null[0m
+[33m[your_program] [0m[0mVAR var null[0m
+[33m[your_program] [0m[0mIDENTIFIER counter null[0m
+[33m[your_program] [0m[0mEQUAL = null[0m
+[33m[your_program] [0m[0mNUMBER 0 0.0[0m
+[33m[your_program] [0m[0mIDENTIFIER counter null[0m
+[33m[your_program] [0m[0mEQUAL = null[0m
+[33m[your_program] [0m[0mIDENTIFIER counter null[0m
+[33m[your_program] [0m[0mPLUS + null[0m
+[33m[your_program] [0m[0mNUMBER 1 1.0[0m
+[33m[your_program] [0m[0mIF if null[0m
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mIDENTIFIER counter null[0m
+[33m[your_program] [0m[0mEQUAL_EQUAL == null[0m
+[33m[your_program] [0m[0mNUMBER 10 10.0[0m
+[33m[your_program] [0m[0mRIGHT_PAREN ) null[0m
+[33m[your_program] [0m[0mLEFT_BRACE { null[0m
+[33m[your_program] [0m[0mRETURN return null[0m
+[33m[your_program] [0m[0mNIL nil null[0m
+[33m[your_program] [0m[0mRIGHT_BRACE } null[0m
+[33m[your_program] [0m[0mRIGHT_BRACE } null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#PQ5] [test-4] [0m[92m✓ 44 line(s) match on stdout[0m
 [33m[tester::#PQ5] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#PQ5] [0m[92mTest passed.[0m
@@ -141,83 +141,83 @@ Debug = true
 [33m[tester::#EY7] [0m[94mRunning tests for Stage #EY7 (ey7)[0m
 [33m[tester::#EY7] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#EY7] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#EY7] [test-1.lox] [0mbar baz
+[33m[tester::#EY7] [test-1.lox] [0m[0mbar baz[0m
 [33m[tester::#EY7] [test-1] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mIDENTIFIER bar null
-[33m[your_program] [0mIDENTIFIER baz null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mIDENTIFIER bar null[0m
+[33m[your_program] [0m[0mIDENTIFIER baz null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#EY7] [test-1] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#EY7] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#EY7] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#EY7] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#EY7] [test-2.lox] [0m_123world_ _hello bar baz 6ar
+[33m[tester::#EY7] [test-2.lox] [0m[0m_123world_ _hello bar baz 6ar[0m
 [33m[tester::#EY7] [test-2] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mIDENTIFIER _123world_ null
-[33m[your_program] [0mIDENTIFIER _hello null
-[33m[your_program] [0mIDENTIFIER bar null
-[33m[your_program] [0mIDENTIFIER baz null
-[33m[your_program] [0mNUMBER 6 6.0
-[33m[your_program] [0mIDENTIFIER ar null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mIDENTIFIER _123world_ null[0m
+[33m[your_program] [0m[0mIDENTIFIER _hello null[0m
+[33m[your_program] [0m[0mIDENTIFIER bar null[0m
+[33m[your_program] [0m[0mIDENTIFIER baz null[0m
+[33m[your_program] [0m[0mNUMBER 6 6.0[0m
+[33m[your_program] [0m[0mIDENTIFIER ar null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#EY7] [test-2] [0m[92m✓ 7 line(s) match on stdout[0m
 [33m[tester::#EY7] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#EY7] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#EY7] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#EY7] [test-3.lox] [0mmessage = "Hello, World!"
-[33m[tester::#EY7] [test-3.lox] [0mnumber = 123
+[33m[tester::#EY7] [test-3.lox] [0m[0mmessage = "Hello, World!"[0m
+[33m[tester::#EY7] [test-3.lox] [0m[0mnumber = 123[0m
 [33m[tester::#EY7] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mIDENTIFIER message null
-[33m[your_program] [0mEQUAL = null
-[33m[your_program] [0mSTRING "Hello, World!" Hello, World!
-[33m[your_program] [0mIDENTIFIER number null
-[33m[your_program] [0mEQUAL = null
-[33m[your_program] [0mNUMBER 123 123.0
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mIDENTIFIER message null[0m
+[33m[your_program] [0m[0mEQUAL = null[0m
+[33m[your_program] [0m[0mSTRING "Hello, World!" Hello, World![0m
+[33m[your_program] [0m[0mIDENTIFIER number null[0m
+[33m[your_program] [0m[0mEQUAL = null[0m
+[33m[your_program] [0m[0mNUMBER 123 123.0[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#EY7] [test-3] [0m[92m✓ 7 line(s) match on stdout[0m
 [33m[tester::#EY7] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#EY7] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#EY7] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#EY7] [test-4.lox] [0m{
-[33m[tester::#EY7] [test-4.lox] [0m[33m// This is a complex test case[0m
-[33m[tester::#EY7] [test-4.lox] [0mstr1 = "Test"
-[33m[tester::#EY7] [test-4.lox] [0mstr2 = "Case"
-[33m[tester::#EY7] [test-4.lox] [0mnum1 = 100
-[33m[tester::#EY7] [test-4.lox] [0mnum2 = 200.00
-[33m[tester::#EY7] [test-4.lox] [0mresult = (str1 == str2) != ((num1 + num2) >= 300)
-[33m[tester::#EY7] [test-4.lox] [0m}
+[33m[tester::#EY7] [test-4.lox] [0m[0m{[0m
+[33m[tester::#EY7] [test-4.lox] [0m[0m[33m// This is a complex test case[0m[0m
+[33m[tester::#EY7] [test-4.lox] [0m[0mstr1 = "Test"[0m
+[33m[tester::#EY7] [test-4.lox] [0m[0mstr2 = "Case"[0m
+[33m[tester::#EY7] [test-4.lox] [0m[0mnum1 = 100[0m
+[33m[tester::#EY7] [test-4.lox] [0m[0mnum2 = 200.00[0m
+[33m[tester::#EY7] [test-4.lox] [0m[0mresult = (str1 == str2) != ((num1 + num2) >= 300)[0m
+[33m[tester::#EY7] [test-4.lox] [0m[0m}[0m
 [33m[tester::#EY7] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mLEFT_BRACE { null
-[33m[your_program] [0mIDENTIFIER str1 null
-[33m[your_program] [0mEQUAL = null
-[33m[your_program] [0mSTRING "Test" Test
-[33m[your_program] [0mIDENTIFIER str2 null
-[33m[your_program] [0mEQUAL = null
-[33m[your_program] [0mSTRING "Case" Case
-[33m[your_program] [0mIDENTIFIER num1 null
-[33m[your_program] [0mEQUAL = null
-[33m[your_program] [0mNUMBER 100 100.0
-[33m[your_program] [0mIDENTIFIER num2 null
-[33m[your_program] [0mEQUAL = null
-[33m[your_program] [0mNUMBER 200.00 200.0
-[33m[your_program] [0mIDENTIFIER result null
-[33m[your_program] [0mEQUAL = null
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mIDENTIFIER str1 null
-[33m[your_program] [0mEQUAL_EQUAL == null
-[33m[your_program] [0mIDENTIFIER str2 null
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mBANG_EQUAL != null
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mIDENTIFIER num1 null
-[33m[your_program] [0mPLUS + null
-[33m[your_program] [0mIDENTIFIER num2 null
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mGREATER_EQUAL >= null
-[33m[your_program] [0mNUMBER 300 300.0
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mRIGHT_BRACE } null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mLEFT_BRACE { null[0m
+[33m[your_program] [0m[0mIDENTIFIER str1 null[0m
+[33m[your_program] [0m[0mEQUAL = null[0m
+[33m[your_program] [0m[0mSTRING "Test" Test[0m
+[33m[your_program] [0m[0mIDENTIFIER str2 null[0m
+[33m[your_program] [0m[0mEQUAL = null[0m
+[33m[your_program] [0m[0mSTRING "Case" Case[0m
+[33m[your_program] [0m[0mIDENTIFIER num1 null[0m
+[33m[your_program] [0m[0mEQUAL = null[0m
+[33m[your_program] [0m[0mNUMBER 100 100.0[0m
+[33m[your_program] [0m[0mIDENTIFIER num2 null[0m
+[33m[your_program] [0m[0mEQUAL = null[0m
+[33m[your_program] [0m[0mNUMBER 200.00 200.0[0m
+[33m[your_program] [0m[0mIDENTIFIER result null[0m
+[33m[your_program] [0m[0mEQUAL = null[0m
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mIDENTIFIER str1 null[0m
+[33m[your_program] [0m[0mEQUAL_EQUAL == null[0m
+[33m[your_program] [0m[0mIDENTIFIER str2 null[0m
+[33m[your_program] [0m[0mRIGHT_PAREN ) null[0m
+[33m[your_program] [0m[0mBANG_EQUAL != null[0m
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mIDENTIFIER num1 null[0m
+[33m[your_program] [0m[0mPLUS + null[0m
+[33m[your_program] [0m[0mIDENTIFIER num2 null[0m
+[33m[your_program] [0m[0mRIGHT_PAREN ) null[0m
+[33m[your_program] [0m[0mGREATER_EQUAL >= null[0m
+[33m[your_program] [0m[0mNUMBER 300 300.0[0m
+[33m[your_program] [0m[0mRIGHT_PAREN ) null[0m
+[33m[your_program] [0m[0mRIGHT_BRACE } null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#EY7] [test-4] [0m[92m✓ 32 line(s) match on stdout[0m
 [33m[tester::#EY7] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#EY7] [0m[92mTest passed.[0m
@@ -225,52 +225,52 @@ Debug = true
 [33m[tester::#KJ0] [0m[94mRunning tests for Stage #KJ0 (kj0)[0m
 [33m[tester::#KJ0] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#KJ0] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#KJ0] [test-1.lox] [0m19
+[33m[tester::#KJ0] [test-1.lox] [0m[0m19[0m
 [33m[tester::#KJ0] [test-1] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mNUMBER 19 19.0
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mNUMBER 19 19.0[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#KJ0] [test-1] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#KJ0] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#KJ0] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#KJ0] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#KJ0] [test-2.lox] [0m8111.9591
+[33m[tester::#KJ0] [test-2.lox] [0m[0m8111.9591[0m
 [33m[tester::#KJ0] [test-2] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mNUMBER 8111.9591 8111.9591
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mNUMBER 8111.9591 8111.9591[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#KJ0] [test-2] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#KJ0] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#KJ0] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#KJ0] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#KJ0] [test-3.lox] [0m72.0000
+[33m[tester::#KJ0] [test-3.lox] [0m[0m72.0000[0m
 [33m[tester::#KJ0] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mNUMBER 72.0000 72.0
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mNUMBER 72.0000 72.0[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#KJ0] [test-3] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#KJ0] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#KJ0] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#KJ0] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#KJ0] [test-4.lox] [0m(80+80) > 80 != ("Success" != "Failure") != (19 >= 82)
+[33m[tester::#KJ0] [test-4.lox] [0m[0m(80+80) > 80 != ("Success" != "Failure") != (19 >= 82)[0m
 [33m[tester::#KJ0] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mNUMBER 80 80.0
-[33m[your_program] [0mPLUS + null
-[33m[your_program] [0mNUMBER 80 80.0
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mGREATER > null
-[33m[your_program] [0mNUMBER 80 80.0
-[33m[your_program] [0mBANG_EQUAL != null
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mSTRING "Success" Success
-[33m[your_program] [0mBANG_EQUAL != null
-[33m[your_program] [0mSTRING "Failure" Failure
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mBANG_EQUAL != null
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mNUMBER 19 19.0
-[33m[your_program] [0mGREATER_EQUAL >= null
-[33m[your_program] [0mNUMBER 82 82.0
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mNUMBER 80 80.0[0m
+[33m[your_program] [0m[0mPLUS + null[0m
+[33m[your_program] [0m[0mNUMBER 80 80.0[0m
+[33m[your_program] [0m[0mRIGHT_PAREN ) null[0m
+[33m[your_program] [0m[0mGREATER > null[0m
+[33m[your_program] [0m[0mNUMBER 80 80.0[0m
+[33m[your_program] [0m[0mBANG_EQUAL != null[0m
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mSTRING "Success" Success[0m
+[33m[your_program] [0m[0mBANG_EQUAL != null[0m
+[33m[your_program] [0m[0mSTRING "Failure" Failure[0m
+[33m[your_program] [0m[0mRIGHT_PAREN ) null[0m
+[33m[your_program] [0m[0mBANG_EQUAL != null[0m
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mNUMBER 19 19.0[0m
+[33m[your_program] [0m[0mGREATER_EQUAL >= null[0m
+[33m[your_program] [0m[0mNUMBER 82 82.0[0m
+[33m[your_program] [0m[0mRIGHT_PAREN ) null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#KJ0] [test-4] [0m[92m✓ 20 line(s) match on stdout[0m
 [33m[tester::#KJ0] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#KJ0] [0m[92mTest passed.[0m
@@ -278,43 +278,43 @@ Debug = true
 [33m[tester::#UE7] [0m[94mRunning tests for Stage #UE7 (ue7)[0m
 [33m[tester::#UE7] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#UE7] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#UE7] [test-1.lox] [0m"hello"
+[33m[tester::#UE7] [test-1.lox] [0m[0m"hello"[0m
 [33m[tester::#UE7] [test-1] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mSTRING "hello" hello
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mSTRING "hello" hello[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#UE7] [test-1] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#UE7] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#UE7] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#UE7] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#UE7] [test-2.lox] [0m"bar" ; "unterminated
+[33m[tester::#UE7] [test-2.lox] [0m[0m"bar" ; "unterminated[0m
 [33m[tester::#UE7] [test-2] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0m[line 1] Error: Unterminated string.
-[33m[your_program] [0mSTRING "bar" bar
-[33m[your_program] [0mSEMICOLON ; null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0m[line 1] Error: Unterminated string.[0m
+[33m[your_program] [0m[0mSTRING "bar" bar[0m
+[33m[your_program] [0m[0mSEMICOLON ; null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#UE7] [test-2] [0m[92m✓ 1 line(s) match on stderr[0m
 [33m[tester::#UE7] [test-2] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#UE7] [test-2] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#UE7] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#UE7] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#UE7] [test-3.lox] [0m"foo <|TAB|>bar 123 [33m// hello world!"[0m
+[33m[tester::#UE7] [test-3.lox] [0m[0m"foo <|TAB|>bar 123 [33m// hello world!"[0m[0m
 [33m[tester::#UE7] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mSTRING "foo 	bar 123 // hello world!" foo 	bar 123 // hello world!
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mSTRING "foo 	bar 123 // hello world!" foo 	bar 123 // hello world![0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#UE7] [test-3] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#UE7] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#UE7] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#UE7] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#UE7] [test-4.lox] [0m("hello"+"foo") != "other_string"
+[33m[tester::#UE7] [test-4.lox] [0m[0m("hello"+"foo") != "other_string"[0m
 [33m[tester::#UE7] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mSTRING "hello" hello
-[33m[your_program] [0mPLUS + null
-[33m[your_program] [0mSTRING "foo" foo
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mBANG_EQUAL != null
-[33m[your_program] [0mSTRING "other_string" other_string
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mSTRING "hello" hello[0m
+[33m[your_program] [0m[0mPLUS + null[0m
+[33m[your_program] [0m[0mSTRING "foo" foo[0m
+[33m[your_program] [0m[0mRIGHT_PAREN ) null[0m
+[33m[your_program] [0m[0mBANG_EQUAL != null[0m
+[33m[your_program] [0m[0mSTRING "other_string" other_string[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#UE7] [test-4] [0m[92m✓ 8 line(s) match on stdout[0m
 [33m[tester::#UE7] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#UE7] [0m[92mTest passed.[0m
@@ -322,67 +322,67 @@ Debug = true
 [33m[tester::#TZ7] [0m[94mRunning tests for Stage #TZ7 (tz7)[0m
 [33m[tester::#TZ7] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#TZ7] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#TZ7] [test-1.lox] [0m()
-[33m[tester::#TZ7] [test-1.lox] [0m<|TAB|>@
+[33m[tester::#TZ7] [test-1.lox] [0m[0m()[0m
+[33m[tester::#TZ7] [test-1.lox] [0m[0m<|TAB|>@[0m
 [33m[tester::#TZ7] [test-1] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0m[line 2] Error: Unexpected character: @
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0m[line 2] Error: Unexpected character: @[0m
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mRIGHT_PAREN ) null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#TZ7] [test-1] [0m[92m✓ 1 line(s) match on stderr[0m
 [33m[tester::#TZ7] [test-1] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#TZ7] [test-1] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#TZ7] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#TZ7] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#TZ7] [test-2.lox] [0m@
-[33m[tester::#TZ7] [test-2.lox] [0m%#
+[33m[tester::#TZ7] [test-2.lox] [0m[0m@[0m
+[33m[tester::#TZ7] [test-2.lox] [0m[0m%#[0m
 [33m[tester::#TZ7] [test-2] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0m[line 1] Error: Unexpected character: @
-[33m[your_program] [0m[line 2] Error: Unexpected character: %
-[33m[your_program] [0m[line 2] Error: Unexpected character: #
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0m[line 1] Error: Unexpected character: @[0m
+[33m[your_program] [0m[0m[line 2] Error: Unexpected character: %[0m
+[33m[your_program] [0m[0m[line 2] Error: Unexpected character: #[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#TZ7] [test-2] [0m[92m✓ 3 line(s) match on stderr[0m
 [33m[tester::#TZ7] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#TZ7] [test-2] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#TZ7] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#TZ7] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#TZ7] [test-3.lox] [0m()  #<|TAB|>{}
-[33m[tester::#TZ7] [test-3.lox] [0m@
-[33m[tester::#TZ7] [test-3.lox] [0m$
-[33m[tester::#TZ7] [test-3.lox] [0m+++
-[33m[tester::#TZ7] [test-3.lox] [0m[33m// Let's Go![0m
-[33m[tester::#TZ7] [test-3.lox] [0m+++
-[33m[tester::#TZ7] [test-3.lox] [0m#
+[33m[tester::#TZ7] [test-3.lox] [0m[0m()  #<|TAB|>{}[0m
+[33m[tester::#TZ7] [test-3.lox] [0m[0m@[0m
+[33m[tester::#TZ7] [test-3.lox] [0m[0m$[0m
+[33m[tester::#TZ7] [test-3.lox] [0m[0m+++[0m
+[33m[tester::#TZ7] [test-3.lox] [0m[0m[33m// Let's Go![0m[0m
+[33m[tester::#TZ7] [test-3.lox] [0m[0m+++[0m
+[33m[tester::#TZ7] [test-3.lox] [0m[0m#[0m
 [33m[tester::#TZ7] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0m[line 1] Error: Unexpected character: #
-[33m[your_program] [0m[line 2] Error: Unexpected character: @
-[33m[your_program] [0m[line 3] Error: Unexpected character: $
-[33m[your_program] [0m[line 7] Error: Unexpected character: #
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mLEFT_BRACE { null
-[33m[your_program] [0mRIGHT_BRACE } null
-[33m[your_program] [0mPLUS + null
-[33m[your_program] [0mPLUS + null
-[33m[your_program] [0mPLUS + null
-[33m[your_program] [0mPLUS + null
-[33m[your_program] [0mPLUS + null
-[33m[your_program] [0mPLUS + null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0m[line 1] Error: Unexpected character: #[0m
+[33m[your_program] [0m[0m[line 2] Error: Unexpected character: @[0m
+[33m[your_program] [0m[0m[line 3] Error: Unexpected character: $[0m
+[33m[your_program] [0m[0m[line 7] Error: Unexpected character: #[0m
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mRIGHT_PAREN ) null[0m
+[33m[your_program] [0m[0mLEFT_BRACE { null[0m
+[33m[your_program] [0m[0mRIGHT_BRACE } null[0m
+[33m[your_program] [0m[0mPLUS + null[0m
+[33m[your_program] [0m[0mPLUS + null[0m
+[33m[your_program] [0m[0mPLUS + null[0m
+[33m[your_program] [0m[0mPLUS + null[0m
+[33m[your_program] [0m[0mPLUS + null[0m
+[33m[your_program] [0m[0mPLUS + null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#TZ7] [test-3] [0m[92m✓ 4 line(s) match on stderr[0m
 [33m[tester::#TZ7] [test-3] [0m[92m✓ 11 line(s) match on stdout[0m
 [33m[tester::#TZ7] [test-3] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#TZ7] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#TZ7] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#TZ7] [test-4.lox] [0m({+ #})
+[33m[tester::#TZ7] [test-4.lox] [0m[0m({+ #})[0m
 [33m[tester::#TZ7] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0m[line 1] Error: Unexpected character: #
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mLEFT_BRACE { null
-[33m[your_program] [0mPLUS + null
-[33m[your_program] [0mRIGHT_BRACE } null
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0m[line 1] Error: Unexpected character: #[0m
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mLEFT_BRACE { null[0m
+[33m[your_program] [0m[0mPLUS + null[0m
+[33m[your_program] [0m[0mRIGHT_BRACE } null[0m
+[33m[your_program] [0m[0mRIGHT_PAREN ) null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#TZ7] [test-4] [0m[92m✓ 1 line(s) match on stderr[0m
 [33m[tester::#TZ7] [test-4] [0m[92m✓ 6 line(s) match on stdout[0m
 [33m[tester::#TZ7] [test-4] [0m[92m✓ Received exit code 65.[0m
@@ -391,55 +391,55 @@ Debug = true
 [33m[tester::#ER2] [0m[94mRunning tests for Stage #ER2 (er2)[0m
 [33m[tester::#ER2] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#ER2] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#ER2] [test-1.lox] [0m<|SPACE|>
+[33m[tester::#ER2] [test-1.lox] [0m[0m<|SPACE|>[0m
 [33m[tester::#ER2] [test-1] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#ER2] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#ER2] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#ER2] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#ER2] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#ER2] [test-2.lox] [0m<|SPACE|><|TAB|>
-[33m[tester::#ER2] [test-2.lox] [0m<|SPACE|>
+[33m[tester::#ER2] [test-2.lox] [0m[0m<|SPACE|><|TAB|>[0m
+[33m[tester::#ER2] [test-2.lox] [0m[0m<|SPACE|>[0m
 [33m[tester::#ER2] [test-2] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#ER2] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#ER2] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#ER2] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#ER2] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#ER2] [test-3.lox] [0m{<|SPACE|>
-[33m[tester::#ER2] [test-3.lox] [0m}
-[33m[tester::#ER2] [test-3.lox] [0m((*
-[33m[tester::#ER2] [test-3.lox] [0m<|SPACE|>-<|TAB|>))
+[33m[tester::#ER2] [test-3.lox] [0m[0m{<|SPACE|>[0m
+[33m[tester::#ER2] [test-3.lox] [0m[0m}[0m
+[33m[tester::#ER2] [test-3.lox] [0m[0m((*[0m
+[33m[tester::#ER2] [test-3.lox] [0m[0m<|SPACE|>-<|TAB|>))[0m
 [33m[tester::#ER2] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mLEFT_BRACE { null
-[33m[your_program] [0mRIGHT_BRACE } null
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mSTAR * null
-[33m[your_program] [0mMINUS - null
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mLEFT_BRACE { null[0m
+[33m[your_program] [0m[0mRIGHT_BRACE } null[0m
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mSTAR * null[0m
+[33m[your_program] [0m[0mMINUS - null[0m
+[33m[your_program] [0m[0mRIGHT_PAREN ) null[0m
+[33m[your_program] [0m[0mRIGHT_PAREN ) null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#ER2] [test-3] [0m[92m✓ 9 line(s) match on stdout[0m
 [33m[tester::#ER2] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#ER2] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#ER2] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#ER2] [test-4.lox] [0m{<|SPACE|>
-[33m[tester::#ER2] [test-4.lox] [0m
-[33m[tester::#ER2] [test-4.lox] [0m<|TAB|><|TAB|>}
-[33m[tester::#ER2] [test-4.lox] [0m((<|SPACE|>,-<=
-[33m[tester::#ER2] [test-4.lox] [0m))
+[33m[tester::#ER2] [test-4.lox] [0m[0m{<|SPACE|>[0m
+[33m[tester::#ER2] [test-4.lox] [0m[0m[0m
+[33m[tester::#ER2] [test-4.lox] [0m[0m<|TAB|><|TAB|>}[0m
+[33m[tester::#ER2] [test-4.lox] [0m[0m((<|SPACE|>,-<=[0m
+[33m[tester::#ER2] [test-4.lox] [0m[0m))[0m
 [33m[tester::#ER2] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mLEFT_BRACE { null
-[33m[your_program] [0mRIGHT_BRACE } null
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mCOMMA , null
-[33m[your_program] [0mMINUS - null
-[33m[your_program] [0mLESS_EQUAL <= null
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mLEFT_BRACE { null[0m
+[33m[your_program] [0m[0mRIGHT_BRACE } null[0m
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mCOMMA , null[0m
+[33m[your_program] [0m[0mMINUS - null[0m
+[33m[your_program] [0m[0mLESS_EQUAL <= null[0m
+[33m[your_program] [0m[0mRIGHT_PAREN ) null[0m
+[33m[your_program] [0m[0mRIGHT_PAREN ) null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#ER2] [test-4] [0m[92m✓ 10 line(s) match on stdout[0m
 [33m[tester::#ER2] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#ER2] [0m[92mTest passed.[0m
@@ -447,41 +447,41 @@ Debug = true
 [33m[tester::#ML2] [0m[94mRunning tests for Stage #ML2 (ml2)[0m
 [33m[tester::#ML2] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#ML2] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#ML2] [test-1.lox] [0m[33m//Comment[0m
+[33m[tester::#ML2] [test-1.lox] [0m[0m[33m//Comment[0m[0m
 [33m[tester::#ML2] [test-1] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#ML2] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#ML2] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#ML2] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#ML2] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#ML2] [test-2.lox] [0m([33m///Unicode:£§᯽☺♣)[0m
+[33m[tester::#ML2] [test-2.lox] [0m[0m([33m///Unicode:£§᯽☺♣)[0m[0m
 [33m[tester::#ML2] [test-2] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#ML2] [test-2] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#ML2] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#ML2] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#ML2] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#ML2] [test-3.lox] [0m/
+[33m[tester::#ML2] [test-3.lox] [0m[0m/[0m
 [33m[tester::#ML2] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mSLASH / null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mSLASH / null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#ML2] [test-3] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#ML2] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#ML2] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#ML2] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#ML2] [test-4.lox] [0m({(<=;.)})[33m//Comment[0m
+[33m[tester::#ML2] [test-4.lox] [0m[0m({(<=;.)})[33m//Comment[0m[0m
 [33m[tester::#ML2] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mLEFT_BRACE { null
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mLESS_EQUAL <= null
-[33m[your_program] [0mSEMICOLON ; null
-[33m[your_program] [0mDOT . null
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mRIGHT_BRACE } null
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mLEFT_BRACE { null[0m
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mLESS_EQUAL <= null[0m
+[33m[your_program] [0m[0mSEMICOLON ; null[0m
+[33m[your_program] [0m[0mDOT . null[0m
+[33m[your_program] [0m[0mRIGHT_PAREN ) null[0m
+[33m[your_program] [0m[0mRIGHT_BRACE } null[0m
+[33m[your_program] [0m[0mRIGHT_PAREN ) null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#ML2] [test-4] [0m[92m✓ 10 line(s) match on stdout[0m
 [33m[tester::#ML2] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#ML2] [0m[92mTest passed.[0m
@@ -489,49 +489,49 @@ Debug = true
 [33m[tester::#ET2] [0m[94mRunning tests for Stage #ET2 (et2)[0m
 [33m[tester::#ET2] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#ET2] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#ET2] [test-1.lox] [0m>=
+[33m[tester::#ET2] [test-1.lox] [0m[0m>=[0m
 [33m[tester::#ET2] [test-1] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mGREATER_EQUAL >= null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mGREATER_EQUAL >= null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#ET2] [test-1] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#ET2] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#ET2] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#ET2] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#ET2] [test-2.lox] [0m<<<=>>>=
+[33m[tester::#ET2] [test-2.lox] [0m[0m<<<=>>>=[0m
 [33m[tester::#ET2] [test-2] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mLESS < null
-[33m[your_program] [0mLESS < null
-[33m[your_program] [0mLESS_EQUAL <= null
-[33m[your_program] [0mGREATER > null
-[33m[your_program] [0mGREATER > null
-[33m[your_program] [0mGREATER_EQUAL >= null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mLESS < null[0m
+[33m[your_program] [0m[0mLESS < null[0m
+[33m[your_program] [0m[0mLESS_EQUAL <= null[0m
+[33m[your_program] [0m[0mGREATER > null[0m
+[33m[your_program] [0m[0mGREATER > null[0m
+[33m[your_program] [0m[0mGREATER_EQUAL >= null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#ET2] [test-2] [0m[92m✓ 7 line(s) match on stdout[0m
 [33m[tester::#ET2] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#ET2] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#ET2] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#ET2] [test-3.lox] [0m>=><<=<
+[33m[tester::#ET2] [test-3.lox] [0m[0m>=><<=<[0m
 [33m[tester::#ET2] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mGREATER_EQUAL >= null
-[33m[your_program] [0mGREATER > null
-[33m[your_program] [0mLESS < null
-[33m[your_program] [0mLESS_EQUAL <= null
-[33m[your_program] [0mLESS < null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mGREATER_EQUAL >= null[0m
+[33m[your_program] [0m[0mGREATER > null[0m
+[33m[your_program] [0m[0mLESS < null[0m
+[33m[your_program] [0m[0mLESS_EQUAL <= null[0m
+[33m[your_program] [0m[0mLESS < null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#ET2] [test-3] [0m[92m✓ 6 line(s) match on stdout[0m
 [33m[tester::#ET2] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#ET2] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#ET2] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#ET2] [test-4.lox] [0m(){>====}
+[33m[tester::#ET2] [test-4.lox] [0m[0m(){>====}[0m
 [33m[tester::#ET2] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mLEFT_BRACE { null
-[33m[your_program] [0mGREATER_EQUAL >= null
-[33m[your_program] [0mEQUAL_EQUAL == null
-[33m[your_program] [0mEQUAL = null
-[33m[your_program] [0mRIGHT_BRACE } null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mRIGHT_PAREN ) null[0m
+[33m[your_program] [0m[0mLEFT_BRACE { null[0m
+[33m[your_program] [0m[0mGREATER_EQUAL >= null[0m
+[33m[your_program] [0m[0mEQUAL_EQUAL == null[0m
+[33m[your_program] [0m[0mEQUAL = null[0m
+[33m[your_program] [0m[0mRIGHT_BRACE } null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#ET2] [test-4] [0m[92m✓ 8 line(s) match on stdout[0m
 [33m[tester::#ET2] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#ET2] [0m[92mTest passed.[0m
@@ -539,52 +539,52 @@ Debug = true
 [33m[tester::#BU3] [0m[94mRunning tests for Stage #BU3 (bu3)[0m
 [33m[tester::#BU3] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#BU3] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#BU3] [test-1.lox] [0m!=
+[33m[tester::#BU3] [test-1.lox] [0m[0m!=[0m
 [33m[tester::#BU3] [test-1] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mBANG_EQUAL != null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mBANG_EQUAL != null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#BU3] [test-1] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#BU3] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#BU3] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#BU3] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#BU3] [test-2.lox] [0m!!===
+[33m[tester::#BU3] [test-2.lox] [0m[0m!!===[0m
 [33m[tester::#BU3] [test-2] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mBANG ! null
-[33m[your_program] [0mBANG_EQUAL != null
-[33m[your_program] [0mEQUAL_EQUAL == null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mBANG ! null[0m
+[33m[your_program] [0m[0mBANG_EQUAL != null[0m
+[33m[your_program] [0m[0mEQUAL_EQUAL == null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#BU3] [test-2] [0m[92m✓ 4 line(s) match on stdout[0m
 [33m[tester::#BU3] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#BU3] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#BU3] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#BU3] [test-3.lox] [0m!{!}(!===)=
+[33m[tester::#BU3] [test-3.lox] [0m[0m!{!}(!===)=[0m
 [33m[tester::#BU3] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mBANG ! null
-[33m[your_program] [0mLEFT_BRACE { null
-[33m[your_program] [0mBANG ! null
-[33m[your_program] [0mRIGHT_BRACE } null
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mBANG_EQUAL != null
-[33m[your_program] [0mEQUAL_EQUAL == null
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mEQUAL = null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mBANG ! null[0m
+[33m[your_program] [0m[0mLEFT_BRACE { null[0m
+[33m[your_program] [0m[0mBANG ! null[0m
+[33m[your_program] [0m[0mRIGHT_BRACE } null[0m
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mBANG_EQUAL != null[0m
+[33m[your_program] [0m[0mEQUAL_EQUAL == null[0m
+[33m[your_program] [0m[0mRIGHT_PAREN ) null[0m
+[33m[your_program] [0m[0mEQUAL = null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#BU3] [test-3] [0m[92m✓ 10 line(s) match on stdout[0m
 [33m[tester::#BU3] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#BU3] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#BU3] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#BU3] [test-4.lox] [0m{(==!=$!%)}
+[33m[tester::#BU3] [test-4.lox] [0m[0m{(==!=$!%)}[0m
 [33m[tester::#BU3] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0m[line 1] Error: Unexpected character: $
-[33m[your_program] [0m[line 1] Error: Unexpected character: %
-[33m[your_program] [0mLEFT_BRACE { null
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mEQUAL_EQUAL == null
-[33m[your_program] [0mBANG_EQUAL != null
-[33m[your_program] [0mBANG ! null
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mRIGHT_BRACE } null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0m[line 1] Error: Unexpected character: $[0m
+[33m[your_program] [0m[0m[line 1] Error: Unexpected character: %[0m
+[33m[your_program] [0m[0mLEFT_BRACE { null[0m
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mEQUAL_EQUAL == null[0m
+[33m[your_program] [0m[0mBANG_EQUAL != null[0m
+[33m[your_program] [0m[0mBANG ! null[0m
+[33m[your_program] [0m[0mRIGHT_PAREN ) null[0m
+[33m[your_program] [0m[0mRIGHT_BRACE } null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#BU3] [test-4] [0m[92m✓ 2 line(s) match on stderr[0m
 [33m[tester::#BU3] [test-4] [0m[92m✓ 8 line(s) match on stdout[0m
 [33m[tester::#BU3] [test-4] [0m[92m✓ Received exit code 65.[0m
@@ -593,49 +593,49 @@ Debug = true
 [33m[tester::#MP7] [0m[94mRunning tests for Stage #MP7 (mp7)[0m
 [33m[tester::#MP7] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#MP7] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#MP7] [test-1.lox] [0m=
+[33m[tester::#MP7] [test-1.lox] [0m[0m=[0m
 [33m[tester::#MP7] [test-1] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mEQUAL = null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mEQUAL = null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#MP7] [test-1] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#MP7] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#MP7] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#MP7] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#MP7] [test-2.lox] [0m==
+[33m[tester::#MP7] [test-2.lox] [0m[0m==[0m
 [33m[tester::#MP7] [test-2] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mEQUAL_EQUAL == null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mEQUAL_EQUAL == null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#MP7] [test-2] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#MP7] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#MP7] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#MP7] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#MP7] [test-3.lox] [0m({=}){==}
+[33m[tester::#MP7] [test-3.lox] [0m[0m({=}){==}[0m
 [33m[tester::#MP7] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mLEFT_BRACE { null
-[33m[your_program] [0mEQUAL = null
-[33m[your_program] [0mRIGHT_BRACE } null
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mLEFT_BRACE { null
-[33m[your_program] [0mEQUAL_EQUAL == null
-[33m[your_program] [0mRIGHT_BRACE } null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mLEFT_BRACE { null[0m
+[33m[your_program] [0m[0mEQUAL = null[0m
+[33m[your_program] [0m[0mRIGHT_BRACE } null[0m
+[33m[your_program] [0m[0mRIGHT_PAREN ) null[0m
+[33m[your_program] [0m[0mLEFT_BRACE { null[0m
+[33m[your_program] [0m[0mEQUAL_EQUAL == null[0m
+[33m[your_program] [0m[0mRIGHT_BRACE } null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#MP7] [test-3] [0m[92m✓ 9 line(s) match on stdout[0m
 [33m[tester::#MP7] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#MP7] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#MP7] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#MP7] [test-4.lox] [0m((#===$%))
+[33m[tester::#MP7] [test-4.lox] [0m[0m((#===$%))[0m
 [33m[tester::#MP7] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0m[line 1] Error: Unexpected character: #
-[33m[your_program] [0m[line 1] Error: Unexpected character: $
-[33m[your_program] [0m[line 1] Error: Unexpected character: %
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mEQUAL_EQUAL == null
-[33m[your_program] [0mEQUAL = null
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0m[line 1] Error: Unexpected character: #[0m
+[33m[your_program] [0m[0m[line 1] Error: Unexpected character: $[0m
+[33m[your_program] [0m[0m[line 1] Error: Unexpected character: %[0m
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mEQUAL_EQUAL == null[0m
+[33m[your_program] [0m[0mEQUAL = null[0m
+[33m[your_program] [0m[0mRIGHT_PAREN ) null[0m
+[33m[your_program] [0m[0mRIGHT_PAREN ) null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#MP7] [test-4] [0m[92m✓ 3 line(s) match on stderr[0m
 [33m[tester::#MP7] [test-4] [0m[92m✓ 7 line(s) match on stdout[0m
 [33m[tester::#MP7] [test-4] [0m[92m✓ Received exit code 65.[0m
@@ -644,55 +644,55 @@ Debug = true
 [33m[tester::#EA6] [0m[94mRunning tests for Stage #EA6 (ea6)[0m
 [33m[tester::#EA6] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#EA6] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#EA6] [test-1.lox] [0m@
+[33m[tester::#EA6] [test-1.lox] [0m[0m@[0m
 [33m[tester::#EA6] [test-1] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0m[line 1] Error: Unexpected character: @
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0m[line 1] Error: Unexpected character: @[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#EA6] [test-1] [0m[92m✓ 1 line(s) match on stderr[0m
 [33m[tester::#EA6] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#EA6] [test-1] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#EA6] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#EA6] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#EA6] [test-2.lox] [0m,.$(#
+[33m[tester::#EA6] [test-2.lox] [0m[0m,.$(#[0m
 [33m[tester::#EA6] [test-2] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0m[line 1] Error: Unexpected character: $
-[33m[your_program] [0m[line 1] Error: Unexpected character: #
-[33m[your_program] [0mCOMMA , null
-[33m[your_program] [0mDOT . null
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0m[line 1] Error: Unexpected character: $[0m
+[33m[your_program] [0m[0m[line 1] Error: Unexpected character: #[0m
+[33m[your_program] [0m[0mCOMMA , null[0m
+[33m[your_program] [0m[0mDOT . null[0m
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#EA6] [test-2] [0m[92m✓ 2 line(s) match on stderr[0m
 [33m[tester::#EA6] [test-2] [0m[92m✓ 4 line(s) match on stdout[0m
 [33m[tester::#EA6] [test-2] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#EA6] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#EA6] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#EA6] [test-3.lox] [0m@#$#@
+[33m[tester::#EA6] [test-3.lox] [0m[0m@#$#@[0m
 [33m[tester::#EA6] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0m[line 1] Error: Unexpected character: @
-[33m[your_program] [0m[line 1] Error: Unexpected character: #
-[33m[your_program] [0m[line 1] Error: Unexpected character: $
-[33m[your_program] [0m[line 1] Error: Unexpected character: #
-[33m[your_program] [0m[line 1] Error: Unexpected character: @
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0m[line 1] Error: Unexpected character: @[0m
+[33m[your_program] [0m[0m[line 1] Error: Unexpected character: #[0m
+[33m[your_program] [0m[0m[line 1] Error: Unexpected character: $[0m
+[33m[your_program] [0m[0m[line 1] Error: Unexpected character: #[0m
+[33m[your_program] [0m[0m[line 1] Error: Unexpected character: @[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#EA6] [test-3] [0m[92m✓ 5 line(s) match on stderr[0m
 [33m[tester::#EA6] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#EA6] [test-3] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#EA6] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#EA6] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#EA6] [test-4.lox] [0m{(+$#.,-@)}
+[33m[tester::#EA6] [test-4.lox] [0m[0m{(+$#.,-@)}[0m
 [33m[tester::#EA6] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0m[line 1] Error: Unexpected character: $
-[33m[your_program] [0m[line 1] Error: Unexpected character: #
-[33m[your_program] [0m[line 1] Error: Unexpected character: @
-[33m[your_program] [0mLEFT_BRACE { null
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mPLUS + null
-[33m[your_program] [0mDOT . null
-[33m[your_program] [0mCOMMA , null
-[33m[your_program] [0mMINUS - null
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mRIGHT_BRACE } null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0m[line 1] Error: Unexpected character: $[0m
+[33m[your_program] [0m[0m[line 1] Error: Unexpected character: #[0m
+[33m[your_program] [0m[0m[line 1] Error: Unexpected character: @[0m
+[33m[your_program] [0m[0mLEFT_BRACE { null[0m
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mPLUS + null[0m
+[33m[your_program] [0m[0mDOT . null[0m
+[33m[your_program] [0m[0mCOMMA , null[0m
+[33m[your_program] [0m[0mMINUS - null[0m
+[33m[your_program] [0m[0mRIGHT_PAREN ) null[0m
+[33m[your_program] [0m[0mRIGHT_BRACE } null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#EA6] [test-4] [0m[92m✓ 3 line(s) match on stderr[0m
 [33m[tester::#EA6] [test-4] [0m[92m✓ 9 line(s) match on stdout[0m
 [33m[tester::#EA6] [test-4] [0m[92m✓ Received exit code 65.[0m
@@ -701,60 +701,60 @@ Debug = true
 [33m[tester::#XC5] [0m[94mRunning tests for Stage #XC5 (xc5)[0m
 [33m[tester::#XC5] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#XC5] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#XC5] [test-1.lox] [0m+-
+[33m[tester::#XC5] [test-1.lox] [0m[0m+-[0m
 [33m[tester::#XC5] [test-1] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mPLUS + null
-[33m[your_program] [0mMINUS - null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mPLUS + null[0m
+[33m[your_program] [0m[0mMINUS - null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#XC5] [test-1] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#XC5] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#XC5] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#XC5] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#XC5] [test-2.lox] [0m++--**..,,;;
+[33m[tester::#XC5] [test-2.lox] [0m[0m++--**..,,;;[0m
 [33m[tester::#XC5] [test-2] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mPLUS + null
-[33m[your_program] [0mPLUS + null
-[33m[your_program] [0mMINUS - null
-[33m[your_program] [0mMINUS - null
-[33m[your_program] [0mSTAR * null
-[33m[your_program] [0mSTAR * null
-[33m[your_program] [0mDOT . null
-[33m[your_program] [0mDOT . null
-[33m[your_program] [0mCOMMA , null
-[33m[your_program] [0mCOMMA , null
-[33m[your_program] [0mSEMICOLON ; null
-[33m[your_program] [0mSEMICOLON ; null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mPLUS + null[0m
+[33m[your_program] [0m[0mPLUS + null[0m
+[33m[your_program] [0m[0mMINUS - null[0m
+[33m[your_program] [0m[0mMINUS - null[0m
+[33m[your_program] [0m[0mSTAR * null[0m
+[33m[your_program] [0m[0mSTAR * null[0m
+[33m[your_program] [0m[0mDOT . null[0m
+[33m[your_program] [0m[0mDOT . null[0m
+[33m[your_program] [0m[0mCOMMA , null[0m
+[33m[your_program] [0m[0mCOMMA , null[0m
+[33m[your_program] [0m[0mSEMICOLON ; null[0m
+[33m[your_program] [0m[0mSEMICOLON ; null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#XC5] [test-2] [0m[92m✓ 13 line(s) match on stdout[0m
 [33m[tester::#XC5] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#XC5] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#XC5] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#XC5] [test-3.lox] [0m-;+*+;.
+[33m[tester::#XC5] [test-3.lox] [0m[0m-;+*+;.[0m
 [33m[tester::#XC5] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mMINUS - null
-[33m[your_program] [0mSEMICOLON ; null
-[33m[your_program] [0mPLUS + null
-[33m[your_program] [0mSTAR * null
-[33m[your_program] [0mPLUS + null
-[33m[your_program] [0mSEMICOLON ; null
-[33m[your_program] [0mDOT . null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mMINUS - null[0m
+[33m[your_program] [0m[0mSEMICOLON ; null[0m
+[33m[your_program] [0m[0mPLUS + null[0m
+[33m[your_program] [0m[0mSTAR * null[0m
+[33m[your_program] [0m[0mPLUS + null[0m
+[33m[your_program] [0m[0mSEMICOLON ; null[0m
+[33m[your_program] [0m[0mDOT . null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#XC5] [test-3] [0m[92m✓ 8 line(s) match on stdout[0m
 [33m[tester::#XC5] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#XC5] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#XC5] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#XC5] [test-4.lox] [0m({,*+.;})
+[33m[tester::#XC5] [test-4.lox] [0m[0m({,*+.;})[0m
 [33m[tester::#XC5] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mLEFT_BRACE { null
-[33m[your_program] [0mCOMMA , null
-[33m[your_program] [0mSTAR * null
-[33m[your_program] [0mPLUS + null
-[33m[your_program] [0mDOT . null
-[33m[your_program] [0mSEMICOLON ; null
-[33m[your_program] [0mRIGHT_BRACE } null
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mLEFT_BRACE { null[0m
+[33m[your_program] [0m[0mCOMMA , null[0m
+[33m[your_program] [0m[0mSTAR * null[0m
+[33m[your_program] [0m[0mPLUS + null[0m
+[33m[your_program] [0m[0mDOT . null[0m
+[33m[your_program] [0m[0mSEMICOLON ; null[0m
+[33m[your_program] [0m[0mRIGHT_BRACE } null[0m
+[33m[your_program] [0m[0mRIGHT_PAREN ) null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#XC5] [test-4] [0m[92m✓ 10 line(s) match on stdout[0m
 [33m[tester::#XC5] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#XC5] [0m[92mTest passed.[0m
@@ -762,47 +762,47 @@ Debug = true
 [33m[tester::#OE8] [0m[94mRunning tests for Stage #OE8 (oe8)[0m
 [33m[tester::#OE8] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#OE8] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#OE8] [test-1.lox] [0m}
+[33m[tester::#OE8] [test-1.lox] [0m[0m}[0m
 [33m[tester::#OE8] [test-1] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mRIGHT_BRACE } null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mRIGHT_BRACE } null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#OE8] [test-1] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#OE8] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#OE8] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#OE8] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#OE8] [test-2.lox] [0m{{}}
+[33m[tester::#OE8] [test-2.lox] [0m[0m{{}}[0m
 [33m[tester::#OE8] [test-2] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mLEFT_BRACE { null
-[33m[your_program] [0mLEFT_BRACE { null
-[33m[your_program] [0mRIGHT_BRACE } null
-[33m[your_program] [0mRIGHT_BRACE } null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mLEFT_BRACE { null[0m
+[33m[your_program] [0m[0mLEFT_BRACE { null[0m
+[33m[your_program] [0m[0mRIGHT_BRACE } null[0m
+[33m[your_program] [0m[0mRIGHT_BRACE } null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#OE8] [test-2] [0m[92m✓ 5 line(s) match on stdout[0m
 [33m[tester::#OE8] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#OE8] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#OE8] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#OE8] [test-3.lox] [0m{}{}{
+[33m[tester::#OE8] [test-3.lox] [0m[0m{}{}{[0m
 [33m[tester::#OE8] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mLEFT_BRACE { null
-[33m[your_program] [0mRIGHT_BRACE } null
-[33m[your_program] [0mLEFT_BRACE { null
-[33m[your_program] [0mRIGHT_BRACE } null
-[33m[your_program] [0mLEFT_BRACE { null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mLEFT_BRACE { null[0m
+[33m[your_program] [0m[0mRIGHT_BRACE } null[0m
+[33m[your_program] [0m[0mLEFT_BRACE { null[0m
+[33m[your_program] [0m[0mRIGHT_BRACE } null[0m
+[33m[your_program] [0m[0mLEFT_BRACE { null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#OE8] [test-3] [0m[92m✓ 6 line(s) match on stdout[0m
 [33m[tester::#OE8] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#OE8] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#OE8] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#OE8] [test-4.lox] [0m(()})}{
+[33m[tester::#OE8] [test-4.lox] [0m[0m(()})}{[0m
 [33m[tester::#OE8] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mRIGHT_BRACE } null
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mRIGHT_BRACE } null
-[33m[your_program] [0mLEFT_BRACE { null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mRIGHT_PAREN ) null[0m
+[33m[your_program] [0m[0mRIGHT_BRACE } null[0m
+[33m[your_program] [0m[0mRIGHT_PAREN ) null[0m
+[33m[your_program] [0m[0mRIGHT_BRACE } null[0m
+[33m[your_program] [0m[0mLEFT_BRACE { null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#OE8] [test-4] [0m[92m✓ 8 line(s) match on stdout[0m
 [33m[tester::#OE8] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#OE8] [0m[92mTest passed.[0m
@@ -810,54 +810,54 @@ Debug = true
 [33m[tester::#OL4] [0m[94mRunning tests for Stage #OL4 (ol4)[0m
 [33m[tester::#OL4] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#OL4] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#OL4] [test-1.lox] [0m(
+[33m[tester::#OL4] [test-1.lox] [0m[0m([0m
 [33m[tester::#OL4] [test-1] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#OL4] [test-1] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#OL4] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#OL4] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#OL4] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#OL4] [test-2.lox] [0m))
+[33m[tester::#OL4] [test-2.lox] [0m[0m))[0m
 [33m[tester::#OL4] [test-2] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mRIGHT_PAREN ) null[0m
+[33m[your_program] [0m[0mRIGHT_PAREN ) null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#OL4] [test-2] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#OL4] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#OL4] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#OL4] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#OL4] [test-3.lox] [0m)(()(
+[33m[tester::#OL4] [test-3.lox] [0m[0m)(()([0m
 [33m[tester::#OL4] [test-3] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mRIGHT_PAREN ) null[0m
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mRIGHT_PAREN ) null[0m
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#OL4] [test-3] [0m[92m✓ 6 line(s) match on stdout[0m
 [33m[tester::#OL4] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#OL4] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#OL4] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#OL4] [test-4.lox] [0m())((()
+[33m[tester::#OL4] [test-4.lox] [0m[0m())((()[0m
 [33m[tester::#OL4] [test-4] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mLEFT_PAREN ( null
-[33m[your_program] [0mRIGHT_PAREN ) null
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mRIGHT_PAREN ) null[0m
+[33m[your_program] [0m[0mRIGHT_PAREN ) null[0m
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mLEFT_PAREN ( null[0m
+[33m[your_program] [0m[0mRIGHT_PAREN ) null[0m
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#OL4] [test-4] [0m[92m✓ 8 line(s) match on stdout[0m
 [33m[tester::#OL4] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#OL4] [0m[92mTest passed.[0m
 
 [33m[tester::#RY8] [0m[94mRunning tests for Stage #RY8 (ry8)[0m
 [33m[tester::#RY8] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#RY8] [test-1.lox] [0m<|EMPTY FILE|>
+[33m[tester::#RY8] [test-1.lox] [0m[0m<|EMPTY FILE|>[0m
 [33m[tester::#RY8] [test-1] [0m[94m$ ./your_program.sh tokenize test.lox[0m
-[33m[your_program] [0mEOF  null
+[33m[your_program] [0m[0mEOF  null[0m
 [33m[tester::#RY8] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#RY8] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#RY8] [0m[92mTest passed.[0m

--- a/internal/test_helpers/fixtures/pass_statements
+++ b/internal/test_helpers/fixtures/pass_statements
@@ -3,32 +3,32 @@ Debug = true
 [33m[tester::#XY1] [0m[94mRunning tests for Stage #XY1 (xy1)[0m
 [33m[tester::#XY1] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#XY1] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#XY1] [test-1.lox] [0mprint false;
+[33m[tester::#XY1] [test-1.lox] [0m[0mprint false;[0m
 [33m[tester::#XY1] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mfalse
+[33m[your_program] [0m[0mfalse[0m
 [33m[tester::#XY1] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#XY1] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#XY1] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#XY1] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#XY1] [test-2.lox] [0m[33m// Concatenation of strings should work[0m
-[33m[tester::#XY1] [test-2.lox] [0mprint "quz" + "hello" + "baz";
+[33m[tester::#XY1] [test-2.lox] [0m[0m[33m// Concatenation of strings should work[0m[0m
+[33m[tester::#XY1] [test-2.lox] [0m[0mprint "quz" + "hello" + "baz";[0m
 [33m[tester::#XY1] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mquzhellobaz
+[33m[your_program] [0m[0mquzhellobaz[0m
 [33m[tester::#XY1] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#XY1] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#XY1] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#XY1] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#XY1] [test-3.lox] [0mprint (92 * 2 + 96 * 2) / (2);
+[33m[tester::#XY1] [test-3.lox] [0m[0mprint (92 * 2 + 96 * 2) / (2);[0m
 [33m[tester::#XY1] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m188
+[33m[your_program] [0m[0m188[0m
 [33m[tester::#XY1] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#XY1] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#XY1] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#XY1] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#XY1] [test-4.lox] [0m[33m// Print statements expect an expression[0m
-[33m[tester::#XY1] [test-4.lox] [0mprint; [33m// expect compile error[0m
+[33m[tester::#XY1] [test-4.lox] [0m[0m[33m// Print statements expect an expression[0m[0m
+[33m[tester::#XY1] [test-4.lox] [0m[0mprint; [33m// expect compile error[0m[0m
 [33m[tester::#XY1] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 2] Error at ';': Expect expression.
+[33m[your_program] [0m[0m[line 2] Error at ';': Expect expression.[0m
 [33m[tester::#XY1] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#XY1] [test-4] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#XY1] [0m[92mTest passed.[0m
@@ -36,67 +36,67 @@ Debug = true
 [33m[tester::#OE4] [0m[94mRunning tests for Stage #OE4 (oe4)[0m
 [33m[tester::#OE4] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#OE4] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#OE4] [test-1.lox] [0m[33m// Concatenation of strings should work[0m
-[33m[tester::#OE4] [test-1.lox] [0mprint "hello" + "foo" + "world";
-[33m[tester::#OE4] [test-1.lox] [0mprint 34 - 90;
-[33m[tester::#OE4] [test-1.lox] [0mprint "world" == "quz";
+[33m[tester::#OE4] [test-1.lox] [0m[0m[33m// Concatenation of strings should work[0m[0m
+[33m[tester::#OE4] [test-1.lox] [0m[0mprint "hello" + "foo" + "world";[0m
+[33m[tester::#OE4] [test-1.lox] [0m[0mprint 34 - 90;[0m
+[33m[tester::#OE4] [test-1.lox] [0m[0mprint "world" == "quz";[0m
 [33m[tester::#OE4] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mhellofooworld
-[33m[your_program] [0m-56
-[33m[your_program] [0mfalse
+[33m[your_program] [0m[0mhellofooworld[0m
+[33m[your_program] [0m[0m-56[0m
+[33m[your_program] [0m[0mfalse[0m
 [33m[tester::#OE4] [test-1] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#OE4] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#OE4] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#OE4] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#OE4] [test-2.lox] [0m[33m// Multiple statements in a single line should work[0m
-[33m[tester::#OE4] [test-2.lox] [0mprint "bar"; print true;
-[33m[tester::#OE4] [test-2.lox] [0mprint true;
-[33m[tester::#OE4] [test-2.lox] [0mprint "world"; print 28;
+[33m[tester::#OE4] [test-2.lox] [0m[0m[33m// Multiple statements in a single line should work[0m[0m
+[33m[tester::#OE4] [test-2.lox] [0m[0mprint "bar"; print true;[0m
+[33m[tester::#OE4] [test-2.lox] [0m[0mprint true;[0m
+[33m[tester::#OE4] [test-2.lox] [0m[0mprint "world"; print 28;[0m
 [33m[tester::#OE4] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mbar
-[33m[your_program] [0mtrue
-[33m[your_program] [0mtrue
-[33m[your_program] [0mworld
-[33m[your_program] [0m28
+[33m[your_program] [0m[0mbar[0m
+[33m[your_program] [0m[0mtrue[0m
+[33m[your_program] [0m[0mtrue[0m
+[33m[your_program] [0m[0mworld[0m
+[33m[your_program] [0m[0m28[0m
 [33m[tester::#OE4] [test-2] [0m[92m✓ 5 line(s) match on stdout[0m
 [33m[tester::#OE4] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#OE4] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#OE4] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#OE4] [test-3.lox] [0m[33m// Leading whitespace should be ignored[0m
-[33m[tester::#OE4] [test-3.lox] [0mprint 17;
-[33m[tester::#OE4] [test-3.lox] [0m    print 17 + 81;
-[33m[tester::#OE4] [test-3.lox] [0m        print 17 + 81 + 52;
+[33m[tester::#OE4] [test-3.lox] [0m[0m[33m// Leading whitespace should be ignored[0m[0m
+[33m[tester::#OE4] [test-3.lox] [0m[0mprint 17;[0m
+[33m[tester::#OE4] [test-3.lox] [0m[0m    print 17 + 81;[0m
+[33m[tester::#OE4] [test-3.lox] [0m[0m        print 17 + 81 + 52;[0m
 [33m[tester::#OE4] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m17
-[33m[your_program] [0m98
-[33m[your_program] [0m150
+[33m[your_program] [0m[0m17[0m
+[33m[your_program] [0m[0m98[0m
+[33m[your_program] [0m[0m150[0m
 [33m[tester::#OE4] [test-3] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#OE4] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#OE4] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#OE4] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#OE4] [test-4.lox] [0mprint true != true;
-[33m[tester::#OE4] [test-4.lox] [0m
-[33m[tester::#OE4] [test-4.lox] [0m[33m// multi-line strings should be supported[0m
-[33m[tester::#OE4] [test-4.lox] [0mprint "44
-[33m[tester::#OE4] [test-4.lox] [0m84
-[33m[tester::#OE4] [test-4.lox] [0m70
-[33m[tester::#OE4] [test-4.lox] [0m";
-[33m[tester::#OE4] [test-4.lox] [0m
-[33m[tester::#OE4] [test-4.lox] [0mprint "There should be an empty line above this.";
-[33m[tester::#OE4] [test-4.lox] [0m
-[33m[tester::#OE4] [test-4.lox] [0mprint "(" + "" + ")";
-[33m[tester::#OE4] [test-4.lox] [0m
-[33m[tester::#OE4] [test-4.lox] [0m[33m// non-ascii characters should be supported[0m
-[33m[tester::#OE4] [test-4.lox] [0mprint "non-ascii: ॐ";
+[33m[tester::#OE4] [test-4.lox] [0m[0mprint true != true;[0m
+[33m[tester::#OE4] [test-4.lox] [0m[0m[0m
+[33m[tester::#OE4] [test-4.lox] [0m[0m[33m// multi-line strings should be supported[0m[0m
+[33m[tester::#OE4] [test-4.lox] [0m[0mprint "44[0m
+[33m[tester::#OE4] [test-4.lox] [0m[0m84[0m
+[33m[tester::#OE4] [test-4.lox] [0m[0m70[0m
+[33m[tester::#OE4] [test-4.lox] [0m[0m";[0m
+[33m[tester::#OE4] [test-4.lox] [0m[0m[0m
+[33m[tester::#OE4] [test-4.lox] [0m[0mprint "There should be an empty line above this.";[0m
+[33m[tester::#OE4] [test-4.lox] [0m[0m[0m
+[33m[tester::#OE4] [test-4.lox] [0m[0mprint "(" + "" + ")";[0m
+[33m[tester::#OE4] [test-4.lox] [0m[0m[0m
+[33m[tester::#OE4] [test-4.lox] [0m[0m[33m// non-ascii characters should be supported[0m[0m
+[33m[tester::#OE4] [test-4.lox] [0m[0mprint "non-ascii: ॐ";[0m
 [33m[tester::#OE4] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mfalse
-[33m[your_program] [0m44
-[33m[your_program] [0m84
-[33m[your_program] [0m70
-[33m[your_program] [0m
-[33m[your_program] [0mThere should be an empty line above this.
-[33m[your_program] [0m()
-[33m[your_program] [0mnon-ascii: ॐ
+[33m[your_program] [0m[0mfalse[0m
+[33m[your_program] [0m[0m44[0m
+[33m[your_program] [0m[0m84[0m
+[33m[your_program] [0m[0m70[0m
+[33m[your_program] [0m[0m[0m
+[33m[your_program] [0m[0mThere should be an empty line above this.[0m
+[33m[your_program] [0m[0m()[0m
+[33m[your_program] [0m[0mnon-ascii: ॐ[0m
 [33m[tester::#OE4] [test-4] [0m[92m✓ 8 line(s) match on stdout[0m
 [33m[tester::#OE4] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#OE4] [0m[92mTest passed.[0m
@@ -104,55 +104,55 @@ Debug = true
 [33m[tester::#FI3] [0m[94mRunning tests for Stage #FI3 (fi3)[0m
 [33m[tester::#FI3] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#FI3] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#FI3] [test-1.lox] [0m[33m// This program tests that statements are executed[0m
-[33m[tester::#FI3] [test-1.lox] [0m[33m// even if they don't have any side effects[0m
-[33m[tester::#FI3] [test-1.lox] [0m[33m// It also tests complex arithmetic expressions[0m
-[33m[tester::#FI3] [test-1.lox] [0m[33m// and string concatenation[0m
-[33m[tester::#FI3] [test-1.lox] [0m(74 + 46 - 10) > (42 - 74) * 2;
-[33m[tester::#FI3] [test-1.lox] [0mprint !false;
-[33m[tester::#FI3] [test-1.lox] [0m"quz" + "world" + "bar" == "quzworldbar";
-[33m[tester::#FI3] [test-1.lox] [0mprint !false;
+[33m[tester::#FI3] [test-1.lox] [0m[0m[33m// This program tests that statements are executed[0m[0m
+[33m[tester::#FI3] [test-1.lox] [0m[0m[33m// even if they don't have any side effects[0m[0m
+[33m[tester::#FI3] [test-1.lox] [0m[0m[33m// It also tests complex arithmetic expressions[0m[0m
+[33m[tester::#FI3] [test-1.lox] [0m[0m[33m// and string concatenation[0m[0m
+[33m[tester::#FI3] [test-1.lox] [0m[0m(74 + 46 - 10) > (42 - 74) * 2;[0m
+[33m[tester::#FI3] [test-1.lox] [0m[0mprint !false;[0m
+[33m[tester::#FI3] [test-1.lox] [0m[0m"quz" + "world" + "bar" == "quzworldbar";[0m
+[33m[tester::#FI3] [test-1.lox] [0m[0mprint !false;[0m
 [33m[tester::#FI3] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mtrue
-[33m[your_program] [0mtrue
+[33m[your_program] [0m[0mtrue[0m
+[33m[your_program] [0m[0mtrue[0m
 [33m[tester::#FI3] [test-1] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#FI3] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#FI3] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#FI3] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#FI3] [test-2.lox] [0m[33m// This program tests statements that don't have[0m
-[33m[tester::#FI3] [test-2.lox] [0m[33m// any side effects[0m
-[33m[tester::#FI3] [test-2.lox] [0m53 - 31 >= -90 * 2 / 90 + 27;
-[33m[tester::#FI3] [test-2.lox] [0mfalse == false;
-[33m[tester::#FI3] [test-2.lox] [0m("world" == "hello") == ("quz" != "baz");
-[33m[tester::#FI3] [test-2.lox] [0mprint false;
+[33m[tester::#FI3] [test-2.lox] [0m[0m[33m// This program tests statements that don't have[0m[0m
+[33m[tester::#FI3] [test-2.lox] [0m[0m[33m// any side effects[0m[0m
+[33m[tester::#FI3] [test-2.lox] [0m[0m53 - 31 >= -90 * 2 / 90 + 27;[0m
+[33m[tester::#FI3] [test-2.lox] [0m[0mfalse == false;[0m
+[33m[tester::#FI3] [test-2.lox] [0m[0m("world" == "hello") == ("quz" != "baz");[0m
+[33m[tester::#FI3] [test-2.lox] [0m[0mprint false;[0m
 [33m[tester::#FI3] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mfalse
+[33m[your_program] [0m[0mfalse[0m
 [33m[tester::#FI3] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#FI3] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#FI3] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#FI3] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#FI3] [test-3.lox] [0m[33m// This program tests that the + operator is only[0m
-[33m[tester::#FI3] [test-3.lox] [0m[33m// supported when both operands are numbers or[0m
-[33m[tester::#FI3] [test-3.lox] [0m[33m// both are strings[0m
-[33m[tester::#FI3] [test-3.lox] [0mprint "the expression below is invalid";
-[33m[tester::#FI3] [test-3.lox] [0m62 + "quz";
-[33m[tester::#FI3] [test-3.lox] [0mprint "this should not be printed";
+[33m[tester::#FI3] [test-3.lox] [0m[0m[33m// This program tests that the + operator is only[0m[0m
+[33m[tester::#FI3] [test-3.lox] [0m[0m[33m// supported when both operands are numbers or[0m[0m
+[33m[tester::#FI3] [test-3.lox] [0m[0m[33m// both are strings[0m[0m
+[33m[tester::#FI3] [test-3.lox] [0m[0mprint "the expression below is invalid";[0m
+[33m[tester::#FI3] [test-3.lox] [0m[0m62 + "quz";[0m
+[33m[tester::#FI3] [test-3.lox] [0m[0mprint "this should not be printed";[0m
 [33m[tester::#FI3] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mthe expression below is invalid
-[33m[your_program] [0mOperands must be two numbers or two strings.
-[33m[your_program] [0m[line 5]
+[33m[your_program] [0m[0mthe expression below is invalid[0m
+[33m[your_program] [0m[0mOperands must be two numbers or two strings.[0m
+[33m[your_program] [0m[0m[line 5][0m
 [33m[tester::#FI3] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#FI3] [test-3] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#FI3] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#FI3] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#FI3] [test-4.lox] [0m[33m// This program tests that the * operator is only[0m
-[33m[tester::#FI3] [test-4.lox] [0m[33m// supported when both operands are numbers[0m
-[33m[tester::#FI3] [test-4.lox] [0mprint "50" + "hello";
-[33m[tester::#FI3] [test-4.lox] [0mprint false * (97 + 23);
+[33m[tester::#FI3] [test-4.lox] [0m[0m[33m// This program tests that the * operator is only[0m[0m
+[33m[tester::#FI3] [test-4.lox] [0m[0m[33m// supported when both operands are numbers[0m[0m
+[33m[tester::#FI3] [test-4.lox] [0m[0mprint "50" + "hello";[0m
+[33m[tester::#FI3] [test-4.lox] [0m[0mprint false * (97 + 23);[0m
 [33m[tester::#FI3] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m50hello
-[33m[your_program] [0mOperands must be numbers.
-[33m[your_program] [0m[line 4]
+[33m[your_program] [0m[0m50hello[0m
+[33m[your_program] [0m[0mOperands must be numbers.[0m
+[33m[your_program] [0m[0m[line 4][0m
 [33m[tester::#FI3] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#FI3] [test-4] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#FI3] [0m[92mTest passed.[0m
@@ -160,50 +160,50 @@ Debug = true
 [33m[tester::#YG2] [0m[94mRunning tests for Stage #YG2 (yg2)[0m
 [33m[tester::#YG2] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#YG2] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YG2] [test-1.lox] [0m[33m// This program tests that variables are[0m
-[33m[tester::#YG2] [test-1.lox] [0m[33m// initialized to the correct value[0m
-[33m[tester::#YG2] [test-1.lox] [0mvar baz = 10;
-[33m[tester::#YG2] [test-1.lox] [0mprint baz;
+[33m[tester::#YG2] [test-1.lox] [0m[0m[33m// This program tests that variables are[0m[0m
+[33m[tester::#YG2] [test-1.lox] [0m[0m[33m// initialized to the correct value[0m[0m
+[33m[tester::#YG2] [test-1.lox] [0m[0mvar baz = 10;[0m
+[33m[tester::#YG2] [test-1.lox] [0m[0mprint baz;[0m
 [33m[tester::#YG2] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m10
+[33m[your_program] [0m[0m10[0m
 [33m[tester::#YG2] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#YG2] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#YG2] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#YG2] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YG2] [test-2.lox] [0m[33m// This program declares multiple variables and[0m
-[33m[tester::#YG2] [test-2.lox] [0m[33m// prints the result of arithmetic operations on[0m
-[33m[tester::#YG2] [test-2.lox] [0m[33m// them[0m
-[33m[tester::#YG2] [test-2.lox] [0mvar foo = 17;
-[33m[tester::#YG2] [test-2.lox] [0mvar bar = 17;
-[33m[tester::#YG2] [test-2.lox] [0mprint foo + bar;
-[33m[tester::#YG2] [test-2.lox] [0mvar quz = 17;
-[33m[tester::#YG2] [test-2.lox] [0mprint foo + bar + quz;
+[33m[tester::#YG2] [test-2.lox] [0m[0m[33m// This program declares multiple variables and[0m[0m
+[33m[tester::#YG2] [test-2.lox] [0m[0m[33m// prints the result of arithmetic operations on[0m[0m
+[33m[tester::#YG2] [test-2.lox] [0m[0m[33m// them[0m[0m
+[33m[tester::#YG2] [test-2.lox] [0m[0mvar foo = 17;[0m
+[33m[tester::#YG2] [test-2.lox] [0m[0mvar bar = 17;[0m
+[33m[tester::#YG2] [test-2.lox] [0m[0mprint foo + bar;[0m
+[33m[tester::#YG2] [test-2.lox] [0m[0mvar quz = 17;[0m
+[33m[tester::#YG2] [test-2.lox] [0m[0mprint foo + bar + quz;[0m
 [33m[tester::#YG2] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m34
-[33m[your_program] [0m51
+[33m[your_program] [0m[0m34[0m
+[33m[your_program] [0m[0m51[0m
 [33m[tester::#YG2] [test-2] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#YG2] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#YG2] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#YG2] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YG2] [test-3.lox] [0m[33m// This program assigns the result of an[0m
-[33m[tester::#YG2] [test-3.lox] [0m[33m// arithmetic expression to a variable[0m
-[33m[tester::#YG2] [test-3.lox] [0m[33m// Then it prints the value of the variable[0m
-[33m[tester::#YG2] [test-3.lox] [0mvar quz = (8 * (68 + 68)) / 4 + 68;
-[33m[tester::#YG2] [test-3.lox] [0mprint quz;
+[33m[tester::#YG2] [test-3.lox] [0m[0m[33m// This program assigns the result of an[0m[0m
+[33m[tester::#YG2] [test-3.lox] [0m[0m[33m// arithmetic expression to a variable[0m[0m
+[33m[tester::#YG2] [test-3.lox] [0m[0m[33m// Then it prints the value of the variable[0m[0m
+[33m[tester::#YG2] [test-3.lox] [0m[0mvar quz = (8 * (68 + 68)) / 4 + 68;[0m
+[33m[tester::#YG2] [test-3.lox] [0m[0mprint quz;[0m
 [33m[tester::#YG2] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m340
+[33m[your_program] [0m[0m340[0m
 [33m[tester::#YG2] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#YG2] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#YG2] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#YG2] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YG2] [test-4.lox] [0m[33m// This program declares variables and performs[0m
-[33m[tester::#YG2] [test-4.lox] [0m[33m// operations on them[0m
-[33m[tester::#YG2] [test-4.lox] [0m[33m// Finally it prints the result of the operations[0m
-[33m[tester::#YG2] [test-4.lox] [0mvar bar = 66;
-[33m[tester::#YG2] [test-4.lox] [0mvar foo = bar;
-[33m[tester::#YG2] [test-4.lox] [0mprint foo + bar;
+[33m[tester::#YG2] [test-4.lox] [0m[0m[33m// This program declares variables and performs[0m[0m
+[33m[tester::#YG2] [test-4.lox] [0m[0m[33m// operations on them[0m[0m
+[33m[tester::#YG2] [test-4.lox] [0m[0m[33m// Finally it prints the result of the operations[0m[0m
+[33m[tester::#YG2] [test-4.lox] [0m[0mvar bar = 66;[0m
+[33m[tester::#YG2] [test-4.lox] [0m[0mvar foo = bar;[0m
+[33m[tester::#YG2] [test-4.lox] [0m[0mprint foo + bar;[0m
 [33m[tester::#YG2] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m132
+[33m[your_program] [0m[0m132[0m
 [33m[tester::#YG2] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#YG2] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#YG2] [0m[92mTest passed.[0m
@@ -211,54 +211,54 @@ Debug = true
 [33m[tester::#SV7] [0m[94mRunning tests for Stage #SV7 (sv7)[0m
 [33m[tester::#SV7] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#SV7] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#SV7] [test-1.lox] [0m[33m// This program tries to access a variable before[0m
-[33m[tester::#SV7] [test-1.lox] [0m[33m// it is declared[0m
-[33m[tester::#SV7] [test-1.lox] [0m[33m// It leads to a runtime error[0m
-[33m[tester::#SV7] [test-1.lox] [0mprint 45;
-[33m[tester::#SV7] [test-1.lox] [0mprint x;
+[33m[tester::#SV7] [test-1.lox] [0m[0m[33m// This program tries to access a variable before[0m[0m
+[33m[tester::#SV7] [test-1.lox] [0m[0m[33m// it is declared[0m[0m
+[33m[tester::#SV7] [test-1.lox] [0m[0m[33m// It leads to a runtime error[0m[0m
+[33m[tester::#SV7] [test-1.lox] [0m[0mprint 45;[0m
+[33m[tester::#SV7] [test-1.lox] [0m[0mprint x;[0m
 [33m[tester::#SV7] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m45
-[33m[your_program] [0mUndefined variable 'x'.
-[33m[your_program] [0m[line 5]
+[33m[your_program] [0m[0m45[0m
+[33m[your_program] [0m[0mUndefined variable 'x'.[0m
+[33m[your_program] [0m[0m[line 5][0m
 [33m[tester::#SV7] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#SV7] [test-1] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#SV7] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#SV7] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#SV7] [test-2.lox] [0m[33m// This program tries to access a variable before[0m
-[33m[tester::#SV7] [test-2.lox] [0m[33m// it is declared[0m
-[33m[tester::#SV7] [test-2.lox] [0m[33m// It leads to a runtime error[0m
-[33m[tester::#SV7] [test-2.lox] [0mvar world = 16;
-[33m[tester::#SV7] [test-2.lox] [0mprint baz;
+[33m[tester::#SV7] [test-2.lox] [0m[0m[33m// This program tries to access a variable before[0m[0m
+[33m[tester::#SV7] [test-2.lox] [0m[0m[33m// it is declared[0m[0m
+[33m[tester::#SV7] [test-2.lox] [0m[0m[33m// It leads to a runtime error[0m[0m
+[33m[tester::#SV7] [test-2.lox] [0m[0mvar world = 16;[0m
+[33m[tester::#SV7] [test-2.lox] [0m[0mprint baz;[0m
 [33m[tester::#SV7] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mUndefined variable 'baz'.
-[33m[your_program] [0m[line 5]
+[33m[your_program] [0m[0mUndefined variable 'baz'.[0m
+[33m[your_program] [0m[0m[line 5][0m
 [33m[tester::#SV7] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#SV7] [test-2] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#SV7] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#SV7] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#SV7] [test-3.lox] [0m[33m// This program tries to access a variable before[0m
-[33m[tester::#SV7] [test-3.lox] [0m[33m// it is declared[0m
-[33m[tester::#SV7] [test-3.lox] [0m[33m// It leads to a runtime error[0m
-[33m[tester::#SV7] [test-3.lox] [0mvar world = 47;
-[33m[tester::#SV7] [test-3.lox] [0mvar result = (world + foo) / bar;
-[33m[tester::#SV7] [test-3.lox] [0mprint result;
+[33m[tester::#SV7] [test-3.lox] [0m[0m[33m// This program tries to access a variable before[0m[0m
+[33m[tester::#SV7] [test-3.lox] [0m[0m[33m// it is declared[0m[0m
+[33m[tester::#SV7] [test-3.lox] [0m[0m[33m// It leads to a runtime error[0m[0m
+[33m[tester::#SV7] [test-3.lox] [0m[0mvar world = 47;[0m
+[33m[tester::#SV7] [test-3.lox] [0m[0mvar result = (world + foo) / bar;[0m
+[33m[tester::#SV7] [test-3.lox] [0m[0mprint result;[0m
 [33m[tester::#SV7] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mUndefined variable 'foo'.
-[33m[your_program] [0m[line 5]
+[33m[your_program] [0m[0mUndefined variable 'foo'.[0m
+[33m[your_program] [0m[0m[line 5][0m
 [33m[tester::#SV7] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#SV7] [test-3] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#SV7] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#SV7] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#SV7] [test-4.lox] [0m[33m// This program tries to access a variable before[0m
-[33m[tester::#SV7] [test-4.lox] [0m[33m// it is declared[0m
-[33m[tester::#SV7] [test-4.lox] [0m[33m// It leads to a runtime error[0m
-[33m[tester::#SV7] [test-4.lox] [0mvar quz = 88;
-[33m[tester::#SV7] [test-4.lox] [0mvar hello = 96;
-[33m[tester::#SV7] [test-4.lox] [0mvar foo = 36;
-[33m[tester::#SV7] [test-4.lox] [0mprint quz + hello + foo + bar; print 53;
+[33m[tester::#SV7] [test-4.lox] [0m[0m[33m// This program tries to access a variable before[0m[0m
+[33m[tester::#SV7] [test-4.lox] [0m[0m[33m// it is declared[0m[0m
+[33m[tester::#SV7] [test-4.lox] [0m[0m[33m// It leads to a runtime error[0m[0m
+[33m[tester::#SV7] [test-4.lox] [0m[0mvar quz = 88;[0m
+[33m[tester::#SV7] [test-4.lox] [0m[0mvar hello = 96;[0m
+[33m[tester::#SV7] [test-4.lox] [0m[0mvar foo = 36;[0m
+[33m[tester::#SV7] [test-4.lox] [0m[0mprint quz + hello + foo + bar; print 53;[0m
 [33m[tester::#SV7] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mUndefined variable 'bar'.
-[33m[your_program] [0m[line 7]
+[33m[your_program] [0m[0mUndefined variable 'bar'.[0m
+[33m[your_program] [0m[0m[line 7][0m
 [33m[tester::#SV7] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#SV7] [test-4] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#SV7] [0m[92mTest passed.[0m
@@ -266,56 +266,56 @@ Debug = true
 [33m[tester::#BC1] [0m[94mRunning tests for Stage #BC1 (bc1)[0m
 [33m[tester::#BC1] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#BC1] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#BC1] [test-1.lox] [0m[33m// This program declares a variable but doesn't[0m
-[33m[tester::#BC1] [test-1.lox] [0m[33m// initialize it[0m
-[33m[tester::#BC1] [test-1.lox] [0m[33m// It prints the variable's value, which should be[0m
-[33m[tester::#BC1] [test-1.lox] [0m[33m// nil[0m
-[33m[tester::#BC1] [test-1.lox] [0mvar hello;
-[33m[tester::#BC1] [test-1.lox] [0mprint hello;
+[33m[tester::#BC1] [test-1.lox] [0m[0m[33m// This program declares a variable but doesn't[0m[0m
+[33m[tester::#BC1] [test-1.lox] [0m[0m[33m// initialize it[0m[0m
+[33m[tester::#BC1] [test-1.lox] [0m[0m[33m// It prints the variable's value, which should be[0m[0m
+[33m[tester::#BC1] [test-1.lox] [0m[0m[33m// nil[0m[0m
+[33m[tester::#BC1] [test-1.lox] [0m[0mvar hello;[0m
+[33m[tester::#BC1] [test-1.lox] [0m[0mprint hello;[0m
 [33m[tester::#BC1] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mnil
+[33m[your_program] [0m[0mnil[0m
 [33m[tester::#BC1] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#BC1] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#BC1] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#BC1] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#BC1] [test-2.lox] [0m[33m// This program declares a variable but doesn't[0m
-[33m[tester::#BC1] [test-2.lox] [0m[33m// initialize it[0m
-[33m[tester::#BC1] [test-2.lox] [0m[33m// It prints the variable's value[0m
-[33m[tester::#BC1] [test-2.lox] [0mvar foo = "baz";
-[33m[tester::#BC1] [test-2.lox] [0mvar bar;
-[33m[tester::#BC1] [test-2.lox] [0mprint bar;
+[33m[tester::#BC1] [test-2.lox] [0m[0m[33m// This program declares a variable but doesn't[0m[0m
+[33m[tester::#BC1] [test-2.lox] [0m[0m[33m// initialize it[0m[0m
+[33m[tester::#BC1] [test-2.lox] [0m[0m[33m// It prints the variable's value[0m[0m
+[33m[tester::#BC1] [test-2.lox] [0m[0mvar foo = "baz";[0m
+[33m[tester::#BC1] [test-2.lox] [0m[0mvar bar;[0m
+[33m[tester::#BC1] [test-2.lox] [0m[0mprint bar;[0m
 [33m[tester::#BC1] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mnil
+[33m[your_program] [0m[0mnil[0m
 [33m[tester::#BC1] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#BC1] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#BC1] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#BC1] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#BC1] [test-3.lox] [0m[33m// This program declares a variable but doesn't[0m
-[33m[tester::#BC1] [test-3.lox] [0m[33m// initialize it[0m
-[33m[tester::#BC1] [test-3.lox] [0m[33m// It prints the variable's value[0m
-[33m[tester::#BC1] [test-3.lox] [0mvar quz = 25;
-[33m[tester::#BC1] [test-3.lox] [0mvar hello;
-[33m[tester::#BC1] [test-3.lox] [0mvar foo;
-[33m[tester::#BC1] [test-3.lox] [0mprint hello;
+[33m[tester::#BC1] [test-3.lox] [0m[0m[33m// This program declares a variable but doesn't[0m[0m
+[33m[tester::#BC1] [test-3.lox] [0m[0m[33m// initialize it[0m[0m
+[33m[tester::#BC1] [test-3.lox] [0m[0m[33m// It prints the variable's value[0m[0m
+[33m[tester::#BC1] [test-3.lox] [0m[0mvar quz = 25;[0m
+[33m[tester::#BC1] [test-3.lox] [0m[0mvar hello;[0m
+[33m[tester::#BC1] [test-3.lox] [0m[0mvar foo;[0m
+[33m[tester::#BC1] [test-3.lox] [0m[0mprint hello;[0m
 [33m[tester::#BC1] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mnil
+[33m[your_program] [0m[0mnil[0m
 [33m[tester::#BC1] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#BC1] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#BC1] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#BC1] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#BC1] [test-4.lox] [0m[33m// This program declares a variable but doesn't[0m
-[33m[tester::#BC1] [test-4.lox] [0m[33m// initialize it[0m
-[33m[tester::#BC1] [test-4.lox] [0m[33m// It prints the variable's value[0m
-[33m[tester::#BC1] [test-4.lox] [0mvar quz = 95 + 71 * 16;
-[33m[tester::#BC1] [test-4.lox] [0mprint quz;
-[33m[tester::#BC1] [test-4.lox] [0mvar baz = 71 * 16;
-[33m[tester::#BC1] [test-4.lox] [0mprint quz + baz;
-[33m[tester::#BC1] [test-4.lox] [0mvar foo;
-[33m[tester::#BC1] [test-4.lox] [0mprint foo;
+[33m[tester::#BC1] [test-4.lox] [0m[0m[33m// This program declares a variable but doesn't[0m[0m
+[33m[tester::#BC1] [test-4.lox] [0m[0m[33m// initialize it[0m[0m
+[33m[tester::#BC1] [test-4.lox] [0m[0m[33m// It prints the variable's value[0m[0m
+[33m[tester::#BC1] [test-4.lox] [0m[0mvar quz = 95 + 71 * 16;[0m
+[33m[tester::#BC1] [test-4.lox] [0m[0mprint quz;[0m
+[33m[tester::#BC1] [test-4.lox] [0m[0mvar baz = 71 * 16;[0m
+[33m[tester::#BC1] [test-4.lox] [0m[0mprint quz + baz;[0m
+[33m[tester::#BC1] [test-4.lox] [0m[0mvar foo;[0m
+[33m[tester::#BC1] [test-4.lox] [0m[0mprint foo;[0m
 [33m[tester::#BC1] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m1231
-[33m[your_program] [0m2367
-[33m[your_program] [0mnil
+[33m[your_program] [0m[0m1231[0m
+[33m[your_program] [0m[0m2367[0m
+[33m[your_program] [0m[0mnil[0m
 [33m[tester::#BC1] [test-4] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#BC1] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#BC1] [0m[92mTest passed.[0m
@@ -323,53 +323,53 @@ Debug = true
 [33m[tester::#DW9] [0m[94mRunning tests for Stage #DW9 (dw9)[0m
 [33m[tester::#DW9] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#DW9] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#DW9] [test-1.lox] [0mvar baz = "before";
-[33m[tester::#DW9] [test-1.lox] [0mprint baz;
-[33m[tester::#DW9] [test-1.lox] [0mvar baz = "after";
-[33m[tester::#DW9] [test-1.lox] [0mprint baz;
+[33m[tester::#DW9] [test-1.lox] [0m[0mvar baz = "before";[0m
+[33m[tester::#DW9] [test-1.lox] [0m[0mprint baz;[0m
+[33m[tester::#DW9] [test-1.lox] [0m[0mvar baz = "after";[0m
+[33m[tester::#DW9] [test-1.lox] [0m[0mprint baz;[0m
 [33m[tester::#DW9] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mbefore
-[33m[your_program] [0mafter
+[33m[your_program] [0m[0mbefore[0m
+[33m[your_program] [0m[0mafter[0m
 [33m[tester::#DW9] [test-1] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#DW9] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#DW9] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#DW9] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#DW9] [test-2.lox] [0mvar world = "after";
-[33m[tester::#DW9] [test-2.lox] [0mvar world = "before";
-[33m[tester::#DW9] [test-2.lox] [0m[33m// Using a previously declared variable's value to[0m
-[33m[tester::#DW9] [test-2.lox] [0m[33m// initialize a new variable should work[0m
-[33m[tester::#DW9] [test-2.lox] [0mvar world = world;
-[33m[tester::#DW9] [test-2.lox] [0mprint world;
+[33m[tester::#DW9] [test-2.lox] [0m[0mvar world = "after";[0m
+[33m[tester::#DW9] [test-2.lox] [0m[0mvar world = "before";[0m
+[33m[tester::#DW9] [test-2.lox] [0m[0m[33m// Using a previously declared variable's value to[0m[0m
+[33m[tester::#DW9] [test-2.lox] [0m[0m[33m// initialize a new variable should work[0m[0m
+[33m[tester::#DW9] [test-2.lox] [0m[0mvar world = world;[0m
+[33m[tester::#DW9] [test-2.lox] [0m[0mprint world;[0m
 [33m[tester::#DW9] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mbefore
+[33m[your_program] [0m[0mbefore[0m
 [33m[tester::#DW9] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#DW9] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#DW9] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#DW9] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#DW9] [test-3.lox] [0m[33m// This program declares and initializes multiple[0m
-[33m[tester::#DW9] [test-3.lox] [0m[33m// variables and prints their values[0m
-[33m[tester::#DW9] [test-3.lox] [0mvar bar = 2;
-[33m[tester::#DW9] [test-3.lox] [0mprint bar;
-[33m[tester::#DW9] [test-3.lox] [0mvar bar = 3;
-[33m[tester::#DW9] [test-3.lox] [0mprint bar;
-[33m[tester::#DW9] [test-3.lox] [0mvar hello = 5;
-[33m[tester::#DW9] [test-3.lox] [0mprint hello;
-[33m[tester::#DW9] [test-3.lox] [0mvar bar = hello;
-[33m[tester::#DW9] [test-3.lox] [0mprint bar;
+[33m[tester::#DW9] [test-3.lox] [0m[0m[33m// This program declares and initializes multiple[0m[0m
+[33m[tester::#DW9] [test-3.lox] [0m[0m[33m// variables and prints their values[0m[0m
+[33m[tester::#DW9] [test-3.lox] [0m[0mvar bar = 2;[0m
+[33m[tester::#DW9] [test-3.lox] [0m[0mprint bar;[0m
+[33m[tester::#DW9] [test-3.lox] [0m[0mvar bar = 3;[0m
+[33m[tester::#DW9] [test-3.lox] [0m[0mprint bar;[0m
+[33m[tester::#DW9] [test-3.lox] [0m[0mvar hello = 5;[0m
+[33m[tester::#DW9] [test-3.lox] [0m[0mprint hello;[0m
+[33m[tester::#DW9] [test-3.lox] [0m[0mvar bar = hello;[0m
+[33m[tester::#DW9] [test-3.lox] [0m[0mprint bar;[0m
 [33m[tester::#DW9] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m2
-[33m[your_program] [0m3
-[33m[your_program] [0m5
-[33m[your_program] [0m5
+[33m[your_program] [0m[0m2[0m
+[33m[your_program] [0m[0m3[0m
+[33m[your_program] [0m[0m5[0m
+[33m[your_program] [0m[0m5[0m
 [33m[tester::#DW9] [test-3] [0m[92m✓ 4 line(s) match on stdout[0m
 [33m[tester::#DW9] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#DW9] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#DW9] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#DW9] [test-4.lox] [0m[33m// As baz is not declared before[0m
-[33m[tester::#DW9] [test-4.lox] [0mvar hello = baz; [33m// expect runtime error[0m
+[33m[tester::#DW9] [test-4.lox] [0m[0m[33m// As baz is not declared before[0m[0m
+[33m[tester::#DW9] [test-4.lox] [0m[0mvar hello = baz; [33m// expect runtime error[0m[0m
 [33m[tester::#DW9] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mUndefined variable 'baz'.
-[33m[your_program] [0m[line 2]
+[33m[your_program] [0m[0mUndefined variable 'baz'.[0m
+[33m[your_program] [0m[0m[line 2][0m
 [33m[tester::#DW9] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#DW9] [test-4] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#DW9] [0m[92mTest passed.[0m
@@ -377,63 +377,63 @@ Debug = true
 [33m[tester::#PL3] [0m[94mRunning tests for Stage #PL3 (pl3)[0m
 [33m[tester::#PL3] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#PL3] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PL3] [test-1.lox] [0mvar baz;
-[33m[tester::#PL3] [test-1.lox] [0mbaz = 1;
-[33m[tester::#PL3] [test-1.lox] [0mprint baz;
-[33m[tester::#PL3] [test-1.lox] [0m[33m// The assignment operator should return[0m
-[33m[tester::#PL3] [test-1.lox] [0m[33m// the value that was assigned[0m
-[33m[tester::#PL3] [test-1.lox] [0mprint baz = 2;
-[33m[tester::#PL3] [test-1.lox] [0mprint baz;
+[33m[tester::#PL3] [test-1.lox] [0m[0mvar baz;[0m
+[33m[tester::#PL3] [test-1.lox] [0m[0mbaz = 1;[0m
+[33m[tester::#PL3] [test-1.lox] [0m[0mprint baz;[0m
+[33m[tester::#PL3] [test-1.lox] [0m[0m[33m// The assignment operator should return[0m[0m
+[33m[tester::#PL3] [test-1.lox] [0m[0m[33m// the value that was assigned[0m[0m
+[33m[tester::#PL3] [test-1.lox] [0m[0mprint baz = 2;[0m
+[33m[tester::#PL3] [test-1.lox] [0m[0mprint baz;[0m
 [33m[tester::#PL3] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m1
-[33m[your_program] [0m2
-[33m[your_program] [0m2
+[33m[your_program] [0m[0m1[0m
+[33m[your_program] [0m[0m2[0m
+[33m[your_program] [0m[0m2[0m
 [33m[tester::#PL3] [test-1] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#PL3] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#PL3] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#PL3] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PL3] [test-2.lox] [0m[33m// This program tests that the assignment operator[0m
-[33m[tester::#PL3] [test-2.lox] [0m[33m// works on any declared variable[0m
-[33m[tester::#PL3] [test-2.lox] [0mvar bar = 87;
-[33m[tester::#PL3] [test-2.lox] [0mvar world = 87;
-[33m[tester::#PL3] [test-2.lox] [0mworld = bar;
-[33m[tester::#PL3] [test-2.lox] [0mbar = world;
-[33m[tester::#PL3] [test-2.lox] [0mprint bar + world;
+[33m[tester::#PL3] [test-2.lox] [0m[0m[33m// This program tests that the assignment operator[0m[0m
+[33m[tester::#PL3] [test-2.lox] [0m[0m[33m// works on any declared variable[0m[0m
+[33m[tester::#PL3] [test-2.lox] [0m[0mvar bar = 87;[0m
+[33m[tester::#PL3] [test-2.lox] [0m[0mvar world = 87;[0m
+[33m[tester::#PL3] [test-2.lox] [0m[0mworld = bar;[0m
+[33m[tester::#PL3] [test-2.lox] [0m[0mbar = world;[0m
+[33m[tester::#PL3] [test-2.lox] [0m[0mprint bar + world;[0m
 [33m[tester::#PL3] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m174
+[33m[your_program] [0m[0m174[0m
 [33m[tester::#PL3] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#PL3] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#PL3] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#PL3] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PL3] [test-3.lox] [0mvar foo;
-[33m[tester::#PL3] [test-3.lox] [0mvar baz;
-[33m[tester::#PL3] [test-3.lox] [0m
-[33m[tester::#PL3] [test-3.lox] [0m[33m// The assignment operator should return[0m
-[33m[tester::#PL3] [test-3.lox] [0m[33m// the value that was assigned[0m
-[33m[tester::#PL3] [test-3.lox] [0mfoo = baz = 50 + 13 * 62;
-[33m[tester::#PL3] [test-3.lox] [0mprint foo;
-[33m[tester::#PL3] [test-3.lox] [0mprint baz;
+[33m[tester::#PL3] [test-3.lox] [0m[0mvar foo;[0m
+[33m[tester::#PL3] [test-3.lox] [0m[0mvar baz;[0m
+[33m[tester::#PL3] [test-3.lox] [0m[0m[0m
+[33m[tester::#PL3] [test-3.lox] [0m[0m[33m// The assignment operator should return[0m[0m
+[33m[tester::#PL3] [test-3.lox] [0m[0m[33m// the value that was assigned[0m[0m
+[33m[tester::#PL3] [test-3.lox] [0m[0mfoo = baz = 50 + 13 * 62;[0m
+[33m[tester::#PL3] [test-3.lox] [0m[0mprint foo;[0m
+[33m[tester::#PL3] [test-3.lox] [0m[0mprint baz;[0m
 [33m[tester::#PL3] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m856
-[33m[your_program] [0m856
+[33m[your_program] [0m[0m856[0m
+[33m[your_program] [0m[0m856[0m
 [33m[tester::#PL3] [test-3] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#PL3] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#PL3] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#PL3] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PL3] [test-4.lox] [0mvar bar = 93;
-[33m[tester::#PL3] [test-4.lox] [0mvar quz;
-[33m[tester::#PL3] [test-4.lox] [0mvar foo;
-[33m[tester::#PL3] [test-4.lox] [0m
-[33m[tester::#PL3] [test-4.lox] [0m[33m// The assignment operator should return[0m
-[33m[tester::#PL3] [test-4.lox] [0m[33m// the value that was assigned[0m
-[33m[tester::#PL3] [test-4.lox] [0mbar = quz = foo = bar * 2;
-[33m[tester::#PL3] [test-4.lox] [0mprint bar;
-[33m[tester::#PL3] [test-4.lox] [0mprint quz;
-[33m[tester::#PL3] [test-4.lox] [0mprint quz;
+[33m[tester::#PL3] [test-4.lox] [0m[0mvar bar = 93;[0m
+[33m[tester::#PL3] [test-4.lox] [0m[0mvar quz;[0m
+[33m[tester::#PL3] [test-4.lox] [0m[0mvar foo;[0m
+[33m[tester::#PL3] [test-4.lox] [0m[0m[0m
+[33m[tester::#PL3] [test-4.lox] [0m[0m[33m// The assignment operator should return[0m[0m
+[33m[tester::#PL3] [test-4.lox] [0m[0m[33m// the value that was assigned[0m[0m
+[33m[tester::#PL3] [test-4.lox] [0m[0mbar = quz = foo = bar * 2;[0m
+[33m[tester::#PL3] [test-4.lox] [0m[0mprint bar;[0m
+[33m[tester::#PL3] [test-4.lox] [0m[0mprint quz;[0m
+[33m[tester::#PL3] [test-4.lox] [0m[0mprint quz;[0m
 [33m[tester::#PL3] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m186
-[33m[your_program] [0m186
-[33m[your_program] [0m186
+[33m[your_program] [0m[0m186[0m
+[33m[your_program] [0m[0m186[0m
+[33m[your_program] [0m[0m186[0m
 [33m[tester::#PL3] [test-4] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#PL3] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#PL3] [0m[92mTest passed.[0m
@@ -441,62 +441,62 @@ Debug = true
 [33m[tester::#VR5] [0m[94mRunning tests for Stage #VR5 (vr5)[0m
 [33m[tester::#VR5] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#VR5] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#VR5] [test-1.lox] [0m[33m// This program tests that curly braces can be[0m
-[33m[tester::#VR5] [test-1.lox] [0m[33m// used to group multiple statements into blocks[0m
-[33m[tester::#VR5] [test-1.lox] [0m{
-[33m[tester::#VR5] [test-1.lox] [0m    var hello = "foo";
-[33m[tester::#VR5] [test-1.lox] [0m    print hello;
-[33m[tester::#VR5] [test-1.lox] [0m}
+[33m[tester::#VR5] [test-1.lox] [0m[0m[33m// This program tests that curly braces can be[0m[0m
+[33m[tester::#VR5] [test-1.lox] [0m[0m[33m// used to group multiple statements into blocks[0m[0m
+[33m[tester::#VR5] [test-1.lox] [0m[0m{[0m
+[33m[tester::#VR5] [test-1.lox] [0m[0m    var hello = "foo";[0m
+[33m[tester::#VR5] [test-1.lox] [0m[0m    print hello;[0m
+[33m[tester::#VR5] [test-1.lox] [0m[0m}[0m
 [33m[tester::#VR5] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mfoo
+[33m[your_program] [0m[0mfoo[0m
 [33m[tester::#VR5] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#VR5] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#VR5] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#VR5] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#VR5] [test-2.lox] [0m[33m// This program tests that blocks can be used[0m
-[33m[tester::#VR5] [test-2.lox] [0m[33m// to group statements and variables[0m
-[33m[tester::#VR5] [test-2.lox] [0m[33m// creating local scopes[0m
-[33m[tester::#VR5] [test-2.lox] [0m{
-[33m[tester::#VR5] [test-2.lox] [0m    var world = "before";
-[33m[tester::#VR5] [test-2.lox] [0m    print world;
-[33m[tester::#VR5] [test-2.lox] [0m}
-[33m[tester::#VR5] [test-2.lox] [0m{
-[33m[tester::#VR5] [test-2.lox] [0m    var world = "after";
-[33m[tester::#VR5] [test-2.lox] [0m    print world;
-[33m[tester::#VR5] [test-2.lox] [0m}
+[33m[tester::#VR5] [test-2.lox] [0m[0m[33m// This program tests that blocks can be used[0m[0m
+[33m[tester::#VR5] [test-2.lox] [0m[0m[33m// to group statements and variables[0m[0m
+[33m[tester::#VR5] [test-2.lox] [0m[0m[33m// creating local scopes[0m[0m
+[33m[tester::#VR5] [test-2.lox] [0m[0m{[0m
+[33m[tester::#VR5] [test-2.lox] [0m[0m    var world = "before";[0m
+[33m[tester::#VR5] [test-2.lox] [0m[0m    print world;[0m
+[33m[tester::#VR5] [test-2.lox] [0m[0m}[0m
+[33m[tester::#VR5] [test-2.lox] [0m[0m{[0m
+[33m[tester::#VR5] [test-2.lox] [0m[0m    var world = "after";[0m
+[33m[tester::#VR5] [test-2.lox] [0m[0m    print world;[0m
+[33m[tester::#VR5] [test-2.lox] [0m[0m}[0m
 [33m[tester::#VR5] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mbefore
-[33m[your_program] [0mafter
+[33m[your_program] [0m[0mbefore[0m
+[33m[your_program] [0m[0mafter[0m
 [33m[tester::#VR5] [test-2] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#VR5] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#VR5] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#VR5] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#VR5] [test-3.lox] [0m[33m// This program tests that scopes can be nested[0m
-[33m[tester::#VR5] [test-3.lox] [0m{
-[33m[tester::#VR5] [test-3.lox] [0m    var bar = 35;
-[33m[tester::#VR5] [test-3.lox] [0m    {
-[33m[tester::#VR5] [test-3.lox] [0m        var quz = 35;
-[33m[tester::#VR5] [test-3.lox] [0m        print quz;
-[33m[tester::#VR5] [test-3.lox] [0m    }
-[33m[tester::#VR5] [test-3.lox] [0m    print bar;
-[33m[tester::#VR5] [test-3.lox] [0m}
+[33m[tester::#VR5] [test-3.lox] [0m[0m[33m// This program tests that scopes can be nested[0m[0m
+[33m[tester::#VR5] [test-3.lox] [0m[0m{[0m
+[33m[tester::#VR5] [test-3.lox] [0m[0m    var bar = 35;[0m
+[33m[tester::#VR5] [test-3.lox] [0m[0m    {[0m
+[33m[tester::#VR5] [test-3.lox] [0m[0m        var quz = 35;[0m
+[33m[tester::#VR5] [test-3.lox] [0m[0m        print quz;[0m
+[33m[tester::#VR5] [test-3.lox] [0m[0m    }[0m
+[33m[tester::#VR5] [test-3.lox] [0m[0m    print bar;[0m
+[33m[tester::#VR5] [test-3.lox] [0m[0m}[0m
 [33m[tester::#VR5] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m35
-[33m[your_program] [0m35
+[33m[your_program] [0m[0m35[0m
+[33m[your_program] [0m[0m35[0m
 [33m[tester::#VR5] [test-3] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#VR5] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#VR5] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#VR5] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#VR5] [test-4.lox] [0m{
-[33m[tester::#VR5] [test-4.lox] [0m    var world = 68;
-[33m[tester::#VR5] [test-4.lox] [0m    var hello = 68;
-[33m[tester::#VR5] [test-4.lox] [0m    {
-[33m[tester::#VR5] [test-4.lox] [0m        print world + hello;
-[33m[tester::#VR5] [test-4.lox] [0m    [33m// Missing closing curly brace[0m
-[33m[tester::#VR5] [test-4.lox] [0m    [33m// Expect compile error[0m
-[33m[tester::#VR5] [test-4.lox] [0m}
+[33m[tester::#VR5] [test-4.lox] [0m[0m{[0m
+[33m[tester::#VR5] [test-4.lox] [0m[0m    var world = 68;[0m
+[33m[tester::#VR5] [test-4.lox] [0m[0m    var hello = 68;[0m
+[33m[tester::#VR5] [test-4.lox] [0m[0m    {[0m
+[33m[tester::#VR5] [test-4.lox] [0m[0m        print world + hello;[0m
+[33m[tester::#VR5] [test-4.lox] [0m[0m    [33m// Missing closing curly brace[0m[0m
+[33m[tester::#VR5] [test-4.lox] [0m[0m    [33m// Expect compile error[0m[0m
+[33m[tester::#VR5] [test-4.lox] [0m[0m}[0m
 [33m[tester::#VR5] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 8] Error at end: Expect '}' after block.
+[33m[your_program] [0m[0m[line 8] Error at end: Expect '}' after block.[0m
 [33m[tester::#VR5] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#VR5] [test-4] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#VR5] [0m[92mTest passed.[0m
@@ -504,95 +504,95 @@ Debug = true
 [33m[tester::#FB4] [0m[94mRunning tests for Stage #FB4 (fb4)[0m
 [33m[tester::#FB4] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#FB4] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#FB4] [test-1.lox] [0mvar hello = (12 * 41) - 84;
-[33m[tester::#FB4] [test-1.lox] [0m{
-[33m[tester::#FB4] [test-1.lox] [0m    [33m// Local scope should be created[0m
-[33m[tester::#FB4] [test-1.lox] [0m    var quz = "bar" + "14";
-[33m[tester::#FB4] [test-1.lox] [0m    print quz;
-[33m[tester::#FB4] [test-1.lox] [0m}
-[33m[tester::#FB4] [test-1.lox] [0mprint hello;
+[33m[tester::#FB4] [test-1.lox] [0m[0mvar hello = (12 * 41) - 84;[0m
+[33m[tester::#FB4] [test-1.lox] [0m[0m{[0m
+[33m[tester::#FB4] [test-1.lox] [0m[0m    [33m// Local scope should be created[0m[0m
+[33m[tester::#FB4] [test-1.lox] [0m[0m    var quz = "bar" + "14";[0m
+[33m[tester::#FB4] [test-1.lox] [0m[0m    print quz;[0m
+[33m[tester::#FB4] [test-1.lox] [0m[0m}[0m
+[33m[tester::#FB4] [test-1.lox] [0m[0mprint hello;[0m
 [33m[tester::#FB4] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mbar14
-[33m[your_program] [0m408
+[33m[your_program] [0m[0mbar14[0m
+[33m[your_program] [0m[0m408[0m
 [33m[tester::#FB4] [test-1] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#FB4] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#FB4] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#FB4] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#FB4] [test-2.lox] [0m[33m// This program tests variable shadowing[0m
-[33m[tester::#FB4] [test-2.lox] [0m[33m// across nested scopes[0m
-[33m[tester::#FB4] [test-2.lox] [0m{
-[33m[tester::#FB4] [test-2.lox] [0m    var foo = "before";
-[33m[tester::#FB4] [test-2.lox] [0m    {
-[33m[tester::#FB4] [test-2.lox] [0m        var foo = "after";
-[33m[tester::#FB4] [test-2.lox] [0m        print foo;
-[33m[tester::#FB4] [test-2.lox] [0m    }
-[33m[tester::#FB4] [test-2.lox] [0m    print foo;
-[33m[tester::#FB4] [test-2.lox] [0m}
+[33m[tester::#FB4] [test-2.lox] [0m[0m[33m// This program tests variable shadowing[0m[0m
+[33m[tester::#FB4] [test-2.lox] [0m[0m[33m// across nested scopes[0m[0m
+[33m[tester::#FB4] [test-2.lox] [0m[0m{[0m
+[33m[tester::#FB4] [test-2.lox] [0m[0m    var foo = "before";[0m
+[33m[tester::#FB4] [test-2.lox] [0m[0m    {[0m
+[33m[tester::#FB4] [test-2.lox] [0m[0m        var foo = "after";[0m
+[33m[tester::#FB4] [test-2.lox] [0m[0m        print foo;[0m
+[33m[tester::#FB4] [test-2.lox] [0m[0m    }[0m
+[33m[tester::#FB4] [test-2.lox] [0m[0m    print foo;[0m
+[33m[tester::#FB4] [test-2.lox] [0m[0m}[0m
 [33m[tester::#FB4] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mafter
-[33m[your_program] [0mbefore
+[33m[your_program] [0m[0mafter[0m
+[33m[your_program] [0m[0mbefore[0m
 [33m[tester::#FB4] [test-2] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#FB4] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#FB4] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#FB4] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#FB4] [test-3.lox] [0m[33m// This program creates nested scopes and tests[0m
-[33m[tester::#FB4] [test-3.lox] [0m[33m// local scopes and variable shadowing[0m
-[33m[tester::#FB4] [test-3.lox] [0mvar baz = "global baz";
-[33m[tester::#FB4] [test-3.lox] [0mvar bar = "global bar";
-[33m[tester::#FB4] [test-3.lox] [0mvar hello = "global hello";
-[33m[tester::#FB4] [test-3.lox] [0m{
-[33m[tester::#FB4] [test-3.lox] [0m  var baz = "outer baz";
-[33m[tester::#FB4] [test-3.lox] [0m  var bar = "outer bar";
-[33m[tester::#FB4] [test-3.lox] [0m  {
-[33m[tester::#FB4] [test-3.lox] [0m    var baz = "inner baz";
-[33m[tester::#FB4] [test-3.lox] [0m    print baz;
-[33m[tester::#FB4] [test-3.lox] [0m    print bar;
-[33m[tester::#FB4] [test-3.lox] [0m    print hello;
-[33m[tester::#FB4] [test-3.lox] [0m  }
-[33m[tester::#FB4] [test-3.lox] [0m  print baz;
-[33m[tester::#FB4] [test-3.lox] [0m  print bar;
-[33m[tester::#FB4] [test-3.lox] [0m  print hello;
-[33m[tester::#FB4] [test-3.lox] [0m}
-[33m[tester::#FB4] [test-3.lox] [0mprint baz;
-[33m[tester::#FB4] [test-3.lox] [0mprint bar;
-[33m[tester::#FB4] [test-3.lox] [0mprint hello;
+[33m[tester::#FB4] [test-3.lox] [0m[0m[33m// This program creates nested scopes and tests[0m[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0m[33m// local scopes and variable shadowing[0m[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0mvar baz = "global baz";[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0mvar bar = "global bar";[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0mvar hello = "global hello";[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0m{[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0m  var baz = "outer baz";[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0m  var bar = "outer bar";[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0m  {[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0m    var baz = "inner baz";[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0m    print baz;[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0m    print bar;[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0m    print hello;[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0m  }[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0m  print baz;[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0m  print bar;[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0m  print hello;[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0m}[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0mprint baz;[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0mprint bar;[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0mprint hello;[0m
 [33m[tester::#FB4] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0minner baz
-[33m[your_program] [0mouter bar
-[33m[your_program] [0mglobal hello
-[33m[your_program] [0mouter baz
-[33m[your_program] [0mouter bar
-[33m[your_program] [0mglobal hello
-[33m[your_program] [0mglobal baz
-[33m[your_program] [0mglobal bar
-[33m[your_program] [0mglobal hello
+[33m[your_program] [0m[0minner baz[0m
+[33m[your_program] [0m[0mouter bar[0m
+[33m[your_program] [0m[0mglobal hello[0m
+[33m[your_program] [0m[0mouter baz[0m
+[33m[your_program] [0m[0mouter bar[0m
+[33m[your_program] [0m[0mglobal hello[0m
+[33m[your_program] [0m[0mglobal baz[0m
+[33m[your_program] [0m[0mglobal bar[0m
+[33m[your_program] [0m[0mglobal hello[0m
 [33m[tester::#FB4] [test-3] [0m[92m✓ 9 line(s) match on stdout[0m
 [33m[tester::#FB4] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#FB4] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#FB4] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#FB4] [test-4.lox] [0m[33m// Variables declared in an outer scope should be[0m
-[33m[tester::#FB4] [test-4.lox] [0m[33m// accessible inside inner scopes, but not the[0m
-[33m[tester::#FB4] [test-4.lox] [0m[33m// other way around[0m
-[33m[tester::#FB4] [test-4.lox] [0m{
-[33m[tester::#FB4] [test-4.lox] [0m  var foo = "outer foo";
-[33m[tester::#FB4] [test-4.lox] [0m  var baz = "outer baz";
-[33m[tester::#FB4] [test-4.lox] [0m  {
-[33m[tester::#FB4] [test-4.lox] [0m    foo = "modified foo";
-[33m[tester::#FB4] [test-4.lox] [0m    var baz = "inner baz";
-[33m[tester::#FB4] [test-4.lox] [0m    print foo;
-[33m[tester::#FB4] [test-4.lox] [0m    print baz;
-[33m[tester::#FB4] [test-4.lox] [0m  }
-[33m[tester::#FB4] [test-4.lox] [0m  print foo;
-[33m[tester::#FB4] [test-4.lox] [0m  print baz;
-[33m[tester::#FB4] [test-4.lox] [0m}
-[33m[tester::#FB4] [test-4.lox] [0mprint foo;
+[33m[tester::#FB4] [test-4.lox] [0m[0m[33m// Variables declared in an outer scope should be[0m[0m
+[33m[tester::#FB4] [test-4.lox] [0m[0m[33m// accessible inside inner scopes, but not the[0m[0m
+[33m[tester::#FB4] [test-4.lox] [0m[0m[33m// other way around[0m[0m
+[33m[tester::#FB4] [test-4.lox] [0m[0m{[0m
+[33m[tester::#FB4] [test-4.lox] [0m[0m  var foo = "outer foo";[0m
+[33m[tester::#FB4] [test-4.lox] [0m[0m  var baz = "outer baz";[0m
+[33m[tester::#FB4] [test-4.lox] [0m[0m  {[0m
+[33m[tester::#FB4] [test-4.lox] [0m[0m    foo = "modified foo";[0m
+[33m[tester::#FB4] [test-4.lox] [0m[0m    var baz = "inner baz";[0m
+[33m[tester::#FB4] [test-4.lox] [0m[0m    print foo;[0m
+[33m[tester::#FB4] [test-4.lox] [0m[0m    print baz;[0m
+[33m[tester::#FB4] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#FB4] [test-4.lox] [0m[0m  print foo;[0m
+[33m[tester::#FB4] [test-4.lox] [0m[0m  print baz;[0m
+[33m[tester::#FB4] [test-4.lox] [0m[0m}[0m
+[33m[tester::#FB4] [test-4.lox] [0m[0mprint foo;[0m
 [33m[tester::#FB4] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mmodified foo
-[33m[your_program] [0minner baz
-[33m[your_program] [0mmodified foo
-[33m[your_program] [0mouter baz
-[33m[your_program] [0mUndefined variable 'foo'.
-[33m[your_program] [0m[line 16]
+[33m[your_program] [0m[0mmodified foo[0m
+[33m[your_program] [0m[0minner baz[0m
+[33m[your_program] [0m[0mmodified foo[0m
+[33m[your_program] [0m[0mouter baz[0m
+[33m[your_program] [0m[0mUndefined variable 'foo'.[0m
+[33m[your_program] [0m[0m[line 16][0m
 [33m[tester::#FB4] [test-4] [0m[92m✓ 4 line(s) match on stdout[0m
 [33m[tester::#FB4] [test-4] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#FB4] [0m[92mTest passed.[0m

--- a/internal/test_helpers/fixtures/pass_statements_final
+++ b/internal/test_helpers/fixtures/pass_statements_final
@@ -3,32 +3,32 @@ Debug = true
 [33m[tester::#XY1] [0m[94mRunning tests for Stage #XY1 (xy1)[0m
 [33m[tester::#XY1] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#XY1] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#XY1] [test-1.lox] [0mprint false;
+[33m[tester::#XY1] [test-1.lox] [0m[0mprint false;[0m
 [33m[tester::#XY1] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mfalse
+[33m[your_program] [0m[0mfalse[0m
 [33m[tester::#XY1] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#XY1] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#XY1] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#XY1] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#XY1] [test-2.lox] [0m[33m// Concatenation of strings should work[0m
-[33m[tester::#XY1] [test-2.lox] [0mprint "quz" + "hello" + "baz";
+[33m[tester::#XY1] [test-2.lox] [0m[0m[33m// Concatenation of strings should work[0m[0m
+[33m[tester::#XY1] [test-2.lox] [0m[0mprint "quz" + "hello" + "baz";[0m
 [33m[tester::#XY1] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mquzhellobaz
+[33m[your_program] [0m[0mquzhellobaz[0m
 [33m[tester::#XY1] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#XY1] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#XY1] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#XY1] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#XY1] [test-3.lox] [0mprint (92 * 2 + 96 * 2) / (2);
+[33m[tester::#XY1] [test-3.lox] [0m[0mprint (92 * 2 + 96 * 2) / (2);[0m
 [33m[tester::#XY1] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m188
+[33m[your_program] [0m[0m188[0m
 [33m[tester::#XY1] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#XY1] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#XY1] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#XY1] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#XY1] [test-4.lox] [0m[33m// Print statements expect an expression[0m
-[33m[tester::#XY1] [test-4.lox] [0mprint; [33m// expect compile error[0m
+[33m[tester::#XY1] [test-4.lox] [0m[0m[33m// Print statements expect an expression[0m[0m
+[33m[tester::#XY1] [test-4.lox] [0m[0mprint; [33m// expect compile error[0m[0m
 [33m[tester::#XY1] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 2] Error at ';': Expect expression.
+[33m[your_program] [0m[0m[line 2] Error at ';': Expect expression.[0m
 [33m[tester::#XY1] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#XY1] [test-4] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#XY1] [0m[92mTest passed.[0m
@@ -36,67 +36,67 @@ Debug = true
 [33m[tester::#OE4] [0m[94mRunning tests for Stage #OE4 (oe4)[0m
 [33m[tester::#OE4] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#OE4] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#OE4] [test-1.lox] [0m[33m// Concatenation of strings should work[0m
-[33m[tester::#OE4] [test-1.lox] [0mprint "hello" + "foo" + "world";
-[33m[tester::#OE4] [test-1.lox] [0mprint 34 - 90;
-[33m[tester::#OE4] [test-1.lox] [0mprint "world" == "quz";
+[33m[tester::#OE4] [test-1.lox] [0m[0m[33m// Concatenation of strings should work[0m[0m
+[33m[tester::#OE4] [test-1.lox] [0m[0mprint "hello" + "foo" + "world";[0m
+[33m[tester::#OE4] [test-1.lox] [0m[0mprint 34 - 90;[0m
+[33m[tester::#OE4] [test-1.lox] [0m[0mprint "world" == "quz";[0m
 [33m[tester::#OE4] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mhellofooworld
-[33m[your_program] [0m-56
-[33m[your_program] [0mfalse
+[33m[your_program] [0m[0mhellofooworld[0m
+[33m[your_program] [0m[0m-56[0m
+[33m[your_program] [0m[0mfalse[0m
 [33m[tester::#OE4] [test-1] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#OE4] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#OE4] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#OE4] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#OE4] [test-2.lox] [0m[33m// Multiple statements in a single line should work[0m
-[33m[tester::#OE4] [test-2.lox] [0mprint "bar"; print true;
-[33m[tester::#OE4] [test-2.lox] [0mprint true;
-[33m[tester::#OE4] [test-2.lox] [0mprint "world"; print 28;
+[33m[tester::#OE4] [test-2.lox] [0m[0m[33m// Multiple statements in a single line should work[0m[0m
+[33m[tester::#OE4] [test-2.lox] [0m[0mprint "bar"; print true;[0m
+[33m[tester::#OE4] [test-2.lox] [0m[0mprint true;[0m
+[33m[tester::#OE4] [test-2.lox] [0m[0mprint "world"; print 28;[0m
 [33m[tester::#OE4] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mbar
-[33m[your_program] [0mtrue
-[33m[your_program] [0mtrue
-[33m[your_program] [0mworld
-[33m[your_program] [0m28
+[33m[your_program] [0m[0mbar[0m
+[33m[your_program] [0m[0mtrue[0m
+[33m[your_program] [0m[0mtrue[0m
+[33m[your_program] [0m[0mworld[0m
+[33m[your_program] [0m[0m28[0m
 [33m[tester::#OE4] [test-2] [0m[92m✓ 5 line(s) match on stdout[0m
 [33m[tester::#OE4] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#OE4] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#OE4] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#OE4] [test-3.lox] [0m[33m// Leading whitespace should be ignored[0m
-[33m[tester::#OE4] [test-3.lox] [0mprint 17;
-[33m[tester::#OE4] [test-3.lox] [0m    print 17 + 81;
-[33m[tester::#OE4] [test-3.lox] [0m        print 17 + 81 + 52;
+[33m[tester::#OE4] [test-3.lox] [0m[0m[33m// Leading whitespace should be ignored[0m[0m
+[33m[tester::#OE4] [test-3.lox] [0m[0mprint 17;[0m
+[33m[tester::#OE4] [test-3.lox] [0m[0m    print 17 + 81;[0m
+[33m[tester::#OE4] [test-3.lox] [0m[0m        print 17 + 81 + 52;[0m
 [33m[tester::#OE4] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m17
-[33m[your_program] [0m98
-[33m[your_program] [0m150
+[33m[your_program] [0m[0m17[0m
+[33m[your_program] [0m[0m98[0m
+[33m[your_program] [0m[0m150[0m
 [33m[tester::#OE4] [test-3] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#OE4] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#OE4] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#OE4] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#OE4] [test-4.lox] [0mprint true != true;
-[33m[tester::#OE4] [test-4.lox] [0m
-[33m[tester::#OE4] [test-4.lox] [0m[33m// multi-line strings should be supported[0m
-[33m[tester::#OE4] [test-4.lox] [0mprint "44
-[33m[tester::#OE4] [test-4.lox] [0m84
-[33m[tester::#OE4] [test-4.lox] [0m70
-[33m[tester::#OE4] [test-4.lox] [0m";
-[33m[tester::#OE4] [test-4.lox] [0m
-[33m[tester::#OE4] [test-4.lox] [0mprint "There should be an empty line above this.";
-[33m[tester::#OE4] [test-4.lox] [0m
-[33m[tester::#OE4] [test-4.lox] [0mprint "(" + "" + ")";
-[33m[tester::#OE4] [test-4.lox] [0m
-[33m[tester::#OE4] [test-4.lox] [0m[33m// non-ascii characters should be supported[0m
-[33m[tester::#OE4] [test-4.lox] [0mprint "non-ascii: ॐ";
+[33m[tester::#OE4] [test-4.lox] [0m[0mprint true != true;[0m
+[33m[tester::#OE4] [test-4.lox] [0m[0m[0m
+[33m[tester::#OE4] [test-4.lox] [0m[0m[33m// multi-line strings should be supported[0m[0m
+[33m[tester::#OE4] [test-4.lox] [0m[0mprint "44[0m
+[33m[tester::#OE4] [test-4.lox] [0m[0m84[0m
+[33m[tester::#OE4] [test-4.lox] [0m[0m70[0m
+[33m[tester::#OE4] [test-4.lox] [0m[0m";[0m
+[33m[tester::#OE4] [test-4.lox] [0m[0m[0m
+[33m[tester::#OE4] [test-4.lox] [0m[0mprint "There should be an empty line above this.";[0m
+[33m[tester::#OE4] [test-4.lox] [0m[0m[0m
+[33m[tester::#OE4] [test-4.lox] [0m[0mprint "(" + "" + ")";[0m
+[33m[tester::#OE4] [test-4.lox] [0m[0m[0m
+[33m[tester::#OE4] [test-4.lox] [0m[0m[33m// non-ascii characters should be supported[0m[0m
+[33m[tester::#OE4] [test-4.lox] [0m[0mprint "non-ascii: ॐ";[0m
 [33m[tester::#OE4] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mfalse
-[33m[your_program] [0m44
-[33m[your_program] [0m84
-[33m[your_program] [0m70
-[33m[your_program] [0m
-[33m[your_program] [0mThere should be an empty line above this.
-[33m[your_program] [0m()
-[33m[your_program] [0mnon-ascii: ॐ
+[33m[your_program] [0m[0mfalse[0m
+[33m[your_program] [0m[0m44[0m
+[33m[your_program] [0m[0m84[0m
+[33m[your_program] [0m[0m70[0m
+[33m[your_program] [0m[0m[0m
+[33m[your_program] [0m[0mThere should be an empty line above this.[0m
+[33m[your_program] [0m[0m()[0m
+[33m[your_program] [0m[0mnon-ascii: ॐ[0m
 [33m[tester::#OE4] [test-4] [0m[92m✓ 8 line(s) match on stdout[0m
 [33m[tester::#OE4] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#OE4] [0m[92mTest passed.[0m
@@ -104,55 +104,55 @@ Debug = true
 [33m[tester::#FI3] [0m[94mRunning tests for Stage #FI3 (fi3)[0m
 [33m[tester::#FI3] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#FI3] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#FI3] [test-1.lox] [0m[33m// This program tests that statements are executed[0m
-[33m[tester::#FI3] [test-1.lox] [0m[33m// even if they don't have any side effects[0m
-[33m[tester::#FI3] [test-1.lox] [0m[33m// It also tests complex arithmetic expressions[0m
-[33m[tester::#FI3] [test-1.lox] [0m[33m// and string concatenation[0m
-[33m[tester::#FI3] [test-1.lox] [0m(74 + 46 - 10) > (42 - 74) * 2;
-[33m[tester::#FI3] [test-1.lox] [0mprint !false;
-[33m[tester::#FI3] [test-1.lox] [0m"quz" + "world" + "bar" == "quzworldbar";
-[33m[tester::#FI3] [test-1.lox] [0mprint !false;
+[33m[tester::#FI3] [test-1.lox] [0m[0m[33m// This program tests that statements are executed[0m[0m
+[33m[tester::#FI3] [test-1.lox] [0m[0m[33m// even if they don't have any side effects[0m[0m
+[33m[tester::#FI3] [test-1.lox] [0m[0m[33m// It also tests complex arithmetic expressions[0m[0m
+[33m[tester::#FI3] [test-1.lox] [0m[0m[33m// and string concatenation[0m[0m
+[33m[tester::#FI3] [test-1.lox] [0m[0m(74 + 46 - 10) > (42 - 74) * 2;[0m
+[33m[tester::#FI3] [test-1.lox] [0m[0mprint !false;[0m
+[33m[tester::#FI3] [test-1.lox] [0m[0m"quz" + "world" + "bar" == "quzworldbar";[0m
+[33m[tester::#FI3] [test-1.lox] [0m[0mprint !false;[0m
 [33m[tester::#FI3] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mtrue
-[33m[your_program] [0mtrue
+[33m[your_program] [0m[0mtrue[0m
+[33m[your_program] [0m[0mtrue[0m
 [33m[tester::#FI3] [test-1] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#FI3] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#FI3] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#FI3] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#FI3] [test-2.lox] [0m[33m// This program tests statements that don't have[0m
-[33m[tester::#FI3] [test-2.lox] [0m[33m// any side effects[0m
-[33m[tester::#FI3] [test-2.lox] [0m53 - 31 >= -90 * 2 / 90 + 27;
-[33m[tester::#FI3] [test-2.lox] [0mfalse == false;
-[33m[tester::#FI3] [test-2.lox] [0m("world" == "hello") == ("quz" != "baz");
-[33m[tester::#FI3] [test-2.lox] [0mprint false;
+[33m[tester::#FI3] [test-2.lox] [0m[0m[33m// This program tests statements that don't have[0m[0m
+[33m[tester::#FI3] [test-2.lox] [0m[0m[33m// any side effects[0m[0m
+[33m[tester::#FI3] [test-2.lox] [0m[0m53 - 31 >= -90 * 2 / 90 + 27;[0m
+[33m[tester::#FI3] [test-2.lox] [0m[0mfalse == false;[0m
+[33m[tester::#FI3] [test-2.lox] [0m[0m("world" == "hello") == ("quz" != "baz");[0m
+[33m[tester::#FI3] [test-2.lox] [0m[0mprint false;[0m
 [33m[tester::#FI3] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mfalse
+[33m[your_program] [0m[0mfalse[0m
 [33m[tester::#FI3] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#FI3] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#FI3] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#FI3] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#FI3] [test-3.lox] [0m[33m// This program tests that the + operator is only[0m
-[33m[tester::#FI3] [test-3.lox] [0m[33m// supported when both operands are numbers or[0m
-[33m[tester::#FI3] [test-3.lox] [0m[33m// both are strings[0m
-[33m[tester::#FI3] [test-3.lox] [0mprint "the expression below is invalid";
-[33m[tester::#FI3] [test-3.lox] [0m62 + "quz";
-[33m[tester::#FI3] [test-3.lox] [0mprint "this should not be printed";
+[33m[tester::#FI3] [test-3.lox] [0m[0m[33m// This program tests that the + operator is only[0m[0m
+[33m[tester::#FI3] [test-3.lox] [0m[0m[33m// supported when both operands are numbers or[0m[0m
+[33m[tester::#FI3] [test-3.lox] [0m[0m[33m// both are strings[0m[0m
+[33m[tester::#FI3] [test-3.lox] [0m[0mprint "the expression below is invalid";[0m
+[33m[tester::#FI3] [test-3.lox] [0m[0m62 + "quz";[0m
+[33m[tester::#FI3] [test-3.lox] [0m[0mprint "this should not be printed";[0m
 [33m[tester::#FI3] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mthe expression below is invalid
-[33m[your_program] [0mOperands must be two numbers or two strings.
-[33m[your_program] [0m[line 5]
+[33m[your_program] [0m[0mthe expression below is invalid[0m
+[33m[your_program] [0m[0mOperands must be two numbers or two strings.[0m
+[33m[your_program] [0m[0m[line 5][0m
 [33m[tester::#FI3] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#FI3] [test-3] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#FI3] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#FI3] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#FI3] [test-4.lox] [0m[33m// This program tests that the * operator is only[0m
-[33m[tester::#FI3] [test-4.lox] [0m[33m// supported when both operands are numbers[0m
-[33m[tester::#FI3] [test-4.lox] [0mprint "50" + "hello";
-[33m[tester::#FI3] [test-4.lox] [0mprint false * (97 + 23);
+[33m[tester::#FI3] [test-4.lox] [0m[0m[33m// This program tests that the * operator is only[0m[0m
+[33m[tester::#FI3] [test-4.lox] [0m[0m[33m// supported when both operands are numbers[0m[0m
+[33m[tester::#FI3] [test-4.lox] [0m[0mprint "50" + "hello";[0m
+[33m[tester::#FI3] [test-4.lox] [0m[0mprint false * (97 + 23);[0m
 [33m[tester::#FI3] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m50hello
-[33m[your_program] [0mOperands must be numbers.
-[33m[your_program] [0m[line 4]
+[33m[your_program] [0m[0m50hello[0m
+[33m[your_program] [0m[0mOperands must be numbers.[0m
+[33m[your_program] [0m[0m[line 4][0m
 [33m[tester::#FI3] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#FI3] [test-4] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#FI3] [0m[92mTest passed.[0m
@@ -160,50 +160,50 @@ Debug = true
 [33m[tester::#YG2] [0m[94mRunning tests for Stage #YG2 (yg2)[0m
 [33m[tester::#YG2] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#YG2] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YG2] [test-1.lox] [0m[33m// This program tests that variables are[0m
-[33m[tester::#YG2] [test-1.lox] [0m[33m// initialized to the correct value[0m
-[33m[tester::#YG2] [test-1.lox] [0mvar baz = 10;
-[33m[tester::#YG2] [test-1.lox] [0mprint baz;
+[33m[tester::#YG2] [test-1.lox] [0m[0m[33m// This program tests that variables are[0m[0m
+[33m[tester::#YG2] [test-1.lox] [0m[0m[33m// initialized to the correct value[0m[0m
+[33m[tester::#YG2] [test-1.lox] [0m[0mvar baz = 10;[0m
+[33m[tester::#YG2] [test-1.lox] [0m[0mprint baz;[0m
 [33m[tester::#YG2] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m10
+[33m[your_program] [0m[0m10[0m
 [33m[tester::#YG2] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#YG2] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#YG2] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#YG2] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YG2] [test-2.lox] [0m[33m// This program declares multiple variables and[0m
-[33m[tester::#YG2] [test-2.lox] [0m[33m// prints the result of arithmetic operations on[0m
-[33m[tester::#YG2] [test-2.lox] [0m[33m// them[0m
-[33m[tester::#YG2] [test-2.lox] [0mvar foo = 17;
-[33m[tester::#YG2] [test-2.lox] [0mvar bar = 17;
-[33m[tester::#YG2] [test-2.lox] [0mprint foo + bar;
-[33m[tester::#YG2] [test-2.lox] [0mvar quz = 17;
-[33m[tester::#YG2] [test-2.lox] [0mprint foo + bar + quz;
+[33m[tester::#YG2] [test-2.lox] [0m[0m[33m// This program declares multiple variables and[0m[0m
+[33m[tester::#YG2] [test-2.lox] [0m[0m[33m// prints the result of arithmetic operations on[0m[0m
+[33m[tester::#YG2] [test-2.lox] [0m[0m[33m// them[0m[0m
+[33m[tester::#YG2] [test-2.lox] [0m[0mvar foo = 17;[0m
+[33m[tester::#YG2] [test-2.lox] [0m[0mvar bar = 17;[0m
+[33m[tester::#YG2] [test-2.lox] [0m[0mprint foo + bar;[0m
+[33m[tester::#YG2] [test-2.lox] [0m[0mvar quz = 17;[0m
+[33m[tester::#YG2] [test-2.lox] [0m[0mprint foo + bar + quz;[0m
 [33m[tester::#YG2] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m34
-[33m[your_program] [0m51
+[33m[your_program] [0m[0m34[0m
+[33m[your_program] [0m[0m51[0m
 [33m[tester::#YG2] [test-2] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#YG2] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#YG2] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#YG2] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YG2] [test-3.lox] [0m[33m// This program assigns the result of an[0m
-[33m[tester::#YG2] [test-3.lox] [0m[33m// arithmetic expression to a variable[0m
-[33m[tester::#YG2] [test-3.lox] [0m[33m// Then it prints the value of the variable[0m
-[33m[tester::#YG2] [test-3.lox] [0mvar quz = (8 * (68 + 68)) / 4 + 68;
-[33m[tester::#YG2] [test-3.lox] [0mprint quz;
+[33m[tester::#YG2] [test-3.lox] [0m[0m[33m// This program assigns the result of an[0m[0m
+[33m[tester::#YG2] [test-3.lox] [0m[0m[33m// arithmetic expression to a variable[0m[0m
+[33m[tester::#YG2] [test-3.lox] [0m[0m[33m// Then it prints the value of the variable[0m[0m
+[33m[tester::#YG2] [test-3.lox] [0m[0mvar quz = (8 * (68 + 68)) / 4 + 68;[0m
+[33m[tester::#YG2] [test-3.lox] [0m[0mprint quz;[0m
 [33m[tester::#YG2] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m340
+[33m[your_program] [0m[0m340[0m
 [33m[tester::#YG2] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#YG2] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#YG2] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#YG2] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#YG2] [test-4.lox] [0m[33m// This program declares variables and performs[0m
-[33m[tester::#YG2] [test-4.lox] [0m[33m// operations on them[0m
-[33m[tester::#YG2] [test-4.lox] [0m[33m// Finally it prints the result of the operations[0m
-[33m[tester::#YG2] [test-4.lox] [0mvar bar = 66;
-[33m[tester::#YG2] [test-4.lox] [0mvar foo = bar;
-[33m[tester::#YG2] [test-4.lox] [0mprint foo + bar;
+[33m[tester::#YG2] [test-4.lox] [0m[0m[33m// This program declares variables and performs[0m[0m
+[33m[tester::#YG2] [test-4.lox] [0m[0m[33m// operations on them[0m[0m
+[33m[tester::#YG2] [test-4.lox] [0m[0m[33m// Finally it prints the result of the operations[0m[0m
+[33m[tester::#YG2] [test-4.lox] [0m[0mvar bar = 66;[0m
+[33m[tester::#YG2] [test-4.lox] [0m[0mvar foo = bar;[0m
+[33m[tester::#YG2] [test-4.lox] [0m[0mprint foo + bar;[0m
 [33m[tester::#YG2] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m132
+[33m[your_program] [0m[0m132[0m
 [33m[tester::#YG2] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#YG2] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#YG2] [0m[92mTest passed.[0m
@@ -211,54 +211,54 @@ Debug = true
 [33m[tester::#SV7] [0m[94mRunning tests for Stage #SV7 (sv7)[0m
 [33m[tester::#SV7] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#SV7] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#SV7] [test-1.lox] [0m[33m// This program tries to access a variable before[0m
-[33m[tester::#SV7] [test-1.lox] [0m[33m// it is declared[0m
-[33m[tester::#SV7] [test-1.lox] [0m[33m// It leads to a runtime error[0m
-[33m[tester::#SV7] [test-1.lox] [0mprint 45;
-[33m[tester::#SV7] [test-1.lox] [0mprint x;
+[33m[tester::#SV7] [test-1.lox] [0m[0m[33m// This program tries to access a variable before[0m[0m
+[33m[tester::#SV7] [test-1.lox] [0m[0m[33m// it is declared[0m[0m
+[33m[tester::#SV7] [test-1.lox] [0m[0m[33m// It leads to a runtime error[0m[0m
+[33m[tester::#SV7] [test-1.lox] [0m[0mprint 45;[0m
+[33m[tester::#SV7] [test-1.lox] [0m[0mprint x;[0m
 [33m[tester::#SV7] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m45
-[33m[your_program] [0mUndefined variable 'x'.
-[33m[your_program] [0m[line 5]
+[33m[your_program] [0m[0m45[0m
+[33m[your_program] [0m[0mUndefined variable 'x'.[0m
+[33m[your_program] [0m[0m[line 5][0m
 [33m[tester::#SV7] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#SV7] [test-1] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#SV7] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#SV7] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#SV7] [test-2.lox] [0m[33m// This program tries to access a variable before[0m
-[33m[tester::#SV7] [test-2.lox] [0m[33m// it is declared[0m
-[33m[tester::#SV7] [test-2.lox] [0m[33m// It leads to a runtime error[0m
-[33m[tester::#SV7] [test-2.lox] [0mvar world = 16;
-[33m[tester::#SV7] [test-2.lox] [0mprint baz;
+[33m[tester::#SV7] [test-2.lox] [0m[0m[33m// This program tries to access a variable before[0m[0m
+[33m[tester::#SV7] [test-2.lox] [0m[0m[33m// it is declared[0m[0m
+[33m[tester::#SV7] [test-2.lox] [0m[0m[33m// It leads to a runtime error[0m[0m
+[33m[tester::#SV7] [test-2.lox] [0m[0mvar world = 16;[0m
+[33m[tester::#SV7] [test-2.lox] [0m[0mprint baz;[0m
 [33m[tester::#SV7] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mUndefined variable 'baz'.
-[33m[your_program] [0m[line 5]
+[33m[your_program] [0m[0mUndefined variable 'baz'.[0m
+[33m[your_program] [0m[0m[line 5][0m
 [33m[tester::#SV7] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#SV7] [test-2] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#SV7] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#SV7] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#SV7] [test-3.lox] [0m[33m// This program tries to access a variable before[0m
-[33m[tester::#SV7] [test-3.lox] [0m[33m// it is declared[0m
-[33m[tester::#SV7] [test-3.lox] [0m[33m// It leads to a runtime error[0m
-[33m[tester::#SV7] [test-3.lox] [0mvar world = 47;
-[33m[tester::#SV7] [test-3.lox] [0mvar result = (world + foo) / bar;
-[33m[tester::#SV7] [test-3.lox] [0mprint result;
+[33m[tester::#SV7] [test-3.lox] [0m[0m[33m// This program tries to access a variable before[0m[0m
+[33m[tester::#SV7] [test-3.lox] [0m[0m[33m// it is declared[0m[0m
+[33m[tester::#SV7] [test-3.lox] [0m[0m[33m// It leads to a runtime error[0m[0m
+[33m[tester::#SV7] [test-3.lox] [0m[0mvar world = 47;[0m
+[33m[tester::#SV7] [test-3.lox] [0m[0mvar result = (world + foo) / bar;[0m
+[33m[tester::#SV7] [test-3.lox] [0m[0mprint result;[0m
 [33m[tester::#SV7] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mUndefined variable 'foo'.
-[33m[your_program] [0m[line 5]
+[33m[your_program] [0m[0mUndefined variable 'foo'.[0m
+[33m[your_program] [0m[0m[line 5][0m
 [33m[tester::#SV7] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#SV7] [test-3] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#SV7] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#SV7] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#SV7] [test-4.lox] [0m[33m// This program tries to access a variable before[0m
-[33m[tester::#SV7] [test-4.lox] [0m[33m// it is declared[0m
-[33m[tester::#SV7] [test-4.lox] [0m[33m// It leads to a runtime error[0m
-[33m[tester::#SV7] [test-4.lox] [0mvar quz = 88;
-[33m[tester::#SV7] [test-4.lox] [0mvar hello = 96;
-[33m[tester::#SV7] [test-4.lox] [0mvar foo = 36;
-[33m[tester::#SV7] [test-4.lox] [0mprint quz + hello + foo + bar; print 53;
+[33m[tester::#SV7] [test-4.lox] [0m[0m[33m// This program tries to access a variable before[0m[0m
+[33m[tester::#SV7] [test-4.lox] [0m[0m[33m// it is declared[0m[0m
+[33m[tester::#SV7] [test-4.lox] [0m[0m[33m// It leads to a runtime error[0m[0m
+[33m[tester::#SV7] [test-4.lox] [0m[0mvar quz = 88;[0m
+[33m[tester::#SV7] [test-4.lox] [0m[0mvar hello = 96;[0m
+[33m[tester::#SV7] [test-4.lox] [0m[0mvar foo = 36;[0m
+[33m[tester::#SV7] [test-4.lox] [0m[0mprint quz + hello + foo + bar; print 53;[0m
 [33m[tester::#SV7] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mUndefined variable 'bar'.
-[33m[your_program] [0m[line 7]
+[33m[your_program] [0m[0mUndefined variable 'bar'.[0m
+[33m[your_program] [0m[0m[line 7][0m
 [33m[tester::#SV7] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#SV7] [test-4] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#SV7] [0m[92mTest passed.[0m
@@ -266,56 +266,56 @@ Debug = true
 [33m[tester::#BC1] [0m[94mRunning tests for Stage #BC1 (bc1)[0m
 [33m[tester::#BC1] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#BC1] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#BC1] [test-1.lox] [0m[33m// This program declares a variable but doesn't[0m
-[33m[tester::#BC1] [test-1.lox] [0m[33m// initialize it[0m
-[33m[tester::#BC1] [test-1.lox] [0m[33m// It prints the variable's value, which should be[0m
-[33m[tester::#BC1] [test-1.lox] [0m[33m// nil[0m
-[33m[tester::#BC1] [test-1.lox] [0mvar hello;
-[33m[tester::#BC1] [test-1.lox] [0mprint hello;
+[33m[tester::#BC1] [test-1.lox] [0m[0m[33m// This program declares a variable but doesn't[0m[0m
+[33m[tester::#BC1] [test-1.lox] [0m[0m[33m// initialize it[0m[0m
+[33m[tester::#BC1] [test-1.lox] [0m[0m[33m// It prints the variable's value, which should be[0m[0m
+[33m[tester::#BC1] [test-1.lox] [0m[0m[33m// nil[0m[0m
+[33m[tester::#BC1] [test-1.lox] [0m[0mvar hello;[0m
+[33m[tester::#BC1] [test-1.lox] [0m[0mprint hello;[0m
 [33m[tester::#BC1] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mnil
+[33m[your_program] [0m[0mnil[0m
 [33m[tester::#BC1] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#BC1] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#BC1] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#BC1] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#BC1] [test-2.lox] [0m[33m// This program declares a variable but doesn't[0m
-[33m[tester::#BC1] [test-2.lox] [0m[33m// initialize it[0m
-[33m[tester::#BC1] [test-2.lox] [0m[33m// It prints the variable's value[0m
-[33m[tester::#BC1] [test-2.lox] [0mvar foo = "baz";
-[33m[tester::#BC1] [test-2.lox] [0mvar bar;
-[33m[tester::#BC1] [test-2.lox] [0mprint bar;
+[33m[tester::#BC1] [test-2.lox] [0m[0m[33m// This program declares a variable but doesn't[0m[0m
+[33m[tester::#BC1] [test-2.lox] [0m[0m[33m// initialize it[0m[0m
+[33m[tester::#BC1] [test-2.lox] [0m[0m[33m// It prints the variable's value[0m[0m
+[33m[tester::#BC1] [test-2.lox] [0m[0mvar foo = "baz";[0m
+[33m[tester::#BC1] [test-2.lox] [0m[0mvar bar;[0m
+[33m[tester::#BC1] [test-2.lox] [0m[0mprint bar;[0m
 [33m[tester::#BC1] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mnil
+[33m[your_program] [0m[0mnil[0m
 [33m[tester::#BC1] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#BC1] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#BC1] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#BC1] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#BC1] [test-3.lox] [0m[33m// This program declares a variable but doesn't[0m
-[33m[tester::#BC1] [test-3.lox] [0m[33m// initialize it[0m
-[33m[tester::#BC1] [test-3.lox] [0m[33m// It prints the variable's value[0m
-[33m[tester::#BC1] [test-3.lox] [0mvar quz = 25;
-[33m[tester::#BC1] [test-3.lox] [0mvar hello;
-[33m[tester::#BC1] [test-3.lox] [0mvar foo;
-[33m[tester::#BC1] [test-3.lox] [0mprint hello;
+[33m[tester::#BC1] [test-3.lox] [0m[0m[33m// This program declares a variable but doesn't[0m[0m
+[33m[tester::#BC1] [test-3.lox] [0m[0m[33m// initialize it[0m[0m
+[33m[tester::#BC1] [test-3.lox] [0m[0m[33m// It prints the variable's value[0m[0m
+[33m[tester::#BC1] [test-3.lox] [0m[0mvar quz = 25;[0m
+[33m[tester::#BC1] [test-3.lox] [0m[0mvar hello;[0m
+[33m[tester::#BC1] [test-3.lox] [0m[0mvar foo;[0m
+[33m[tester::#BC1] [test-3.lox] [0m[0mprint hello;[0m
 [33m[tester::#BC1] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mnil
+[33m[your_program] [0m[0mnil[0m
 [33m[tester::#BC1] [test-3] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#BC1] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#BC1] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#BC1] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#BC1] [test-4.lox] [0m[33m// This program declares a variable but doesn't[0m
-[33m[tester::#BC1] [test-4.lox] [0m[33m// initialize it[0m
-[33m[tester::#BC1] [test-4.lox] [0m[33m// It prints the variable's value[0m
-[33m[tester::#BC1] [test-4.lox] [0mvar quz = 95 + 71 * 16;
-[33m[tester::#BC1] [test-4.lox] [0mprint quz;
-[33m[tester::#BC1] [test-4.lox] [0mvar baz = 71 * 16;
-[33m[tester::#BC1] [test-4.lox] [0mprint quz + baz;
-[33m[tester::#BC1] [test-4.lox] [0mvar foo;
-[33m[tester::#BC1] [test-4.lox] [0mprint foo;
+[33m[tester::#BC1] [test-4.lox] [0m[0m[33m// This program declares a variable but doesn't[0m[0m
+[33m[tester::#BC1] [test-4.lox] [0m[0m[33m// initialize it[0m[0m
+[33m[tester::#BC1] [test-4.lox] [0m[0m[33m// It prints the variable's value[0m[0m
+[33m[tester::#BC1] [test-4.lox] [0m[0mvar quz = 95 + 71 * 16;[0m
+[33m[tester::#BC1] [test-4.lox] [0m[0mprint quz;[0m
+[33m[tester::#BC1] [test-4.lox] [0m[0mvar baz = 71 * 16;[0m
+[33m[tester::#BC1] [test-4.lox] [0m[0mprint quz + baz;[0m
+[33m[tester::#BC1] [test-4.lox] [0m[0mvar foo;[0m
+[33m[tester::#BC1] [test-4.lox] [0m[0mprint foo;[0m
 [33m[tester::#BC1] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m1231
-[33m[your_program] [0m2367
-[33m[your_program] [0mnil
+[33m[your_program] [0m[0m1231[0m
+[33m[your_program] [0m[0m2367[0m
+[33m[your_program] [0m[0mnil[0m
 [33m[tester::#BC1] [test-4] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#BC1] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#BC1] [0m[92mTest passed.[0m
@@ -323,53 +323,53 @@ Debug = true
 [33m[tester::#DW9] [0m[94mRunning tests for Stage #DW9 (dw9)[0m
 [33m[tester::#DW9] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#DW9] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#DW9] [test-1.lox] [0mvar baz = "before";
-[33m[tester::#DW9] [test-1.lox] [0mprint baz;
-[33m[tester::#DW9] [test-1.lox] [0mvar baz = "after";
-[33m[tester::#DW9] [test-1.lox] [0mprint baz;
+[33m[tester::#DW9] [test-1.lox] [0m[0mvar baz = "before";[0m
+[33m[tester::#DW9] [test-1.lox] [0m[0mprint baz;[0m
+[33m[tester::#DW9] [test-1.lox] [0m[0mvar baz = "after";[0m
+[33m[tester::#DW9] [test-1.lox] [0m[0mprint baz;[0m
 [33m[tester::#DW9] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mbefore
-[33m[your_program] [0mafter
+[33m[your_program] [0m[0mbefore[0m
+[33m[your_program] [0m[0mafter[0m
 [33m[tester::#DW9] [test-1] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#DW9] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#DW9] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#DW9] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#DW9] [test-2.lox] [0mvar world = "after";
-[33m[tester::#DW9] [test-2.lox] [0mvar world = "before";
-[33m[tester::#DW9] [test-2.lox] [0m[33m// Using a previously declared variable's value to[0m
-[33m[tester::#DW9] [test-2.lox] [0m[33m// initialize a new variable should work[0m
-[33m[tester::#DW9] [test-2.lox] [0mvar world = world;
-[33m[tester::#DW9] [test-2.lox] [0mprint world;
+[33m[tester::#DW9] [test-2.lox] [0m[0mvar world = "after";[0m
+[33m[tester::#DW9] [test-2.lox] [0m[0mvar world = "before";[0m
+[33m[tester::#DW9] [test-2.lox] [0m[0m[33m// Using a previously declared variable's value to[0m[0m
+[33m[tester::#DW9] [test-2.lox] [0m[0m[33m// initialize a new variable should work[0m[0m
+[33m[tester::#DW9] [test-2.lox] [0m[0mvar world = world;[0m
+[33m[tester::#DW9] [test-2.lox] [0m[0mprint world;[0m
 [33m[tester::#DW9] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mbefore
+[33m[your_program] [0m[0mbefore[0m
 [33m[tester::#DW9] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#DW9] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#DW9] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#DW9] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#DW9] [test-3.lox] [0m[33m// This program declares and initializes multiple[0m
-[33m[tester::#DW9] [test-3.lox] [0m[33m// variables and prints their values[0m
-[33m[tester::#DW9] [test-3.lox] [0mvar bar = 2;
-[33m[tester::#DW9] [test-3.lox] [0mprint bar;
-[33m[tester::#DW9] [test-3.lox] [0mvar bar = 3;
-[33m[tester::#DW9] [test-3.lox] [0mprint bar;
-[33m[tester::#DW9] [test-3.lox] [0mvar hello = 5;
-[33m[tester::#DW9] [test-3.lox] [0mprint hello;
-[33m[tester::#DW9] [test-3.lox] [0mvar bar = hello;
-[33m[tester::#DW9] [test-3.lox] [0mprint bar;
+[33m[tester::#DW9] [test-3.lox] [0m[0m[33m// This program declares and initializes multiple[0m[0m
+[33m[tester::#DW9] [test-3.lox] [0m[0m[33m// variables and prints their values[0m[0m
+[33m[tester::#DW9] [test-3.lox] [0m[0mvar bar = 2;[0m
+[33m[tester::#DW9] [test-3.lox] [0m[0mprint bar;[0m
+[33m[tester::#DW9] [test-3.lox] [0m[0mvar bar = 3;[0m
+[33m[tester::#DW9] [test-3.lox] [0m[0mprint bar;[0m
+[33m[tester::#DW9] [test-3.lox] [0m[0mvar hello = 5;[0m
+[33m[tester::#DW9] [test-3.lox] [0m[0mprint hello;[0m
+[33m[tester::#DW9] [test-3.lox] [0m[0mvar bar = hello;[0m
+[33m[tester::#DW9] [test-3.lox] [0m[0mprint bar;[0m
 [33m[tester::#DW9] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m2
-[33m[your_program] [0m3
-[33m[your_program] [0m5
-[33m[your_program] [0m5
+[33m[your_program] [0m[0m2[0m
+[33m[your_program] [0m[0m3[0m
+[33m[your_program] [0m[0m5[0m
+[33m[your_program] [0m[0m5[0m
 [33m[tester::#DW9] [test-3] [0m[92m✓ 4 line(s) match on stdout[0m
 [33m[tester::#DW9] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#DW9] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#DW9] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#DW9] [test-4.lox] [0m[33m// As baz is not declared before[0m
-[33m[tester::#DW9] [test-4.lox] [0mvar hello = baz; [33m// expect runtime error[0m
+[33m[tester::#DW9] [test-4.lox] [0m[0m[33m// As baz is not declared before[0m[0m
+[33m[tester::#DW9] [test-4.lox] [0m[0mvar hello = baz; [33m// expect runtime error[0m[0m
 [33m[tester::#DW9] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mUndefined variable 'baz'.
-[33m[your_program] [0m[line 2]
+[33m[your_program] [0m[0mUndefined variable 'baz'.[0m
+[33m[your_program] [0m[0m[line 2][0m
 [33m[tester::#DW9] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#DW9] [test-4] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#DW9] [0m[92mTest passed.[0m
@@ -377,63 +377,63 @@ Debug = true
 [33m[tester::#PL3] [0m[94mRunning tests for Stage #PL3 (pl3)[0m
 [33m[tester::#PL3] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#PL3] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PL3] [test-1.lox] [0mvar baz;
-[33m[tester::#PL3] [test-1.lox] [0mbaz = 1;
-[33m[tester::#PL3] [test-1.lox] [0mprint baz;
-[33m[tester::#PL3] [test-1.lox] [0m[33m// The assignment operator should return[0m
-[33m[tester::#PL3] [test-1.lox] [0m[33m// the value that was assigned[0m
-[33m[tester::#PL3] [test-1.lox] [0mprint baz = 2;
-[33m[tester::#PL3] [test-1.lox] [0mprint baz;
+[33m[tester::#PL3] [test-1.lox] [0m[0mvar baz;[0m
+[33m[tester::#PL3] [test-1.lox] [0m[0mbaz = 1;[0m
+[33m[tester::#PL3] [test-1.lox] [0m[0mprint baz;[0m
+[33m[tester::#PL3] [test-1.lox] [0m[0m[33m// The assignment operator should return[0m[0m
+[33m[tester::#PL3] [test-1.lox] [0m[0m[33m// the value that was assigned[0m[0m
+[33m[tester::#PL3] [test-1.lox] [0m[0mprint baz = 2;[0m
+[33m[tester::#PL3] [test-1.lox] [0m[0mprint baz;[0m
 [33m[tester::#PL3] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m1
-[33m[your_program] [0m2
-[33m[your_program] [0m2
+[33m[your_program] [0m[0m1[0m
+[33m[your_program] [0m[0m2[0m
+[33m[your_program] [0m[0m2[0m
 [33m[tester::#PL3] [test-1] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#PL3] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#PL3] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#PL3] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PL3] [test-2.lox] [0m[33m// This program tests that the assignment operator[0m
-[33m[tester::#PL3] [test-2.lox] [0m[33m// works on any declared variable[0m
-[33m[tester::#PL3] [test-2.lox] [0mvar bar = 87;
-[33m[tester::#PL3] [test-2.lox] [0mvar world = 87;
-[33m[tester::#PL3] [test-2.lox] [0mworld = bar;
-[33m[tester::#PL3] [test-2.lox] [0mbar = world;
-[33m[tester::#PL3] [test-2.lox] [0mprint bar + world;
+[33m[tester::#PL3] [test-2.lox] [0m[0m[33m// This program tests that the assignment operator[0m[0m
+[33m[tester::#PL3] [test-2.lox] [0m[0m[33m// works on any declared variable[0m[0m
+[33m[tester::#PL3] [test-2.lox] [0m[0mvar bar = 87;[0m
+[33m[tester::#PL3] [test-2.lox] [0m[0mvar world = 87;[0m
+[33m[tester::#PL3] [test-2.lox] [0m[0mworld = bar;[0m
+[33m[tester::#PL3] [test-2.lox] [0m[0mbar = world;[0m
+[33m[tester::#PL3] [test-2.lox] [0m[0mprint bar + world;[0m
 [33m[tester::#PL3] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m174
+[33m[your_program] [0m[0m174[0m
 [33m[tester::#PL3] [test-2] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#PL3] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#PL3] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#PL3] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PL3] [test-3.lox] [0mvar foo;
-[33m[tester::#PL3] [test-3.lox] [0mvar baz;
-[33m[tester::#PL3] [test-3.lox] [0m
-[33m[tester::#PL3] [test-3.lox] [0m[33m// The assignment operator should return[0m
-[33m[tester::#PL3] [test-3.lox] [0m[33m// the value that was assigned[0m
-[33m[tester::#PL3] [test-3.lox] [0mfoo = baz = 50 + 13 * 62;
-[33m[tester::#PL3] [test-3.lox] [0mprint foo;
-[33m[tester::#PL3] [test-3.lox] [0mprint baz;
+[33m[tester::#PL3] [test-3.lox] [0m[0mvar foo;[0m
+[33m[tester::#PL3] [test-3.lox] [0m[0mvar baz;[0m
+[33m[tester::#PL3] [test-3.lox] [0m[0m[0m
+[33m[tester::#PL3] [test-3.lox] [0m[0m[33m// The assignment operator should return[0m[0m
+[33m[tester::#PL3] [test-3.lox] [0m[0m[33m// the value that was assigned[0m[0m
+[33m[tester::#PL3] [test-3.lox] [0m[0mfoo = baz = 50 + 13 * 62;[0m
+[33m[tester::#PL3] [test-3.lox] [0m[0mprint foo;[0m
+[33m[tester::#PL3] [test-3.lox] [0m[0mprint baz;[0m
 [33m[tester::#PL3] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m856
-[33m[your_program] [0m856
+[33m[your_program] [0m[0m856[0m
+[33m[your_program] [0m[0m856[0m
 [33m[tester::#PL3] [test-3] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#PL3] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#PL3] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#PL3] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#PL3] [test-4.lox] [0mvar bar = 93;
-[33m[tester::#PL3] [test-4.lox] [0mvar quz;
-[33m[tester::#PL3] [test-4.lox] [0mvar foo;
-[33m[tester::#PL3] [test-4.lox] [0m
-[33m[tester::#PL3] [test-4.lox] [0m[33m// The assignment operator should return[0m
-[33m[tester::#PL3] [test-4.lox] [0m[33m// the value that was assigned[0m
-[33m[tester::#PL3] [test-4.lox] [0mbar = quz = foo = bar * 2;
-[33m[tester::#PL3] [test-4.lox] [0mprint bar;
-[33m[tester::#PL3] [test-4.lox] [0mprint quz;
-[33m[tester::#PL3] [test-4.lox] [0mprint quz;
+[33m[tester::#PL3] [test-4.lox] [0m[0mvar bar = 93;[0m
+[33m[tester::#PL3] [test-4.lox] [0m[0mvar quz;[0m
+[33m[tester::#PL3] [test-4.lox] [0m[0mvar foo;[0m
+[33m[tester::#PL3] [test-4.lox] [0m[0m[0m
+[33m[tester::#PL3] [test-4.lox] [0m[0m[33m// The assignment operator should return[0m[0m
+[33m[tester::#PL3] [test-4.lox] [0m[0m[33m// the value that was assigned[0m[0m
+[33m[tester::#PL3] [test-4.lox] [0m[0mbar = quz = foo = bar * 2;[0m
+[33m[tester::#PL3] [test-4.lox] [0m[0mprint bar;[0m
+[33m[tester::#PL3] [test-4.lox] [0m[0mprint quz;[0m
+[33m[tester::#PL3] [test-4.lox] [0m[0mprint quz;[0m
 [33m[tester::#PL3] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m186
-[33m[your_program] [0m186
-[33m[your_program] [0m186
+[33m[your_program] [0m[0m186[0m
+[33m[your_program] [0m[0m186[0m
+[33m[your_program] [0m[0m186[0m
 [33m[tester::#PL3] [test-4] [0m[92m✓ 3 line(s) match on stdout[0m
 [33m[tester::#PL3] [test-4] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#PL3] [0m[92mTest passed.[0m
@@ -441,62 +441,62 @@ Debug = true
 [33m[tester::#VR5] [0m[94mRunning tests for Stage #VR5 (vr5)[0m
 [33m[tester::#VR5] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#VR5] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#VR5] [test-1.lox] [0m[33m// This program tests that curly braces can be[0m
-[33m[tester::#VR5] [test-1.lox] [0m[33m// used to group multiple statements into blocks[0m
-[33m[tester::#VR5] [test-1.lox] [0m{
-[33m[tester::#VR5] [test-1.lox] [0m    var hello = "foo";
-[33m[tester::#VR5] [test-1.lox] [0m    print hello;
-[33m[tester::#VR5] [test-1.lox] [0m}
+[33m[tester::#VR5] [test-1.lox] [0m[0m[33m// This program tests that curly braces can be[0m[0m
+[33m[tester::#VR5] [test-1.lox] [0m[0m[33m// used to group multiple statements into blocks[0m[0m
+[33m[tester::#VR5] [test-1.lox] [0m[0m{[0m
+[33m[tester::#VR5] [test-1.lox] [0m[0m    var hello = "foo";[0m
+[33m[tester::#VR5] [test-1.lox] [0m[0m    print hello;[0m
+[33m[tester::#VR5] [test-1.lox] [0m[0m}[0m
 [33m[tester::#VR5] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mfoo
+[33m[your_program] [0m[0mfoo[0m
 [33m[tester::#VR5] [test-1] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#VR5] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#VR5] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#VR5] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#VR5] [test-2.lox] [0m[33m// This program tests that blocks can be used[0m
-[33m[tester::#VR5] [test-2.lox] [0m[33m// to group statements and variables[0m
-[33m[tester::#VR5] [test-2.lox] [0m[33m// creating local scopes[0m
-[33m[tester::#VR5] [test-2.lox] [0m{
-[33m[tester::#VR5] [test-2.lox] [0m    var world = "before";
-[33m[tester::#VR5] [test-2.lox] [0m    print world;
-[33m[tester::#VR5] [test-2.lox] [0m}
-[33m[tester::#VR5] [test-2.lox] [0m{
-[33m[tester::#VR5] [test-2.lox] [0m    var world = "after";
-[33m[tester::#VR5] [test-2.lox] [0m    print world;
-[33m[tester::#VR5] [test-2.lox] [0m}
+[33m[tester::#VR5] [test-2.lox] [0m[0m[33m// This program tests that blocks can be used[0m[0m
+[33m[tester::#VR5] [test-2.lox] [0m[0m[33m// to group statements and variables[0m[0m
+[33m[tester::#VR5] [test-2.lox] [0m[0m[33m// creating local scopes[0m[0m
+[33m[tester::#VR5] [test-2.lox] [0m[0m{[0m
+[33m[tester::#VR5] [test-2.lox] [0m[0m    var world = "before";[0m
+[33m[tester::#VR5] [test-2.lox] [0m[0m    print world;[0m
+[33m[tester::#VR5] [test-2.lox] [0m[0m}[0m
+[33m[tester::#VR5] [test-2.lox] [0m[0m{[0m
+[33m[tester::#VR5] [test-2.lox] [0m[0m    var world = "after";[0m
+[33m[tester::#VR5] [test-2.lox] [0m[0m    print world;[0m
+[33m[tester::#VR5] [test-2.lox] [0m[0m}[0m
 [33m[tester::#VR5] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mbefore
-[33m[your_program] [0mafter
+[33m[your_program] [0m[0mbefore[0m
+[33m[your_program] [0m[0mafter[0m
 [33m[tester::#VR5] [test-2] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#VR5] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#VR5] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#VR5] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#VR5] [test-3.lox] [0m[33m// This program tests that scopes can be nested[0m
-[33m[tester::#VR5] [test-3.lox] [0m{
-[33m[tester::#VR5] [test-3.lox] [0m    var bar = 35;
-[33m[tester::#VR5] [test-3.lox] [0m    {
-[33m[tester::#VR5] [test-3.lox] [0m        var quz = 35;
-[33m[tester::#VR5] [test-3.lox] [0m        print quz;
-[33m[tester::#VR5] [test-3.lox] [0m    }
-[33m[tester::#VR5] [test-3.lox] [0m    print bar;
-[33m[tester::#VR5] [test-3.lox] [0m}
+[33m[tester::#VR5] [test-3.lox] [0m[0m[33m// This program tests that scopes can be nested[0m[0m
+[33m[tester::#VR5] [test-3.lox] [0m[0m{[0m
+[33m[tester::#VR5] [test-3.lox] [0m[0m    var bar = 35;[0m
+[33m[tester::#VR5] [test-3.lox] [0m[0m    {[0m
+[33m[tester::#VR5] [test-3.lox] [0m[0m        var quz = 35;[0m
+[33m[tester::#VR5] [test-3.lox] [0m[0m        print quz;[0m
+[33m[tester::#VR5] [test-3.lox] [0m[0m    }[0m
+[33m[tester::#VR5] [test-3.lox] [0m[0m    print bar;[0m
+[33m[tester::#VR5] [test-3.lox] [0m[0m}[0m
 [33m[tester::#VR5] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m35
-[33m[your_program] [0m35
+[33m[your_program] [0m[0m35[0m
+[33m[your_program] [0m[0m35[0m
 [33m[tester::#VR5] [test-3] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#VR5] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#VR5] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#VR5] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#VR5] [test-4.lox] [0m{
-[33m[tester::#VR5] [test-4.lox] [0m    var world = 68;
-[33m[tester::#VR5] [test-4.lox] [0m    var hello = 68;
-[33m[tester::#VR5] [test-4.lox] [0m    {
-[33m[tester::#VR5] [test-4.lox] [0m        print world + hello;
-[33m[tester::#VR5] [test-4.lox] [0m    [33m// Missing closing curly brace[0m
-[33m[tester::#VR5] [test-4.lox] [0m    [33m// Expect compile error[0m
-[33m[tester::#VR5] [test-4.lox] [0m}
+[33m[tester::#VR5] [test-4.lox] [0m[0m{[0m
+[33m[tester::#VR5] [test-4.lox] [0m[0m    var world = 68;[0m
+[33m[tester::#VR5] [test-4.lox] [0m[0m    var hello = 68;[0m
+[33m[tester::#VR5] [test-4.lox] [0m[0m    {[0m
+[33m[tester::#VR5] [test-4.lox] [0m[0m        print world + hello;[0m
+[33m[tester::#VR5] [test-4.lox] [0m[0m    [33m// Missing closing curly brace[0m[0m
+[33m[tester::#VR5] [test-4.lox] [0m[0m    [33m// Expect compile error[0m[0m
+[33m[tester::#VR5] [test-4.lox] [0m[0m}[0m
 [33m[tester::#VR5] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0m[line 8] Error at end: Expect '}' after block.
+[33m[your_program] [0m[0m[line 8] Error at end: Expect '}' after block.[0m
 [33m[tester::#VR5] [test-4] [0m[92m✓ 1 line(s) match on stdout[0m
 [33m[tester::#VR5] [test-4] [0m[92m✓ Received exit code 65.[0m
 [33m[tester::#VR5] [0m[92mTest passed.[0m
@@ -504,95 +504,95 @@ Debug = true
 [33m[tester::#FB4] [0m[94mRunning tests for Stage #FB4 (fb4)[0m
 [33m[tester::#FB4] [test-1] [0m[94mRunning test case: 1[0m
 [33m[tester::#FB4] [test-1] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#FB4] [test-1.lox] [0mvar hello = (12 * 41) - 84;
-[33m[tester::#FB4] [test-1.lox] [0m{
-[33m[tester::#FB4] [test-1.lox] [0m    [33m// Local scope should be created[0m
-[33m[tester::#FB4] [test-1.lox] [0m    var quz = "bar" + "14";
-[33m[tester::#FB4] [test-1.lox] [0m    print quz;
-[33m[tester::#FB4] [test-1.lox] [0m}
-[33m[tester::#FB4] [test-1.lox] [0mprint hello;
+[33m[tester::#FB4] [test-1.lox] [0m[0mvar hello = (12 * 41) - 84;[0m
+[33m[tester::#FB4] [test-1.lox] [0m[0m{[0m
+[33m[tester::#FB4] [test-1.lox] [0m[0m    [33m// Local scope should be created[0m[0m
+[33m[tester::#FB4] [test-1.lox] [0m[0m    var quz = "bar" + "14";[0m
+[33m[tester::#FB4] [test-1.lox] [0m[0m    print quz;[0m
+[33m[tester::#FB4] [test-1.lox] [0m[0m}[0m
+[33m[tester::#FB4] [test-1.lox] [0m[0mprint hello;[0m
 [33m[tester::#FB4] [test-1] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mbar14
-[33m[your_program] [0m408
+[33m[your_program] [0m[0mbar14[0m
+[33m[your_program] [0m[0m408[0m
 [33m[tester::#FB4] [test-1] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#FB4] [test-1] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#FB4] [test-2] [0m[94mRunning test case: 2[0m
 [33m[tester::#FB4] [test-2] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#FB4] [test-2.lox] [0m[33m// This program tests variable shadowing[0m
-[33m[tester::#FB4] [test-2.lox] [0m[33m// across nested scopes[0m
-[33m[tester::#FB4] [test-2.lox] [0m{
-[33m[tester::#FB4] [test-2.lox] [0m    var foo = "before";
-[33m[tester::#FB4] [test-2.lox] [0m    {
-[33m[tester::#FB4] [test-2.lox] [0m        var foo = "after";
-[33m[tester::#FB4] [test-2.lox] [0m        print foo;
-[33m[tester::#FB4] [test-2.lox] [0m    }
-[33m[tester::#FB4] [test-2.lox] [0m    print foo;
-[33m[tester::#FB4] [test-2.lox] [0m}
+[33m[tester::#FB4] [test-2.lox] [0m[0m[33m// This program tests variable shadowing[0m[0m
+[33m[tester::#FB4] [test-2.lox] [0m[0m[33m// across nested scopes[0m[0m
+[33m[tester::#FB4] [test-2.lox] [0m[0m{[0m
+[33m[tester::#FB4] [test-2.lox] [0m[0m    var foo = "before";[0m
+[33m[tester::#FB4] [test-2.lox] [0m[0m    {[0m
+[33m[tester::#FB4] [test-2.lox] [0m[0m        var foo = "after";[0m
+[33m[tester::#FB4] [test-2.lox] [0m[0m        print foo;[0m
+[33m[tester::#FB4] [test-2.lox] [0m[0m    }[0m
+[33m[tester::#FB4] [test-2.lox] [0m[0m    print foo;[0m
+[33m[tester::#FB4] [test-2.lox] [0m[0m}[0m
 [33m[tester::#FB4] [test-2] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mafter
-[33m[your_program] [0mbefore
+[33m[your_program] [0m[0mafter[0m
+[33m[your_program] [0m[0mbefore[0m
 [33m[tester::#FB4] [test-2] [0m[92m✓ 2 line(s) match on stdout[0m
 [33m[tester::#FB4] [test-2] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#FB4] [test-3] [0m[94mRunning test case: 3[0m
 [33m[tester::#FB4] [test-3] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#FB4] [test-3.lox] [0m[33m// This program creates nested scopes and tests[0m
-[33m[tester::#FB4] [test-3.lox] [0m[33m// local scopes and variable shadowing[0m
-[33m[tester::#FB4] [test-3.lox] [0mvar baz = "global baz";
-[33m[tester::#FB4] [test-3.lox] [0mvar bar = "global bar";
-[33m[tester::#FB4] [test-3.lox] [0mvar hello = "global hello";
-[33m[tester::#FB4] [test-3.lox] [0m{
-[33m[tester::#FB4] [test-3.lox] [0m  var baz = "outer baz";
-[33m[tester::#FB4] [test-3.lox] [0m  var bar = "outer bar";
-[33m[tester::#FB4] [test-3.lox] [0m  {
-[33m[tester::#FB4] [test-3.lox] [0m    var baz = "inner baz";
-[33m[tester::#FB4] [test-3.lox] [0m    print baz;
-[33m[tester::#FB4] [test-3.lox] [0m    print bar;
-[33m[tester::#FB4] [test-3.lox] [0m    print hello;
-[33m[tester::#FB4] [test-3.lox] [0m  }
-[33m[tester::#FB4] [test-3.lox] [0m  print baz;
-[33m[tester::#FB4] [test-3.lox] [0m  print bar;
-[33m[tester::#FB4] [test-3.lox] [0m  print hello;
-[33m[tester::#FB4] [test-3.lox] [0m}
-[33m[tester::#FB4] [test-3.lox] [0mprint baz;
-[33m[tester::#FB4] [test-3.lox] [0mprint bar;
-[33m[tester::#FB4] [test-3.lox] [0mprint hello;
+[33m[tester::#FB4] [test-3.lox] [0m[0m[33m// This program creates nested scopes and tests[0m[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0m[33m// local scopes and variable shadowing[0m[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0mvar baz = "global baz";[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0mvar bar = "global bar";[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0mvar hello = "global hello";[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0m{[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0m  var baz = "outer baz";[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0m  var bar = "outer bar";[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0m  {[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0m    var baz = "inner baz";[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0m    print baz;[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0m    print bar;[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0m    print hello;[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0m  }[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0m  print baz;[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0m  print bar;[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0m  print hello;[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0m}[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0mprint baz;[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0mprint bar;[0m
+[33m[tester::#FB4] [test-3.lox] [0m[0mprint hello;[0m
 [33m[tester::#FB4] [test-3] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0minner baz
-[33m[your_program] [0mouter bar
-[33m[your_program] [0mglobal hello
-[33m[your_program] [0mouter baz
-[33m[your_program] [0mouter bar
-[33m[your_program] [0mglobal hello
-[33m[your_program] [0mglobal baz
-[33m[your_program] [0mglobal bar
-[33m[your_program] [0mglobal hello
+[33m[your_program] [0m[0minner baz[0m
+[33m[your_program] [0m[0mouter bar[0m
+[33m[your_program] [0m[0mglobal hello[0m
+[33m[your_program] [0m[0mouter baz[0m
+[33m[your_program] [0m[0mouter bar[0m
+[33m[your_program] [0m[0mglobal hello[0m
+[33m[your_program] [0m[0mglobal baz[0m
+[33m[your_program] [0m[0mglobal bar[0m
+[33m[your_program] [0m[0mglobal hello[0m
 [33m[tester::#FB4] [test-3] [0m[92m✓ 9 line(s) match on stdout[0m
 [33m[tester::#FB4] [test-3] [0m[92m✓ Received exit code 0.[0m
 [33m[tester::#FB4] [test-4] [0m[94mRunning test case: 4[0m
 [33m[tester::#FB4] [test-4] [0m[94mWriting contents to ./test.lox:[0m
-[33m[tester::#FB4] [test-4.lox] [0m[33m// Variables declared in an outer scope should be[0m
-[33m[tester::#FB4] [test-4.lox] [0m[33m// accessible inside inner scopes, but not the[0m
-[33m[tester::#FB4] [test-4.lox] [0m[33m// other way around[0m
-[33m[tester::#FB4] [test-4.lox] [0m{
-[33m[tester::#FB4] [test-4.lox] [0m  var foo = "outer foo";
-[33m[tester::#FB4] [test-4.lox] [0m  var baz = "outer baz";
-[33m[tester::#FB4] [test-4.lox] [0m  {
-[33m[tester::#FB4] [test-4.lox] [0m    foo = "modified foo";
-[33m[tester::#FB4] [test-4.lox] [0m    var baz = "inner baz";
-[33m[tester::#FB4] [test-4.lox] [0m    print foo;
-[33m[tester::#FB4] [test-4.lox] [0m    print baz;
-[33m[tester::#FB4] [test-4.lox] [0m  }
-[33m[tester::#FB4] [test-4.lox] [0m  print foo;
-[33m[tester::#FB4] [test-4.lox] [0m  print baz;
-[33m[tester::#FB4] [test-4.lox] [0m}
-[33m[tester::#FB4] [test-4.lox] [0mprint foo;
+[33m[tester::#FB4] [test-4.lox] [0m[0m[33m// Variables declared in an outer scope should be[0m[0m
+[33m[tester::#FB4] [test-4.lox] [0m[0m[33m// accessible inside inner scopes, but not the[0m[0m
+[33m[tester::#FB4] [test-4.lox] [0m[0m[33m// other way around[0m[0m
+[33m[tester::#FB4] [test-4.lox] [0m[0m{[0m
+[33m[tester::#FB4] [test-4.lox] [0m[0m  var foo = "outer foo";[0m
+[33m[tester::#FB4] [test-4.lox] [0m[0m  var baz = "outer baz";[0m
+[33m[tester::#FB4] [test-4.lox] [0m[0m  {[0m
+[33m[tester::#FB4] [test-4.lox] [0m[0m    foo = "modified foo";[0m
+[33m[tester::#FB4] [test-4.lox] [0m[0m    var baz = "inner baz";[0m
+[33m[tester::#FB4] [test-4.lox] [0m[0m    print foo;[0m
+[33m[tester::#FB4] [test-4.lox] [0m[0m    print baz;[0m
+[33m[tester::#FB4] [test-4.lox] [0m[0m  }[0m
+[33m[tester::#FB4] [test-4.lox] [0m[0m  print foo;[0m
+[33m[tester::#FB4] [test-4.lox] [0m[0m  print baz;[0m
+[33m[tester::#FB4] [test-4.lox] [0m[0m}[0m
+[33m[tester::#FB4] [test-4.lox] [0m[0mprint foo;[0m
 [33m[tester::#FB4] [test-4] [0m[94m$ ./your_program.sh run test.lox[0m
-[33m[your_program] [0mmodified foo
-[33m[your_program] [0minner baz
-[33m[your_program] [0mmodified foo
-[33m[your_program] [0mouter baz
-[33m[your_program] [0mUndefined variable 'foo'.
-[33m[your_program] [0m[line 16]
+[33m[your_program] [0m[0mmodified foo[0m
+[33m[your_program] [0m[0minner baz[0m
+[33m[your_program] [0m[0mmodified foo[0m
+[33m[your_program] [0m[0mouter baz[0m
+[33m[your_program] [0m[0mUndefined variable 'foo'.[0m
+[33m[your_program] [0m[0m[line 16][0m
 [33m[tester::#FB4] [test-4] [0m[92m✓ 4 line(s) match on stdout[0m
 [33m[tester::#FB4] [test-4] [0m[92m✓ Received exit code 70.[0m
 [33m[tester::#FB4] [0m[92mTest passed.[0m


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> - **Deps:** Switches `github.com/codecrafters-io/tester-utils` from a pseudo-version to tagged `v0.4.12` in `go.mod`; updates `go.sum`.
> - **Fixtures:** Regenerates/normalizes outputs in `internal/test_helpers/fixtures/pass_classes`, `pass_classes_final`, and adds `pass_control_flow`, now including explicit ANSI reset codes and minor formatting adjustments to test script logs and expected outputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffc108fe6f98e29253ab07297dc7f269bc6cddcd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->