### PR TITLE
Update GitHub Actions workflow to use Go 1.25 and setup-go@v6

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,9 +19,9 @@ jobs:
         run: git fetch --prune --unshallow
 
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v6
         with:
-          go-version: 1.22.x
+          go-version: 1.25.x
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v1


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only change affecting release builds; primary risk is unexpected Go 1.25 compatibility/build differences during publishing.
> 
> **Overview**
> Updates the release publishing GitHub Actions workflow to use `actions/setup-go@v6` and build with Go `1.25.x` instead of `1.22.x` during tagged releases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f49931c95121a4fbf6a15fe34f26745fba738c2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->