### PR TITLE
Embed tester directory into the binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build:
 	go build -o dist/main.out ./cmd/tester
 
 test:
-	TESTER_DIR=$(shell pwd) go test -v ./internal/
+	go test -v ./internal/
 
 test_and_watch:
 	onchange '**/*' -- go test -v ./internal/

--- a/assets.go
+++ b/assets.go
@@ -1,0 +1,6 @@
+package interpretertester
+
+import "embed"
+
+//go:embed test_programs
+var TestFS embed.FS

--- a/internal/test_cases/run_test_case.go
+++ b/internal/test_cases/run_test_case.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	interpretertester "github.com/codecrafters-io/interpreter-tester"
 	"github.com/codecrafters-io/interpreter-tester/internal/assertions"
 	"github.com/codecrafters-io/interpreter-tester/internal/interpreter_executable"
 	loxapi "github.com/codecrafters-io/interpreter-tester/internal/lox/api"
@@ -35,7 +36,7 @@ type RunTestCaseFrontMatter struct {
 }
 
 func NewRunTestCaseFromFilePath(filePath string) RunTestCase {
-	fileContents, err := os.ReadFile(filePath)
+	fileContents, err := interpretertester.TestFS.ReadFile(filePath)
 	if err != nil {
 		panic(fmt.Sprintf("CodeCrafters Internal Error: Encountered error while reading test file: %s", err))
 	}

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -2,11 +2,11 @@ package internal
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 
+	interpretertester "github.com/codecrafters-io/interpreter-tester"
 	testcases "github.com/codecrafters-io/interpreter-tester/internal/test_cases"
 	"github.com/codecrafters-io/tester-utils/random"
 )
@@ -34,10 +34,8 @@ func getRandBoolean() string {
 func GetTestCasesForCurrentStage(stageIdentifier string) []testcases.RunTestCase {
 	var testCases []testcases.RunTestCase
 
-	// Construct the path to the test_programs directory
-	parentDir := filepath.Join(os.Getenv("TESTER_DIR"), "test_programs")
-	testDir := filepath.Join(parentDir, stageIdentifier)
-	files, err := os.ReadDir(testDir)
+	testDir := filepath.Join("test_programs", stageIdentifier)
+	files, err := interpretertester.TestFS.ReadDir(testDir)
 	if err != nil {
 		panic(fmt.Sprintf("CodeCrafters Internal Error: Encountered error while reading test directory: %s", err))
 	}

--- a/main.goreleaser.yml
+++ b/main.goreleaser.yml
@@ -7,6 +7,3 @@ builds:
 archives:
   - name_template: "{{ .Tag }}_{{ .Os }}_{{ .Arch }}"
     format: tar.gz
-    files:
-      - test.sh
-      - test_programs/**/*

--- a/test.sh
+++ b/test.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec "${TESTER_DIR}/tester"


### PR DESCRIPTION
This makes the binary independent from its source code. For example, a user can copy it into their directory and does not need to specify the path to the source code of the binary via an environment variable.

It also removes some friction when running the tester, as the undocumented TESTER_DIR environment variable is no longer required.

The distribution of the binary is simplified as well, since the directory with tests does not need to be shipped with the binary.

The embeded FS needs to be created in root directory because [go:embed does not support embedding parent directories](https://github.com/golang/go/issues/46056).